### PR TITLE
Fix templates not being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "azurefunctions" extension will be documented in this file.
 
+## 0.3.1 - 2017-12-06
+### Fixed
+- JavaScript 'Verified' templates not displayed
+- Java templates not displayed
+
 ## 0.3.0 - 2017-12-01
 ### Added
 - Java support

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%extension.description%",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -15,7 +15,7 @@ import { localize } from '../localize';
 import { ConfigSetting, ValueType } from '../templates/ConfigSetting';
 import { EnumValue } from '../templates/EnumValue';
 import { Template, TemplateLanguage } from '../templates/Template';
-import { TemplateData } from '../templates/TemplateData';
+import { convertTemplateIdToJava, TemplateData } from '../templates/TemplateData';
 import { cpUtils } from '../utils/cpUtils';
 import * as fsUtil from '../utils/fs';
 import { getJavaClassName, validateJavaFunctionName, validatePackageName } from '../utils/javaNameUtils';
@@ -66,7 +66,7 @@ async function validateIsFunctionApp(telemetryProperties: { [key: string]: strin
 async function promptForFunctionName(ui: IUserInterface, functionAppPath: string, template: Template, language: string, packageName: string): Promise<string> {
     let defaultFunctionName: string | undefined;
     if (language === TemplateLanguage.Java) {
-        defaultFunctionName = await fsUtil.getUniqueJavaFsPath(functionAppPath, packageName, `${template.name}Java`);
+        defaultFunctionName = await fsUtil.getUniqueJavaFsPath(functionAppPath, packageName, `${convertTemplateIdToJava(template.id)}Java`);
     } else {
         defaultFunctionName = await fsUtil.getUniqueFsPath(functionAppPath, template.defaultFunctionName);
     }
@@ -178,7 +178,7 @@ export async function createFunction(
             '-B',
             `"-Dfunctions.package=${packageName}"`,
             `"-Dfunctions.name=${name}"`,
-            `"-Dfunctions.template=${template.name}"`,
+            `"-Dfunctions.template=${convertTemplateIdToJava(template.id)}"`,
             ...javaFuntionProperties
         );
         newFilePath = getNewJavaFunctionFilePath(functionAppPath, packageName, name);

--- a/src/templates/Template.ts
+++ b/src/templates/Template.ts
@@ -46,6 +46,10 @@ export class Template {
         this._resources = resources;
     }
 
+    public get id(): string {
+        return this._template.id;
+    }
+
     public get name(): string {
         return this._resources.getValue(this._template.metadata.name);
     }

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -27,14 +27,14 @@ export class TemplateData {
     private _config: Config | undefined;
 
     private readonly _verifiedTemplates: string[] = [
-        'BlobTrigger',
-        'Generic Webhook',
-        'Github Webhook',
-        'HttpTrigger',
-        'HttpTriggerWithParameters',
-        'ManualTrigger',
-        'QueueTrigger',
-        'TimerTrigger'
+        'BlobTrigger-JavaScript',
+        'GenericWebHook-JavaScript',
+        'GitHubWebHook-JavaScript',
+        'HttpTrigger-JavaScript',
+        'HttpTriggerWithParameters-JavaScript',
+        'ManualTrigger-JavaScript',
+        'QueueTrigger-JavaScript',
+        'TimerTrigger-JavaScript'
     ];
 
     private readonly _javaTemplates: string[] = [
@@ -73,7 +73,7 @@ export class TemplateData {
             // Will refactor the code here when templates HTTP API is ready.
             // See issue here: https://github.com/Microsoft/vscode-azurefunctions/issues/84
             const javaTemplates: Template[] = this._templates.filter((t: Template) => t.language === TemplateLanguage.JavaScript);
-            return javaTemplates.filter((t: Template) => this._javaTemplates.find((vt: string) => vt === t.name));
+            return javaTemplates.filter((t: Template) => this._javaTemplates.find((vt: string) => vt === convertTemplateIdToJava(t.id)));
         } else {
             const jsTemplates: Template[] = this._templates.filter((t: Template) => t.language === TemplateLanguage.JavaScript);
             // tslint:disable-next-line:no-backbone-get-set-outside-model
@@ -84,7 +84,7 @@ export class TemplateData {
                     return jsTemplates.filter((t: Template) => t.isCategory(TemplateCategory.Core));
                 case 'Verified':
                 default:
-                    return jsTemplates.filter((t: Template) => this._verifiedTemplates.find((vt: string) => vt === t.name));
+                    return jsTemplates.filter((t: Template) => this._verifiedTemplates.find((vt: string) => vt === t.id));
             }
         }
 
@@ -137,4 +137,8 @@ export class TemplateData {
 
         return <T>(JSON.parse(await <Thenable<string>>request(options).promise()));
     }
+}
+
+export function convertTemplateIdToJava(id: string): string {
+    return id.replace('-JavaScript', '');
 }

--- a/test/createFunction.test.ts
+++ b/test/createFunction.test.ts
@@ -42,8 +42,8 @@ suiteTeardown(async () => {
 });
 
 // tslint:disable-next-line:max-func-body-length
-suite('Create Function Tests', () => {
-    const blobTrigger: string = 'BlobTrigger';
+suite('Create Core Function Tests', () => {
+    const blobTrigger: string = 'Blob trigger';
     test(blobTrigger, async () => {
         await testCreateFunction(
             blobTrigger,
@@ -54,7 +54,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const cosmosDBTrigger: string = 'CosmosDBTrigger';
+    const cosmosDBTrigger: string = 'Cosmos DB trigger';
     test(cosmosDBTrigger, async () => {
         await testCreateFunction(
             cosmosDBTrigger,
@@ -68,7 +68,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const eventHubTrigger: string = 'EventHubTrigger';
+    const eventHubTrigger: string = 'Event Hub trigger';
     test(eventHubTrigger, async () => {
         await testCreateFunction(
             eventHubTrigger,
@@ -80,17 +80,17 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const genericWebhook: string = 'Generic Webhook';
+    const genericWebhook: string = 'Generic webhook';
     test(genericWebhook, async () => {
         await testCreateFunction(genericWebhook);
     });
 
-    const gitHubWebhook: string = 'GitHub Webhook';
+    const gitHubWebhook: string = 'GitHub webhook';
     test(gitHubWebhook, async () => {
         await testCreateFunction(gitHubWebhook);
     });
 
-    const httpTrigger: string = 'HttpTrigger';
+    const httpTrigger: string = 'HTTP trigger';
     test(httpTrigger, async () => {
         await testCreateFunction(
             httpTrigger,
@@ -98,7 +98,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const httpTriggerWithParameters: string = 'HttpTriggerWithParameters';
+    const httpTriggerWithParameters: string = 'HTTP trigger with parameters';
     test(httpTriggerWithParameters, async () => {
         await testCreateFunction(
             httpTriggerWithParameters,
@@ -106,12 +106,12 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const manualTrigger: string = 'ManualTrigger';
+    const manualTrigger: string = 'Manual trigger';
     test(manualTrigger, async () => {
         await testCreateFunction(manualTrigger);
     });
 
-    const queueTrigger: string = 'QueueTrigger';
+    const queueTrigger: string = 'Queue trigger';
     test(queueTrigger, async () => {
         await testCreateFunction(
             queueTrigger,
@@ -122,7 +122,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const serviceBusQueueTrigger: string = 'ServiceBusQueueTrigger';
+    const serviceBusQueueTrigger: string = 'Service Bus Queue trigger';
     test(serviceBusQueueTrigger, async () => {
         await testCreateFunction(
             serviceBusQueueTrigger,
@@ -134,7 +134,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const serviceBusTopicTrigger: string = 'ServiceBusTopicTrigger';
+    const serviceBusTopicTrigger: string = 'Service Bus Topic trigger';
     test(serviceBusTopicTrigger, async () => {
         await testCreateFunction(
             serviceBusTopicTrigger,
@@ -147,7 +147,7 @@ suite('Create Function Tests', () => {
         );
     });
 
-    const timerTrigger: string = 'TimerTrigger';
+    const timerTrigger: string = 'Timer trigger';
     test(timerTrigger, async () => {
         await testCreateFunction(
             timerTrigger,

--- a/test/templateData.test.ts
+++ b/test/templateData.test.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { Template, TemplateLanguage } from '../src/templates/Template';
+import { TemplateData } from '../src/templates/TemplateData';
+
+const templateFilterSetting: string = 'azureFunctions.templateFilter';
+const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration();
+// tslint:disable-next-line:no-backbone-get-set-outside-model
+const oldTemplateFilter: string | undefined = config.get(templateFilterSetting);
+
+suiteTeardown(async () => {
+    await config.update(templateFilterSetting, oldTemplateFilter, vscode.ConfigurationTarget.Global);
+});
+
+suite('Template Data Tests', () => {
+    const templateData: TemplateData = new TemplateData();
+
+    test('JavaScript Verified Templates Count', async () => {
+        await config.update(templateFilterSetting, 'Verified', vscode.ConfigurationTarget.Global);
+        const templates: Template[] = await templateData.getTemplates(TemplateLanguage.JavaScript);
+        assert.equal(templates.length, 8);
+    });
+
+    test('Java Templates Count', async () => {
+        const templates: Template[] = await templateData.getTemplates(TemplateLanguage.Java);
+        assert.equal(templates.length, 4);
+    });
+});


### PR DESCRIPTION
Use template.id (which shouldn't change) to detect for equality rather than template.metadata.name (which can and has changed)

Fixes #117 