### PR TITLE
Add back prereq for .net core 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Prerequisites
 * For local debugging:
+  * [.NET Core 2.0](https://www.microsoft.com/net/download/core)
   * [Azure Core Function Tools 2.0](https://www.npmjs.com/package/azure-functions-core-tools)
   ```
   npm install --global azure-functions-core-tools@core


### PR DESCRIPTION
I accidentally deleted this prereq when I refactored to add Java info: https://github.com/Microsoft/vscode-azurefunctions/pull/101