### PR TITLE
Add vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,11 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+test/**
+src/**
+**/*.map
+.gitignore
+.travis.yml
+package-lock.json
+tsconfig.json
+tslint.json


### PR DESCRIPTION
This is used when creating a vsix. It actually doesn't affect the vsix size that much, but it's still the clean thing to do

Fixes #71 