### PR TITLE
Improve entry points for zip deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,16 @@
                 "command": "azureFunctions.deployZip",
                 "title": "%azFunc.deployZip%",
                 "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.deployZipFromExplorer",
+                "title": "%azFunc.deployZipFromExplorer%",
+                "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.deployZipFromFolder",
+                "title": "%azFunc.deployZipFromFolder%",
+                "category": "Azure Functions"
             }
         ],
         "views": {
@@ -144,9 +154,26 @@
                     "group": "2_functionAppControlCommands@3"
                 },
                 {
-                    "command": "azureFunctions.deployZip",
+                    "command": "azureFunctions.deployZipFromExplorer",
                     "when": "view == azureFunctionsExplorer && viewItem == azureFunctionsFunctionApp",
                     "group": "3_functionAppDeployCommands@1"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "azureFunctions.deployZipFromFolder",
+                    "when": "explorerResourceIsFolder == true",
+                    "group": "zzz_@1"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command": "azureFunctions.deployZipFromExplorer",
+                    "when": "never"
+                },
+                {
+                    "command": "azureFunctions.deployZipFromFolder",
+                    "when": "never"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,5 +8,7 @@
     "azFunc.stopFunctionApp": "Stop",
     "azFunc.restartFunctionApp": "Restart",
     "azFunc.showExplorerDescription": "Show or hide the Azure Functions Explorer",
-    "azFunc.deployZip": "Deploy as Zip Package"
+    "azFunc.deployZip": "Deploy Zip Package",
+    "azFunc.deployZipFromExplorer": "Deploy here as Zip",
+    "azFunc.deployZipFromFolder": "Deploy to Function App as Zip"
 }

--- a/src/AzureFunctionsExplorer.ts
+++ b/src/AzureFunctionsExplorer.ts
@@ -5,10 +5,10 @@
 
 import { Event, EventEmitter, TreeDataProvider, TreeItem } from 'vscode';
 import { AzureAccount, AzureResourceFilter } from './azure-account.api';
+import { localize } from './localize';
 import { NodeBase } from './nodes/NodeBase';
 import { SubscriptionNode } from './nodes/SubscriptionNode';
