### PR TITLE
Support create java function project

### DIFF
--- a/src/IUserInterface.ts
+++ b/src/IUserInterface.ts
@@ -9,7 +9,7 @@ export interface IUserInterface {
     showQuickPick<T>(items: PickWithData<T>[] | Thenable<PickWithData<T>[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<PickWithData<T>>;
     showQuickPick(items: Pick[] | Thenable<Pick[]>, placeHolder: string, ignoreFocusOut?: boolean): Promise<Pick>;
 
-    showInputBox(placeHolder: string, prompt: string, ignoreFocusOut?: boolean, validateInput?: (s: string) => string | undefined | null, value?: string): Promise<string>;
+    showInputBox(placeHolder: string, prompt: string, ignoreFocusOut?: boolean, validateInput?: (s: string) => string | undefined | null, defaultValue?: string): Promise<string>;
 
     showFolderDialog(): Promise<string>;
 }

--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -19,6 +19,7 @@ import { TemplateData } from '../templates/TemplateData';
 import * as fsUtil from '../utils/fs';
 import * as workspaceUtil from '../utils/workspace';
 import { VSCodeUI } from '../VSCodeUI';
+import * as CreateNewProject from './createNewProject';
 
 const expectedFunctionAppFiles: string[] = [
     'host.json',
@@ -48,7 +49,7 @@ async function validateIsFunctionApp(outputChannel: vscode.OutputChannel, functi
         const message: string = localize('azFunc.missingFuncAppFiles', 'The current folder is missing the following function app files: \'{0}\'. Add the missing files?', missingFiles.join(','));
         const result: string | undefined = await vscode.window.showWarningMessage(message, yes, no);
         if (result === yes) {
-            await FunctionsCli.createNewProject(outputChannel, functionAppPath);
+            await CreateNewProject.createNewProject(outputChannel, functionAppPath);
         } else {
             throw new errors.UserCancelledError();
         }

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -32,7 +32,7 @@ export async function createNewProject(outputChannel: vscode.OutputChannel, func
         case TemplateLanguage.Java:
             // Get parameters for Maven command
             const { groupId, artifactId, version, packageName, appName } = await promotForMavenParameters(ui, functionAppPath);
-            // Use maven command currently, will change to function CLI when the function CLI init project command is ready.
+            // Use maven command to init Java function project.
             await FunctionsCli.createNewProject(
                 outputChannel,
                 functionAppPath,

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -8,25 +8,89 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as FunctionsCli from '../functions-cli';
 import { IUserInterface } from '../IUserInterface';
+import { Pick } from '../IUserInterface';
 import { localize } from '../localize';
 import * as TemplateFiles from '../template-files';
+import { TemplateLanguage } from '../templates/Template';
 import * as fsUtil from '../utils/fs';
 import * as workspaceUtil from '../utils/workspace';
 import { VSCodeUI } from '../VSCodeUI';
 
-export async function createNewProject(outputChannel: vscode.OutputChannel, ui: IUserInterface = new VSCodeUI()): Promise<void> {
-    const functionAppPath: string = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
+export async function createNewProject(outputChannel: vscode.OutputChannel, workingDirectory?: string, ui: IUserInterface = new VSCodeUI()): Promise<void> {
+    let functionAppPath: string;
+    if (!workingDirectory || workingDirectory.length === 0) {
+        functionAppPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
+    } else {
+        functionAppPath = workingDirectory;
+    }
+
+    const languages: Pick[] = [
+        new Pick(TemplateLanguage.JavaScript),
+        new Pick(TemplateLanguage.Java)
+    ];
+    const language: Pick = await ui.showQuickPick(languages, localize('azFunc.selectFuncTemplate', 'Select the language of your function project'));
+
+    let javaTargetPath: string = '';
+    switch (language.label) {
+        case TemplateLanguage.Java:
+            const groupIdPlaceHolder: string = localize('azFunc.java.groupIdPlaceholder', 'groupId');
+            const groupIdPrompt: string = localize('azFunc.java.groupIdPrompt', 'Provide value of "groupId"');
+            const groupId: string = await ui.showInputBox(groupIdPlaceHolder, groupIdPrompt, false);
+
+            const artifactIdPlaceHolder: string = localize('azFunc.java.artifactIdPlaceholder', 'artifactId');
+            const artifactIdprompt: string = localize('azFunc.java.artifactIdPrompt', 'Provide value of "artifactId"');
+            const artifactId: string = await ui.showInputBox(artifactIdPlaceHolder, artifactIdprompt, false);
+
+            const versionPlaceHolder: string = localize('azFunc.java.versionPlaceHolder', '1.0-SNAPSHOT');
+            const versionPrompt: string = localize('azFunc.java.versionPrompt', 'Provide value of "version"');
+            const version: string = await ui.showInputBox(versionPlaceHolder, versionPrompt, false, undefined, '1.0-SNAPSHOT');
+
+            const packagePlaceHolder: string = localize('azFunc.java.packagePlaceHolder', groupId);
+            const packagePrompt: string = localize('azFunc.java.packagePrompt', 'Provide value of "package"');
+            const packageName: string = await ui.showInputBox(packagePlaceHolder, packagePrompt, false, undefined, groupId);
+
+            const appNamePlaceHolder: string = localize('azFunc.java.appNamePlaceHolder', `${artifactId}-${Date.now()}`);
+            const appNamePrompt: string = localize('azFunc.java.appNamePrompt', 'Provide value of "appName"');
+            const appName: string = await ui.showInputBox(appNamePlaceHolder, appNamePrompt, false, undefined, `${artifactId}-${Date.now()}`);
+
+            // Use maven command currently, will change to function CLI when the function CLI init project command is ready.
+            await FunctionsCli.createNewProject(
+                outputChannel,
+                functionAppPath,
+                language.label,
+                'archetype:generate',
+                '-DarchetypeGroupId="com.microsoft.azure"',
+                '-DarchetypeArtifactId="azure-functions-archetype"',
+                `-DgroupId="${groupId}"`,
+                `-DartifactId="${artifactId}"`,
+                `-Dversion="${version}"`,
+                `-Dpackage="${packageName}"`,
+                `-DappName="${appName}"`,
+                '-B' // in Batch Mode
+            );
+
+            functionAppPath = path.join(functionAppPath, artifactId);
+            javaTargetPath = `target/azure-functions/${appName}/`;
+            break;
+        default:
+            await FunctionsCli.createNewProject(outputChannel, functionAppPath, language.label, 'init');
+            break;
+    }
 
     const tasksJsonPath: string = path.join(functionAppPath, '.vscode', 'tasks.json');
     const tasksJsonExists: boolean = await fse.pathExists(tasksJsonPath);
     const launchJsonPath: string = path.join(functionAppPath, '.vscode', 'launch.json');
     const launchJsonExists: boolean = await fse.pathExists(launchJsonPath);
 
-    await FunctionsCli.createNewProject(outputChannel, functionAppPath);
-
     if (!tasksJsonExists && !launchJsonExists) {
-        await fsUtil.writeFormattedJson(tasksJsonPath, TemplateFiles.tasksJson);
-        await fsUtil.writeFormattedJson(launchJsonPath, TemplateFiles.launchJson);
+        const vsCodePath: string = path.join(functionAppPath, '.vscode');
+        if (!await fse.pathExists(vsCodePath)) {
+            await fse.mkdir(vsCodePath);
+        }
+        await Promise.all([
+            fse.writeFile(tasksJsonPath, TemplateFiles.getTasksJson(language.label, javaTargetPath)),
+            fsUtil.writeFormattedJson(launchJsonPath, TemplateFiles.getLaunchJson(language.label))
+        ]);
     }
 
     if (!workspaceUtil.isFolderOpenInWorkspace(functionAppPath)) {

--- a/src/functions-cli.ts
+++ b/src/functions-cli.ts
@@ -6,19 +6,21 @@
 import * as cp from 'child_process';
 import * as vscode from 'vscode';
 import { localize } from './localize';
+import { TemplateLanguage } from './templates/Template';
 
 // tslint:disable-next-line:export-name
-export async function createNewProject(outputChannel: vscode.OutputChannel, workingDirectory: string): Promise<void> {
-    await executeCommand(outputChannel, workingDirectory, 'init');
+export async function createNewProject(outputChannel: vscode.OutputChannel, workingDirectory: string, languageName: string, ...args: string[]): Promise<void> {
+    await executeCommand(outputChannel, workingDirectory, languageName, ...args);
 }
 
-async function executeCommand(outputChannel: vscode.OutputChannel, workingDirectory: string, ...args: string[]): Promise<void> {
+async function executeCommand(outputChannel: vscode.OutputChannel, workingDirectory: string, languageName: String, ...args: string[]): Promise<void> {
     await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
         const options: cp.SpawnOptions = {
             cwd: workingDirectory,
             shell: true
         };
-        const childProc: cp.ChildProcess = cp.spawn('func', args, options);
+        const command: string = languageName === TemplateLanguage.Java ? 'mvn' : 'func';
+        const childProc: cp.ChildProcess = cp.spawn(command, args, options);
         let stderr: string = '';
         childProc.stdout.on('data', (data: string | Buffer) => outputChannel.append(data.toString()));
         childProc.stderr.on('data', (data: string | Buffer) => stderr = stderr.concat(data.toString()));

--- a/src/functions-cli.ts
+++ b/src/functions-cli.ts
@@ -10,16 +10,16 @@ import { TemplateLanguage } from './templates/Template';
 
 // tslint:disable-next-line:export-name
 export async function createNewProject(outputChannel: vscode.OutputChannel, workingDirectory: string, languageName: string, ...args: string[]): Promise<void> {
-    await executeCommand(outputChannel, workingDirectory, languageName, ...args);
+    const command: string = languageName === TemplateLanguage.Java ? 'mvn' : 'func';
+    await executeCommand(outputChannel, workingDirectory, command, ...args);
 }
 
-async function executeCommand(outputChannel: vscode.OutputChannel, workingDirectory: string, languageName: String, ...args: string[]): Promise<void> {
+async function executeCommand(outputChannel: vscode.OutputChannel, workingDirectory: string, command: string, ...args: string[]): Promise<void> {
     await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
         const options: cp.SpawnOptions = {
             cwd: workingDirectory,
             shell: true
         };
-        const command: string = languageName === TemplateLanguage.Java ? 'mvn' : 'func';
         const childProc: cp.ChildProcess = cp.spawn(command, args, options);
         let stderr: string = '';
         childProc.stdout.on('data', (data: string | Buffer) => outputChannel.append(data.toString()));

--- a/src/template-files.ts
+++ b/src/template-files.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from './localize';
+import { TemplateLanguage } from './templates/Template';
 
 const taskId: string = 'launchFunctionApp';
-export const tasksJson: {} = {
+const tasksJsonForJavascript: {} = {
     version: '2.0.0',
     tasks: [
         {
@@ -40,7 +41,7 @@ export const tasksJson: {} = {
     ]
 };
 
-export const launchJson: {} = {
+const launchJsonForJavascript: {} = {
     version: '0.2.0',
     configurations: [
         {
@@ -53,3 +54,84 @@ export const launchJson: {} = {
         }
     ]
 };
+
+const taskJsonForJava: {} = {
+    version: '2.0.0',
+    tasks: [
+        {
+            taskName: 'Launch Function App',
+            identifier: 'launchFunctionApp',
+            linux: {
+                command: 'sh -c "mvn clean package && func host start --script-root %path%"'
+            },
+            osx: {
+                command: 'sh -c "mvn clean package && func host start --script-root %path%"'
+            },
+            windows: {
+                command: 'powershell mvn clean package; func host start --script-root %path%'
+            },
+            type: 'shell',
+            isBackground: true,
+            presentation: {
+                reveal: 'always'
+            },
+            problemMatcher: [
+                {
+                    owner: 'azureFunctions',
+                    pattern: [
+                        {
+                            regexp: '\\b\\B',
+                            file: 1,
+                            location: 2,
+                            message: 3
+                        }
+                    ],
+                    background: {
+                        activeOnStart: true,
+                        beginsPattern: '^.*Stopping host.*',
+                        endsPattern: '^.*Job host started.*'
+                    }
+                }
+            ]
+        }
+    ]
+};
+
+const launchJsonForJava: {} = {
+    version: '0.2.0',
+    configurations: [
+        {
+            name: localize('azFunc.attachToFunc', 'Attach to Azure Functions'),
+            type: 'java',
+            request: 'attach',
+            hostName: 'localhost',
+            port: 5005,
+            preLaunchTask: taskId
+        }
+    ]
+};
+
+function stringifyJSON(data: {}): string {
+    return JSON.stringify(data, null, '    ');
+}
+
+export function getTasksJson(language: string, args: string): string {
+    switch (language) {
+        case TemplateLanguage.Java:
+            let taskJsonString: string = stringifyJSON(taskJsonForJava);
+            taskJsonString = taskJsonString.replace(/%path%/g, args);
+
+            return taskJsonString;
+        default:
+            return stringifyJSON(tasksJsonForJavascript);
+    }
+}
+
+export function getLaunchJson(language: string): object {
+    switch (language) {
+        case TemplateLanguage.Java:
+            return launchJsonForJava;
+        default:
+            return launchJsonForJavascript;
+    }
+}

--- a/src/templates/Template.ts
+++ b/src/templates/Template.ts
@@ -30,7 +30,8 @@ interface ITemplateMetadata {
 }
 
 export enum TemplateLanguage {
-    JavaScript = 'JavaScript'
+    JavaScript = 'JavaScript',
+    Java = 'Java'
 }
 
 export enum TemplateCategory {

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+const terminal: vscode.Terminal = vscode.window.createTerminal('Azure Functions');
+
+// tslint:disable-next-line:export-name
+export function runCommandInTerminal(command: string, addNewLine: boolean = true): void {
+    terminal.show();
+    terminal.sendText(command, addNewLine);
+}

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -3,10 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
+import { TemplateLanguage } from '../templates/Template';
 
 export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string): Promise<string> {
     const browse: string = ':browse';
@@ -32,4 +34,16 @@ export function isFolderOpenInWorkspace(fsPath: string): boolean {
     } else {
         return false;
     }
+}
+
+export function getProjectType(projectPath: string): string {
+    let language: string = TemplateLanguage.JavaScript;
+    fse.readdirSync(projectPath).forEach((file: string) => {
+        const stat: fse.Stats = fse.statSync(path.join(projectPath, file));
+        // Currently checking the existing pom.xml to determine whether the function project is Java language based.
+        if (stat.isFile() && file === 'pom.xml') {
+            language = TemplateLanguage.Java;
+        }
+    });
+    return language;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -23,12 +23,9 @@ export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: str
 
 export function isFolderOpenInWorkspace(fsPath: string): boolean {
     if (vscode.workspace.workspaceFolders) {
-        if (!fsPath.endsWith(path.sep)) {
-            fsPath = fsPath + path.sep;
-        }
 
         const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.find((f: vscode.WorkspaceFolder): boolean => {
-            return fsPath.startsWith(f.uri.fsPath);
+            return path.relative(fsPath, f.uri.fsPath) === '';
         });
 
         return folder !== undefined;


### PR DESCRIPTION
Work Item: #48 

Support create java function project. Currently we will use Maven archetype (call mvn cli) to create a Java typed function project. And we'll change it to function cli when the related part in cli is ready.

UI: 
![create project](https://user-images.githubusercontent.com/6193897/32360276-1b2bf2ce-c08f-11e7-8289-c01e929550d3.gif)


Todo:
- Add Java function (#49)
- deploy Java function (#50)


-------------- Update on Wed Nov 08 2017 09:59:31 GMT+0800 (China Standard Time) --------------

Add code to support add Java function.
- Using [Maven plugin](https://github.com/Microsoft/azure-maven-plugins/tree/master/azure-functions-maven-plugin#add-new-function-to-current-project) to do this job.
_Confirmed from Maven plugin team, this command has no batch mode, so I send it to terminal and user can fill in the parameter in the terminal_
- Currently, we determine whether the project is Java based or not by finding ```pom.xml``` in the selected folder.