### PR TITLE
Chrisdias/compileerror

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
         "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",
-        "typescript": "2.5.3",
+        "typescript": "^2.0.3",
         "vscode": "^1.0.0"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -230,11 +230,12 @@
         "@types/fs-extra": "^4.0.3",
         "@types/mocha": "^2.2.32",
         "@types/node": "^8.0.28",
-        "@types/request-promise": "^4.1.38",
+        "@types/request-promise": "4.1.38",
+        "@types/request": "2.0.7",
         "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",
-        "typescript": "^2.0.3",
+        "typescript": "2.5.3",
         "vscode": "^1.0.0"
     },
     "dependencies": {


### PR DESCRIPTION
on a clean machine i was getting a compile error (`vsce package` or running `tsc -p ./`) caused by mismatched typescript definition files. see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/20678

explicitly requiring the @types/request fixes this problem.