-import * as util from './util';
-import { localize } from './util';
+import * as uiUtil from './utils/ui';
 
 export class AzureFunctionsExplorer implements TreeDataProvider<NodeBase> {
     private onDidChangeTreeDataEmitter: EventEmitter<NodeBase> = new EventEmitter<NodeBase>();
@@ -53,18 +53,18 @@ export class AzureFunctionsExplorer implements TreeDataProvider<NodeBase> {
 
     public async showNodePicker(expectedContextValue: string): Promise<NodeBase> {
         let childType: string | undefined = 'Subscription';
-        let quickPicksTask: Promise<util.PickWithData<NodeBase>[]> = Promise.resolve(this.rootNodes.map((c: NodeBase) => new util.PickWithData<NodeBase>(c, c.label)));
+        let quickPicksTask: Promise<uiUtil.PickWithData<NodeBase>[]> = Promise.resolve(this.rootNodes.map((c: NodeBase) => new uiUtil.PickWithData<NodeBase>(c, c.label)));
 
         while (childType) {
-            const pick: util.PickWithData<NodeBase> = await util.showQuickPick<NodeBase>(quickPicksTask, localize('azFunc.selectNode', 'Select a {0}', childType));
+            const pick: uiUtil.PickWithData<NodeBase> = await uiUtil.showQuickPick<NodeBase>(quickPicksTask, localize('azFunc.selectNode', 'Select a {0}', childType));
             const node: NodeBase = pick.data;
             if (node.contextValue === expectedContextValue) {
                 return node;
             }
 
             childType = node.childType;
-            quickPicksTask = node.getChildren(false).then((nodes: NodeBase[]): util.PickWithData<NodeBase>[] => {
-                return nodes.map((c: NodeBase) => new util.PickWithData<NodeBase>(c, c.label));
+            quickPicksTask = node.getChildren(false).then((nodes: NodeBase[]): uiUtil.PickWithData<NodeBase>[] => {
+                return nodes.map((c: NodeBase) => new uiUtil.PickWithData<NodeBase>(c, c.label));
             });
         }
 

--- a/src/ErrorData.ts
+++ b/src/ErrorData.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from './util';
+import { localize } from './localize';
 
 export class ErrorData {
     public readonly message: string;

--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -8,8 +8,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as errors from '../errors';
 import * as FunctionsCli from '../functions-cli';
-import * as util from '../util';
-import { localize } from '../util';
+import { localize } from '../localize';
+import * as uiUtil from '../utils/ui';
 
 const expectedFunctionAppFiles: string[] = [
     'host.json',
@@ -39,8 +39,8 @@ export async function createFunction(outputChannel: vscode.OutputChannel): Promi
     } else if (folders.length === 1) {
         functionAppPath = folders[0].uri.fsPath;
     } else {
-        const folderPicks: util.Pick[] = folders.map((f: vscode.WorkspaceFolder) => new util.Pick(f.uri.fsPath));
-        const folder: util.Pick = await util.showQuickPick(folderPicks, localize('azFunc.newFuncSelectFolder', 'Select a workspace folder for your new function'));
+        const folderPicks: uiUtil.Pick[] = folders.map((f: vscode.WorkspaceFolder) => new uiUtil.Pick(f.uri.fsPath));
+        const folder: uiUtil.Pick = await uiUtil.showQuickPick(folderPicks, localize('azFunc.newFuncSelectFolder', 'Select a workspace folder for your new function'));
         functionAppPath = folder.label;
     }
 
@@ -57,17 +57,17 @@ export async function createFunction(outputChannel: vscode.OutputChannel): Promi
         }
     }
 
-    const templates: util.Pick[] = [
-        new util.Pick('BlobTrigger'),
-        new util.Pick('HttpTrigger'),
-        new util.Pick('QueueTrigger'),
-        new util.Pick('TimerTrigger')
+    const templates: uiUtil.Pick[] = [
+        new uiUtil.Pick('BlobTrigger'),
+        new uiUtil.Pick('HttpTrigger'),
+        new uiUtil.Pick('QueueTrigger'),
+        new uiUtil.Pick('TimerTrigger')
     ];
-    const template: util.Pick = await util.showQuickPick(templates, localize('azFunc.selectFuncTemplate', 'Select a function template'));
+    const template: uiUtil.Pick = await uiUtil.showQuickPick(templates, localize('azFunc.selectFuncTemplate', 'Select a function template'));
 
     const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function Name');
     const prompt: string = localize('azFunc.funcNamePrompt', 'Provide a function name');
-    const name: string = await util.showInputBox(placeHolder, prompt, false, (s: string) => validateTemplateName(functionAppPath, s));
+    const name: string = await uiUtil.showInputBox(placeHolder, prompt, false, (s: string) => validateTemplateName(functionAppPath, s));
 
     await FunctionsCli.createFunction(outputChannel, functionAppPath, template.label, name);
     const newFileUri: vscode.Uri = vscode.Uri.file(path.join(functionAppPath, name, 'index.js'));

--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -10,6 +10,7 @@ import * as errors from '../errors';
 import * as FunctionsCli from '../functions-cli';
 import { localize } from '../localize';
 import * as uiUtil from '../utils/ui';
+import * as workspaceUtil from '../utils/workspace';
 
 const expectedFunctionAppFiles: string[] = [
     'host.json',
@@ -32,17 +33,7 @@ function validateTemplateName(rootPath: string, name: string): string | undefine
 }
 
 export async function createFunction(outputChannel: vscode.OutputChannel): Promise<void> {
-    let functionAppPath: string;
-    const folders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
-    if (!folders || folders.length === 0) {
-        throw new errors.NoWorkspaceError();
-    } else if (folders.length === 1) {
-        functionAppPath = folders[0].uri.fsPath;
-    } else {
-        const folderPicks: uiUtil.Pick[] = folders.map((f: vscode.WorkspaceFolder) => new uiUtil.Pick(f.uri.fsPath));
-        const folder: uiUtil.Pick = await uiUtil.showQuickPick(folderPicks, localize('azFunc.newFuncSelectFolder', 'Select a workspace folder for your new function'));
-        functionAppPath = folder.label;
-    }
+    const functionAppPath: string = await workspaceUtil.selectWorkspaceFolder(localize('azFunc.selectFunctionAppFolderExisting', 'Select the folder containing your function app'));
 
     const missingFiles: string[] = getMissingFunctionAppFiles(functionAppPath);
     if (missingFiles.length !== 0) {

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -7,21 +7,22 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as FunctionsCli from '../functions-cli';
+import { localize } from '../localize';
 import * as TemplateFiles from '../template-files';
-import * as util from '../util';
-import { localize } from '../util';
+import * as fsUtil from '../utils/fs';
+import * as uiUtil from '../utils/ui';
 
 export async function createNewProject(outputChannel: vscode.OutputChannel): Promise<void> {
     const newFolderId: string = 'newFolder';
-    let folderPicks: util.PickWithData<string>[] = [new util.PickWithData(newFolderId, localize('azFunc.newFolder', '$(plus) New Folder'))];
+    let folderPicks: uiUtil.PickWithData<string>[] = [new uiUtil.PickWithData(newFolderId, localize('azFunc.newFolder', '$(plus) New Folder'))];
     const folders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
     if (folders) {
-        folderPicks = folderPicks.concat(folders.map((f: vscode.WorkspaceFolder) => new util.PickWithData('', f.uri.fsPath)));
+        folderPicks = folderPicks.concat(folders.map((f: vscode.WorkspaceFolder) => new uiUtil.PickWithData('', f.uri.fsPath)));
     }
-    const folder: util.PickWithData<string> = await util.showQuickPick<string>(folderPicks, localize('azFunc.newFuncAppSelectFolder', 'Select a workspace folder for your new function app'));
+    const folder: uiUtil.PickWithData<string> = await uiUtil.showQuickPick<string>(folderPicks, localize('azFunc.newFuncAppSelectFolder', 'Select a workspace folder for your new function app'));
     const createNewFolder: boolean = folder.data === newFolderId;
 
-    const functionAppPath: string = createNewFolder ? await util.showFolderDialog() : folder.label;
+    const functionAppPath: string = createNewFolder ? await uiUtil.showFolderDialog() : folder.label;
 
     const tasksJsonPath: string = path.join(functionAppPath, '.vscode', 'tasks.json');
     const tasksJsonExists: boolean = fs.existsSync(tasksJsonPath);
@@ -31,8 +32,8 @@ export async function createNewProject(outputChannel: vscode.OutputChannel): Pro
     await FunctionsCli.createNewProject(outputChannel, functionAppPath);
 
     if (!tasksJsonExists && !launchJsonExists) {
-        await util.writeToFile(tasksJsonPath, TemplateFiles.getTasksJson());
-        await util.writeToFile(launchJsonPath, TemplateFiles.getLaunchJson());
+        await fsUtil.writeToFile(tasksJsonPath, TemplateFiles.getTasksJson());
+        await fsUtil.writeToFile(launchJsonPath, TemplateFiles.getLaunchJson());
     }
 
     if (createNewFolder) {

--- a/src/commands/deployZip.ts
+++ b/src/commands/deployZip.ts
@@ -7,9 +7,9 @@
 import WebSiteManagementClient = require('azure-arm-website');
 import * as vscode from 'vscode';
 import { AzureFunctionsExplorer } from '../AzureFunctionsExplorer';
+import { localize } from '../localize';
 import { FunctionAppNode } from '../nodes/FunctionAppNode';
-import * as util from '../util';
-import { localize } from '../util';
+import * as uiUtil from '../utils/ui';
 
 export async function deployZip(explorer: AzureFunctionsExplorer, outputChannel: vscode.OutputChannel, node?: FunctionAppNode): Promise<void> {
     if (!node) {
@@ -19,13 +19,13 @@ export async function deployZip(explorer: AzureFunctionsExplorer, outputChannel:
     const client: WebSiteManagementClient = node.getWebSiteClient();
 
     const newFolderId: string = 'newFolder';
-    let folderPicks: util.PickWithData<string>[] = [new util.PickWithData(newFolderId, localize('azFunc.selectOtherFolder', '$(plus) Select other folder'))];
+    let folderPicks: uiUtil.PickWithData<string>[] = [new uiUtil.PickWithData(newFolderId, localize('azFunc.selectOtherFolder', '$(plus) Select other folder'))];
     const folders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
     if (folders) {
-        folderPicks = folderPicks.concat(folders.map((f: vscode.WorkspaceFolder) => new util.PickWithData<string>('', f.uri.fsPath)));
+        folderPicks = folderPicks.concat(folders.map((f: vscode.WorkspaceFolder) => new uiUtil.PickWithData<string>('', f.uri.fsPath)));
     }
-    const folder: util.PickWithData<string> = await util.showQuickPick<string>(folderPicks, localize('azFunc.deployZipSelectFolder', 'Select a workspace folder to deploy to your Function App'));
-    const folderPath: string = folder.data === newFolderId ? await util.showFolderDialog() : folder.label;
+    const folder: uiUtil.PickWithData<string> = await uiUtil.showQuickPick<string>(folderPicks, localize('azFunc.deployZipSelectFolder', 'Select a workspace folder to deploy to your Function App'));
+    const folderPath: string = folder.data === newFolderId ? await uiUtil.showFolderDialog() : folder.label;
 
     await node.siteWrapper.deployZip(folderPath, client, outputChannel);
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from './util';
+import { localize } from './localize';
 
 export class UserCancelledError extends Error { }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,9 +18,9 @@ import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
 import { ErrorData } from './ErrorData';
 import * as errors from './errors';
+import { localize } from './localize';
 import { FunctionAppNode } from './nodes/FunctionAppNode';
 import { NodeBase } from './nodes/NodeBase';
-import { localize } from './util';
 
 let reporter: TelemetryReporter | undefined;
 

--- a/src/functions-cli.ts
+++ b/src/functions-cli.ts
@@ -5,7 +5,7 @@
 
 import * as cp from 'child_process';
 import * as vscode from 'vscode';
-import { localize } from './util';
+import { localize } from './localize';
 
 export async function createFunction(outputChannel: vscode.OutputChannel, workingDirectory: string, templateName: string, name: string): Promise<void> {
     await executeCommand(outputChannel, workingDirectory, 'new', '--language', 'JavaScript', '--template', templateName, '--name', name);

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vscode-nls';
+
+export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();

--- a/src/template-files.ts
+++ b/src/template-files.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from './util';
+import { localize } from './localize';
 
 const taskId: string = 'launchFunctionApp';
 const tasksJson: {} = {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+
+// tslint:disable-next-line:export-name
+export async function writeToFile(path: string, data: string): Promise<void> {
+    await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
+        fs.writeFile(path, data, (error?: Error) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
+    });
+}

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -3,13 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { QuickPickItem } from 'vscode';
-import * as nls from 'vscode-nls';
-import * as errors from './errors';
-
-export const localize: nls.LocalizeFunc = nls.config(process.env.VSCODE_NLS_CONFIG)();
+import * as errors from '../errors';
+import { localize } from '../localize';
 
 export async function showQuickPick<T>(items: PickWithData<T>[] | Thenable<PickWithData<T>[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<PickWithData<T>>;
 export async function showQuickPick(items: Pick[] | Thenable<Pick[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<Pick>;
@@ -76,16 +73,4 @@ export class PickWithData<T> extends Pick {
         super(label, description);
         this.data = data;
     }
-}
-
-export async function writeToFile(path: string, data: string): Promise<void> {
-    await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
-        fs.writeFile(path, data, (error?: Error) => {
-            if (error) {
-                reject(error);
-            } else {
-                resolve();
-            }
-        });
-    });
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { localize } from '../localize';
+import * as uiUtil from './ui';
+
+export async function selectWorkspaceFolder(placeholder: string): Promise<string> {
+    const browse: string = ':browse';
+    let folder: uiUtil.PickWithData<string> | undefined;
+    if (vscode.workspace.workspaceFolders) {
+        let folderPicks: uiUtil.PickWithData<string>[] = [new uiUtil.PickWithData(browse, localize('azFunc.browse', '$(file-directory) Browse...'))];
+        folderPicks = folderPicks.concat(vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => new uiUtil.PickWithData('', f.uri.fsPath)));
+
+        folder = await uiUtil.showQuickPick<string>(folderPicks, placeholder);
+    }
+
+    return folder && folder.data !== browse ? folder.label : await uiUtil.showFolderDialog();
+}
+
+export function isFolderOpenInWorkspace(fsPath: string): boolean {
+    if (vscode.workspace.workspaceFolders) {
+        if (!fsPath.endsWith(path.sep)) {
+            fsPath = fsPath + path.sep;
+        }
+
+        const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.find((f: vscode.WorkspaceFolder): boolean => {
+            return fsPath.startsWith(f.uri.fsPath);
+        });
+
+        return folder !== undefined;
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
1. Add 'right click on folder' entry point
1. Add context-specific wording for each entry point
1. Make folder selection consistent across several commands
1. Refactor util.ts into multiple files

Fixes #15 