### PR TITLE
Add function name check and fix some bugs

### DIFF
--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -25,6 +25,8 @@ import * as workspaceUtil from '../utils/workspace';
 import { VSCodeUI } from '../VSCodeUI';
 import { createNewProject } from './createNewProject';
 
+const functionNameRegex: RegExp = /^[a-zA-Z][a-zA-Z\d_\-]*$/;
+
 const requiredFunctionAppFiles: string[] = [
     'host.json',
     'local.settings.json',
@@ -41,6 +43,9 @@ function validateTemplateName(rootPath: string, name: string | undefined, langua
     } else {
         if (fse.existsSync(path.join(rootPath, name))) {
             return localize('azFunc.existingFolderError', 'A folder with the name \'{0}\' already exists.', name);
+        }
+        if (!functionNameRegex.test(name)) {
+            return localize('azFunc.functionNameInvalidError', 'Function name must start with a letter and can contain letters, digits, \'_\' and \'-\'');
         }
         return undefined;
     }

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -64,13 +64,13 @@ const tasksJsonForJava: {} = {
             label: localize('azFunc.launchFuncApp', 'Launch Function App'),
             identifier: taskId,
             linux: {
-                command: 'sh -c "mvn clean package -B && func host start --script-root %path%"'
+                command: 'sh -c "mvn clean package -B && func host start --script-root \\\"%path%\\\""'
             },
             osx: {
-                command: 'sh -c "mvn clean package -B && func host start --script-root %path%"'
+                command: 'sh -c "mvn clean package -B && func host start --script-root \\\"%path%\\\""'
             },
             windows: {
-                command: 'powershell mvn clean package -B; func host start --script-root %path%'
+                command: 'powershell -command "mvn clean package -B; func host start --script-root \\\"%path%\\\""'
             },
             type: 'shell',
             isBackground: true,
@@ -184,6 +184,7 @@ async function createJavaFunctionProject(outputChannel: OutputChannel, functionA
     const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());
     await fse.ensureDir(tempFolder);
     // Use maven command to init Java function project.
+    outputChannel.show();
     await cpUtils.executeCommand(
         outputChannel,
         tempFolder,

--- a/src/utils/javaNameUtils.ts
+++ b/src/utils/javaNameUtils.ts
@@ -21,6 +21,7 @@ const keywords: string[] = [
 
 const identifierRegex: RegExp = /^[a-zA-Z_$][a-zA-Z\d_$]*$/;
 const mavenCheckRegex: RegExp = /^[a-zA-Z\d_\-\.]+$/;
+const javaFunctionRegex: RegExp = /^[a-zA-Z][a-zA-Z\d_]*$/;
 
 function isKeyword(name: string): boolean {
     return keywords.indexOf(name) > -1;
@@ -50,7 +51,13 @@ export function getJavaClassName(name: string): string {
 }
 
 export function validateJavaFunctionName(name: string): string | undefined {
-    return validateJavaName(name);
+    if (isKeyword(name)) {
+        return localize('azFunc.JavaNameIsKeywordError', '\'{0}\' is a reserved keyword.', name);
+    }
+    if (!javaFunctionRegex.test(name)) {
+        return localize('azFunc.functionNameInvalidError', 'Java Function name must start with a letter and can contain letters, digits and \'_\'');
+    }
+    return undefined;
 }
 
 export function validateMavenIdentifier(input: string): string | undefined {

--- a/test/createFunction.test.ts
+++ b/test/createFunction.test.ts
@@ -156,10 +156,11 @@ suite('Create Function Tests', () => {
     });
 });
 
-async function testCreateFunction(funcName: string, ...inputs: (string | undefined)[]): Promise<void> {
+async function testCreateFunction(templateName: string, ...inputs: (string | undefined)[]): Promise<void> {
     // Setup common inputs
+    const funcName: string = templateName.replace(/ /g, '');
     inputs.unshift(funcName); // Specify the function name
-    inputs.unshift(funcName); // Select the function template
+    inputs.unshift(templateName); // Select the function template
     inputs.unshift(testFolder); // Select the test func app folder
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
         inputs.unshift(undefined); // If the test environment has an open workspace, select the 'Browse...' option


### PR DESCRIPTION
In this PR, I did the following changes here:

**In ```src/commands/createFunction.ts```:**
change the function name validation according to the portal hit:
![_20171201132014](https://user-images.githubusercontent.com/6193897/33469960-b93853be-d6a0-11e7-9bd1-294e489668f1.png)

**In ```src/commands/createNewProject.ts```:** 
add ```"``` around %path% in case that the path contains spaces #102 
Show the outpput channel when creating java function project

**In ```test/createFunction.test.ts```:**
Update the unit test code according to the code change

**In ```src/utils/javaNameUtils.ts```:**
Since the function name will also used for the Java class name, so the name should not be a reserved keyword, and both obey java name identifier rule and function name rule (no '-' and '$').