### PR TITLE
Refactor error handling and add unit tests for the first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ package-lock.json
 # Output
 out
 *.vsix
+.vscode-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,20 @@ language: node_js
 node_js:
   - 'stable'
 
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
 install:
   - npm install
 
 script:
-  - tsc -p ./
-  - tslint --project tsconfig.json -e src/*.d.ts --type-check -t verbose
+  - npm run vscode:prepublish
+  - npm run lint
+  - npm run test
 
 notifications:
   email:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,8 @@
     "files.trimTrailingWhitespace": true,
     "search.exclude": {
         "out": true,
-        "**/node_modules": true
+        "**/node_modules": true,
+        ".vscode-test": true
     },
     "tslint.autoFixOnSave": true,
     "tslint.ignoreDefinitionFiles": true

--- a/package.json
+++ b/package.json
@@ -175,7 +175,9 @@
     },
     "devDependencies": {
         "@types/archiver": "^2.0.0",
+        "@types/mocha": "^2.2.32",
         "@types/node": "^8.0.28",
+        "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^2.0.3",

--- a/src/ErrorData.ts
+++ b/src/ErrorData.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from './util';
+
+export class ErrorData {
+    public readonly message: string;
+    public readonly errorType: string;
+    // tslint:disable-next-line:no-any
+    constructor(error: any) {
+        if (error instanceof Error) {
+            this.errorType = error.constructor.name;
+            this.message = error.message;
+        } else if (typeof (error) === 'object' && error !== null) {
+            this.errorType = (<object>error).constructor.name;
+            this.message = JSON.stringify(error);
+            // tslint:disable-next-line:no-unsafe-any
+        } else if (error !== undefined && error !== null && error.toString && error.toString().trim() !== '') {
+            this.errorType = typeof (error);
+            // tslint:disable-next-line:no-unsafe-any
+            this.message = error.toString();
+        } else {
+            this.errorType = typeof (error);
+            this.message = localize('azFunc.unknownError', 'Unknown Error');
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,11 +15,11 @@ import { openInPortal } from './commands/openInPortal';
 import { restartFunctionApp } from './commands/restartFunctionApp';
 import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
+import { ErrorData } from './ErrorData';
 import * as errors from './errors';
 import { FunctionAppNode } from './nodes/FunctionAppNode';
 import { NodeBase } from './nodes/NodeBase';
 import { localize } from './util';
-import * as util from './util';
 
 let reporter: TelemetryReporter | undefined;
 
@@ -68,7 +68,7 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
     context.subscriptions.push(vscode.commands.registerCommand(commandId, async (...args: {}[]) => {
         const start: number = Date.now();
         let result: string = 'Succeeded';
-        let errorData: string | undefined;
+        let errorData: ErrorData | undefined;
 
         try {
             if (args.length === 0) {
@@ -81,16 +81,15 @@ function initAsyncCommand(context: vscode.ExtensionContext, commandId: string, c
                 result = 'Canceled';
             } else {
                 result = 'Failed';
-                errorData = util.errorToString(<{}>error);
-                if (error instanceof Error) {
-                    vscode.window.showErrorMessage(error.message);
-                }
+                errorData = new ErrorData(error);
+                vscode.window.showErrorMessage(errorData.message);
             }
         } finally {
             const end: number = Date.now();
             const properties: { [key: string]: string; } = { result: result };
             if (errorData) {
-                properties.error = errorData;
+                properties.error = errorData.errorType;
+                properties.errorMessage = errorData.message;
             }
 
             if (reporter) {

--- a/src/functions-cli.ts
+++ b/src/functions-cli.ts
@@ -16,7 +16,7 @@ export async function createFunctionApp(outputChannel: vscode.OutputChannel, wor
 }
 
 async function executeCommand(outputChannel: vscode.OutputChannel, workingDirectory: string, ...args: string[]): Promise<void> {
-    await new Promise((resolve: () => void, reject: (e: {}) => void): void => {
+    await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
         const options: cp.SpawnOptions = {
             cwd: workingDirectory,
             shell: true
@@ -32,7 +32,8 @@ async function executeCommand(outputChannel: vscode.OutputChannel, workingDirect
                 // 'func' commands always seem to return exit code 0. For now,
                 // we will use stderr to detect if an error occurs (even though stderr
                 // doesn't necessarily mean there's an error)
-                reject(errorMessage);
+                // https://github.com/Azure/azure-functions-cli/issues/272
+                reject(new Error(errorMessage));
             } else if (code !== 0) {
                 reject(new Error(localize('azFunc.funcCliCommandError', 'Command failed with exit code \'{0}\'.', code)));
             } else {

--- a/src/nodes/FunctionAppNode.ts
+++ b/src/nodes/FunctionAppNode.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Site } from '../../node_modules/azure-arm-website/lib/models';
+import { Site } from 'azure-arm-website/lib/models';
 import * as errors from '../errors';
 import * as util from '../util';
 import { NodeBase } from './NodeBase';

--- a/src/nodes/SubscriptionNode.ts
+++ b/src/nodes/SubscriptionNode.ts
@@ -5,7 +5,7 @@
 
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
-import { Site, WebAppCollection } from '../../node_modules/azure-arm-website/lib/models';
+import { Site, WebAppCollection } from 'azure-arm-website/lib/models';
 import { AzureResourceFilter } from '../azure-account.api';
 import * as errors from '../errors';
 import { FunctionAppNode } from './FunctionAppNode';

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,29 +5,14 @@
 
 // tslint:disable-next-line:no-require-imports
 import WebSiteManagementClient = require('azure-arm-website');
+import { Site } from 'azure-arm-website/lib/models';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { QuickPickItem } from 'vscode';
 import * as nls from 'vscode-nls';
-import { Site } from '../node_modules/azure-arm-website/lib/models';
 import * as errors from './errors';
 
 export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();
-
-export function errorToString(error: {}): string | undefined {
-    if (error instanceof Error) {
-        return JSON.stringify({
-            Error: error.constructor.name,
-            Message: error.message
-        });
-    } else if (typeof (error) === 'object') {
-        return JSON.stringify({
-            object: error.constructor.name
-        });
-    } else {
-        return undefined;
-    }
-}
 
 export async function showQuickPick<T>(items: PickWithData<T>[] | Thenable<PickWithData<T>[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<PickWithData<T>>;
 export async function showQuickPick(items: Pick[] | Thenable<Pick[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<Pick>;
@@ -115,7 +100,7 @@ export class PickWithData<T> extends Pick {
 }
 
 export async function writeToFile(path: string, data: string): Promise<void> {
-    await new Promise((resolve: () => void, reject: (e: {}) => void): void => {
+    await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
         fs.writeFile(path, data, (error?: Error) => {
             if (error) {
                 reject(error);

--- a/test/errorUtil.test.ts
+++ b/test/errorUtil.test.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ErrorData } from '../src/ErrorData';
+
+suite('Error Data Tests', () => {
+    test('Generic Error', () => {
+        const ed: ErrorData = new ErrorData(new Error('test'));
+        assert.equal(ed.errorType, 'Error');
+        assert.equal(ed.message, 'test');
+    });
+
+    test('Specific Error', () => {
+        const ed: ErrorData = new ErrorData(new ReferenceError('test'));
+        assert.equal(ed.errorType, 'ReferenceError');
+        assert.equal(ed.message, 'test');
+    });
+
+    test('String', () => {
+        const ed: ErrorData = new ErrorData('test');
+        assert.equal(ed.errorType, 'string');
+        assert.equal(ed.message, 'test');
+    });
+
+    test('Empty String', () => {
+        const ed: ErrorData = new ErrorData('   ');
+        assert.equal(ed.errorType, 'string');
+        assert.equal(ed.message, 'Unknown Error');
+    });
+
+    test('Object', () => {
+        const ed: ErrorData = new ErrorData({ errorCode: 1 });
+        assert.equal(ed.errorType, 'Object');
+        assert.equal(ed.message, '{"errorCode":1}');
+    });
+
+    test('Custom Object', () => {
+        class MyObject {
+            public readonly msg: string;
+            constructor(msg: string) { this.msg = msg; }
+        }
+
+        const ed: ErrorData = new ErrorData(new MyObject('test'));
+        assert.equal(ed.errorType, 'MyObject');
+        assert.equal(ed.message, '{"msg":"test"}');
+    });
+
+    test('Null', () => {
+        const ed: ErrorData = new ErrorData(null);
+        assert.equal(ed.errorType, 'object');
+        assert.equal(ed.message, 'Unknown Error');
+    });
+
+    test('Array', () => {
+        const ed: ErrorData = new ErrorData([1, 2]);
+        assert.equal(ed.errorType, 'Array');
+        assert.equal(ed.message, '[1,2]');
+    });
+
+    test('Number', () => {
+        const ed: ErrorData = new ErrorData(3);
+        assert.equal(ed.errorType, 'number');
+        assert.equal(ed.message, '3');
+    });
+
+    test('Boolean', () => {
+        const ed: ErrorData = new ErrorData(false);
+        assert.equal(ed.errorType, 'boolean');
+        assert.equal(ed.message, 'false');
+    });
+
+    test('Undefined', () => {
+        const ed: ErrorData = new ErrorData(undefined);
+        assert.equal(ed.errorType, 'undefined');
+        assert.equal(ed.message, 'Unknown Error');
+    });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,24 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+// tslint:disable-next-line:no-require-imports
+import testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+// tslint:disable-next-line:no-unsafe-any
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;


### PR DESCRIPTION
If we let errors bubble out of our extension, VSCode will sometimes show the error and sometimes not. To be safe, we should show the message ourselves. I also like showing messages in one place (extension.ts) so that our experience is consistent across the extension and so that telemetry always catches it.

However, when I initially implemented this I didn't do the correct typing all over the place and thus an error of type 'string' wouldn't be displayed to the user. Now it should work for whatever type of error is thrown at us. I also took this as an excuse to experiment with unit tests