### PR TITLE
remove duplicated code about checking the existance of maven

### DIFF
--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -166,9 +166,7 @@ export async function createFunction(
 
     let newFilePath: string;
     if (languageType === TemplateLanguage.Java) {
-        if (!(await mavenUtils.isMavenInstalled(functionAppPath))) {
-            throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
-        }
+        await mavenUtils.validateMavenInstalled(functionAppPath);
         outputChannel.show();
         await cpUtils.executeCommand(
             outputChannel,

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -180,9 +180,7 @@ async function promotForMavenParameters(ui: IUserInterface, functionAppPath: str
 }
 
 async function createJavaFunctionProject(outputChannel: OutputChannel, functionAppPath: string, ui: IUserInterface): Promise<string> {
-    if (!(await mavenUtils.isMavenInstalled(functionAppPath))) {
-        throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
-    }
+    await mavenUtils.validateMavenInstalled(functionAppPath);
     // Get parameters for Maven command
     const { groupId, artifactId, version, packageName, appName } = await promotForMavenParameters(ui, functionAppPath);
     const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -47,9 +47,7 @@ export async function deploy(tree: AzureTreeDataProvider, outputChannel: vscode.
 }
 
 async function getJavaFolderPath(outputChannel: vscode.OutputChannel, basePath: string, ui: IUserInterface): Promise<string> {
-    if (!(await mavenUtils.isMavenInstalled(basePath))) {
-        throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
-    }
+    await mavenUtils.validateMavenInstalled(basePath);
     outputChannel.show();
     await cpUtils.executeCommand(outputChannel, basePath, 'mvn', 'clean', 'package', '-B');
     const pomLocation: string = path.join(basePath, 'pom.xml');

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from '../localize';
 import { cpUtils } from './cpUtils';
 
 export namespace mavenUtils {
     const mvnCommand: string = 'mvn';
-    export async function isMavenInstalled(workingDirectory: string): Promise<boolean> {
+    export async function validateMavenInstalled(workingDirectory: string): Promise<void> {
         try {
             await cpUtils.executeCommand(undefined, workingDirectory, mvnCommand, '--version');
-            return true;
         } catch {
-            return false;
+            throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
         }
     }
 }


### PR DESCRIPTION
Work item: #107 - Remove the duplicated code about checking the existance of maven.

About #104. As commented, I'll change the related part of code when maven plugin change the logic to name the java function.