### PR TITLE
Remove note about Node <8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## Prerequisites for local debugging
 * [Node v8.0+](https://nodejs.org/)
-  * Older versions of node will be supported soon. See issue [#1](https://github.com/Microsoft/vscode-azurefunctions/issues/1)
 * [.NET Core 2.0](https://www.microsoft.com/net/download/core)
 * [Azure Core Function Tools 2.0](https://www.npmjs.com/package/azure-functions-core-tools)
   ```


### PR DESCRIPTION
Per discussion with Jing and Matt, 8.0 recently became LTS, so we don't need to support <8.0.

I added a comment to issue #1 and gave users a workaround for older versions.