### PR TITLE
Replace deprecated property in tasks template with updated one

### DIFF
--- a/src/template-files.ts
+++ b/src/template-files.ts
@@ -10,7 +10,7 @@ export const tasksJson: {} = {
     version: '2.0.0',
     tasks: [
         {
-            taskName: localize('azFunc.launchFuncApp', 'Launch Function App'),
+            label: localize('azFunc.launchFuncApp', 'Launch Function App'),
             identifier: taskId,
             type: 'shell',
             command: 'func host start',


### PR DESCRIPTION
The taksName has been deprecated:
Microsoft/vscode#29852
PR removes error highlight in editor.

Thanks!