### PR TITLE
Add template filter configuration setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,16 @@
                         "type": "boolean",
                         "default": true,
                         "description": "%azFunc.showExplorerDescription%"
+                    },
+                    "azureFunctions.templateFilter": {
+                        "type": "string",
+                        "default": "Verified",
+                        "enum": [
+                            "Verified",
+                            "Core",
+                            "All"
+                        ],
+                        "description": "%azFunc.templateFilterDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
     "azFunc.stopFunctionApp": "Stop",
     "azFunc.restartFunctionApp": "Restart",
     "azFunc.showExplorerDescription": "Show or hide the Azure Functions Explorer",
+    "azFunc.templateFilterDescription": "Specify the templates to display when creating a new function. The supported values are 'Verified', 'Core', and 'All'. The 'Verified' category is a subset of 'Core' that has been verified to work with the latest VS Code extension.",
     "azFunc.deployZip": "Deploy Zip Package",
     "azFunc.deployZipFromExplorer": "Deploy here as Zip",
     "azFunc.deployZipFromFolder": "Deploy to Function App as Zip"

--- a/test/createFunction.test.ts
+++ b/test/createFunction.test.ts
@@ -17,6 +17,11 @@ const templateData: TemplateData = new TemplateData();
 const testFolder: string = path.join(os.tmpdir(), `azFunc.createFuncTests${fsUtil.randomName()}`);
 const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions Test');
 
+const templateFilterSetting: string = 'azureFunctions.templateFilter';
+const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+// tslint:disable-next-line:no-backbone-get-set-outside-model
+const oldTemplateFilter: string | undefined = config.get(templateFilterSetting);
+
 suiteSetup(async () => {
     await fsUtil.makeFolder(testFolder);
     await fsUtil.makeFolder(path.join(testFolder, '.vscode'));
@@ -26,11 +31,14 @@ suiteSetup(async () => {
         fsUtil.writeToFile(path.join(testFolder, 'local.settings.json'), ''),
         fsUtil.writeToFile(path.join(testFolder, '.vscode', 'launch.json'), '')
     ]);
+
+    await config.update(templateFilterSetting, 'Core', vscode.ConfigurationTarget.Global);
 });
 
 suiteTeardown(async () => {
     outputChannel.dispose();
     await fsUtil.deleteFolderAndContents(testFolder);
+    await config.update(templateFilterSetting, oldTemplateFilter, vscode.ConfigurationTarget.Global);
 });
 
 suite('Create Function Tests', () => {


### PR DESCRIPTION
Some of the templates don't work on the latest func cli when debugging locally. Adding a 'Verified' setting for just the ones that work and an 'All' setting for those adventurous users

Fixes #31 
Fixes #30