### PR TITLE
Allow programatic use of deploy, createFunction, and createNewProject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - npm run vscode:prepublish
   - npm run lint
-  - npm run test
+  - gulp test
 
 notifications:
   email:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,57 @@
+# Azure Functions API
+
+The following extension commands are supported for programatic use. If a parameter is not specified, the user will be prompted for the value. You must list 'ms-azuretools.vscode-azurefunctions' under the 'extensionDependencies' section of your package.json to ensure these apis are available to your extension.
+> NOTE: The functions extension is still in preview and the apis are subject to change.
+
+Commands:
+* [Create New Project](#create-new-project)
+* [Create Function](#create-function)
+* [Deploy](#deploy)
+
+## Create New Project
+
+### Parameters
+
+|Name|Type|Description|
+|---|---|---|
+|projectPath|string|Absolute file path that will contain your new project. If the path doesn't exist, it will be created.|
+|language|string|The currently supported languages are 'JavaScript' and 'Java'.|
+|openFolder|boolean|(Defaulted to true) Represents whether or not to open the project folder after it has been created. If true, the extension host may be restarted when the folder is opened.|
+
+### Example Usage
+
+```typescript
+await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', false /* openFolder */);
+```
+
+## Create Function
+
+### Parameters
+
+|Name|Type|Description|
+|---|---|---|
+|projectPath|string|Absolute file path that contains your project.|
+|templateId|string|The id of the template you want to create.|
+|functionName|string|The name of the function to be created.|
+|functionSettings|...string[]|Any settings unique to a template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
+
+### Example Usage
+
+```typescript
+await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, 'HttpTrigger-JavaScript', 'HttpTrigger1', 'Anonymous');
+```
+
+## Deploy
+
+### Parameters
+
+|Name|Type|Description|
+|---|---|---|
+|projectPath|string|Absolute file path that contains your project.|
+|functionAppId|string|The id of the function app you are deploying to.|
+
+### Example Usage
+
+```typescript
+await vscode.commands.executeCommand('azureFunctions.deploy', projectPath, '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleGroup/providers/Microsoft.Web/sites/exampleSite');
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const gulp = require('gulp');
+const decompress = require('gulp-decompress');
+const download = require('gulp-download');
+const path = require('path');
+const os = require('os');
+const fse = require('fs-extra');
+
+gulp.task('install-azure-account', async () => {
+    const version = '0.2.2';
+    const extensionPath = path.join(os.homedir(), `.vscode/extensions/ms-vscode.azure-account-${version}`);
+    if (!await fse.pathExists(extensionPath)) {
+        return download(`http://ms-vscode.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vscode/extension/azure-account/${version}/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage`)
+            .pipe(decompress({
+                filter: file => file.path.startsWith('extension/'),
+                map: file => {
+                    file.path = file.path.slice(10);
+                    return file;
+                }
+            }))
+            .pipe(gulp.dest(extensionPath));
+    } else {
+        console.log('Azure Account extension already installed.');
+    }
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,14 @@ const download = require('gulp-download');
 const path = require('path');
 const os = require('os');
 const fse = require('fs-extra');
+const cp = require('child_process');
+
+gulp.task('test', ['install-azure-account'], (cb) => {
+    const cmd = cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit' });
+    cmd.on('close', (code) => {
+        cb(code);
+    });
+});
 
 gulp.task('install-azure-account', async () => {
     const version = '0.2.2';

--- a/package.json
+++ b/package.json
@@ -370,8 +370,7 @@
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "gulp install-azure-account;node ./node_modules/vscode/bin/test"
+        "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
         "@types/clipboardy": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
         "compile": "tsc -watch -p ./",
         "lint": "tslint --project tsconfig.json -e src/*.d.ts -t verbose",
         "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
+        "test": "gulp install-azure-account;node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
         "@types/clipboardy": "^1.1.0",
@@ -381,6 +381,9 @@
         "@types/request": "2.0.7",
         "@types/request-promise": "4.1.38",
         "@types/xml2js": "^0.4.2",
+        "gulp": "^3.9.1",
+        "gulp-decompress": "^2.0.1",
+        "gulp-download": "^0.0.1",
         "mocha": "^2.3.3",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",

--- a/src/commands/createFunction/FunctionCreatorBase.ts
+++ b/src/commands/createFunction/FunctionCreatorBase.ts
@@ -6,7 +6,7 @@
 import { IUserInterface } from "../../IUserInterface";
 import { Template } from "../../templates/Template";
 
-export abstract class AbstractFunctionCreator {
+export abstract class FunctionCreatorBase {
     protected readonly _functionNameRegex: RegExp = /^[a-zA-Z][a-zA-Z\d_\-]*$/;
     protected _functionAppPath: string;
     protected _template: Template;
@@ -20,6 +20,6 @@ export abstract class AbstractFunctionCreator {
      * Prompt for any settings that are specific to this creator
      * This includes the function name (Since the name could have different restrictions for different languages)
      */
-    public abstract async promptForSettings(ui: IUserInterface): Promise<void>;
+    public abstract async promptForSettings(ui: IUserInterface, functionName: string | undefined): Promise<void>;
     public abstract async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined>;
 }

--- a/src/commands/createFunction/JavaFunctionCreator.ts
+++ b/src/commands/createFunction/JavaFunctionCreator.ts
@@ -14,13 +14,13 @@ import { cpUtils } from "../../utils/cpUtils";
 import * as fsUtil from '../../utils/fs';
 import { getFullClassName, parseJavaClassName, validatePackageName } from "../../utils/javaNameUtils";
 import { mavenUtils } from "../../utils/mavenUtils";
-import { AbstractFunctionCreator } from './AbstractFunctionCreator';
+import { FunctionCreatorBase } from './FunctionCreatorBase';
 
 function getNewJavaFunctionFilePath(functionAppPath: string, packageName: string, functionName: string): string {
     return path.join(functionAppPath, 'src', 'main', 'java', ...packageName.split('.'), `${parseJavaClassName(functionName)}.java`);
 }
 
-export class JavaFunctionCreator extends AbstractFunctionCreator {
+export class JavaFunctionCreator extends FunctionCreatorBase {
     private _outputChannel: OutputChannel;
     private _packageName: string;
     private _functionName: string;
@@ -30,15 +30,19 @@ export class JavaFunctionCreator extends AbstractFunctionCreator {
         this._outputChannel = outputChannel;
     }
 
-    public async promptForSettings(ui: IUserInterface): Promise<void> {
+    public async promptForSettings(ui: IUserInterface, functionName: string | undefined): Promise<void> {
         const packagePlaceHolder: string = localize('azFunc.java.packagePlaceHolder', 'Package');
         const packagePrompt: string = localize('azFunc.java.packagePrompt', 'Provide a package name');
         this._packageName = await ui.showInputBox(packagePlaceHolder, packagePrompt, false, validatePackageName, 'com.function');
 
-        const defaultFunctionName: string | undefined = await fsUtil.getUniqueJavaFsPath(this._functionAppPath, this._packageName, `${convertTemplateIdToJava(this._template.id)}Java`);
-        const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
-        const prompt: string = localize('azFunc.funcNamePrompt', 'Provide a function name');
-        this._functionName = await ui.showInputBox(placeHolder, prompt, false, (s: string) => this.validateTemplateName(s), defaultFunctionName || this._template.defaultFunctionName);
+        if (!functionName) {
+            const defaultFunctionName: string | undefined = await fsUtil.getUniqueJavaFsPath(this._functionAppPath, this._packageName, `${convertTemplateIdToJava(this._template.id)}Java`);
+            const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
+            const prompt: string = localize('azFunc.funcNamePrompt', 'Provide a function name');
+            this._functionName = await ui.showInputBox(placeHolder, prompt, false, (s: string) => this.validateTemplateName(s), defaultFunctionName || this._template.defaultFunctionName);
+        } else {
+            this._functionName = functionName;
+        }
     }
 
     public async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined> {

--- a/src/commands/createFunction/ScriptFunctionCreator.ts
+++ b/src/commands/createFunction/ScriptFunctionCreator.ts
@@ -10,7 +10,7 @@ import { localize } from "../../localize";
 import { ProjectLanguage } from '../../ProjectSettings';
 import { Template } from "../../templates/Template";
 import * as fsUtil from '../../utils/fs';
-import { AbstractFunctionCreator } from './AbstractFunctionCreator';
+import { FunctionCreatorBase } from './FunctionCreatorBase';
 
 function getFileNameFromLanguage(language: string): string | undefined {
     switch (language) {
@@ -38,7 +38,7 @@ function getFileNameFromLanguage(language: string): string | undefined {
 /**
  * Function creator for multiple languages that don't require compilation (JavaScript, C# Script, Bash, etc.)
  */
-export class ScriptFunctionCreator extends AbstractFunctionCreator {
+export class ScriptFunctionCreator extends FunctionCreatorBase {
     private _language: string;
     private _functionName: string;
 
@@ -47,11 +47,15 @@ export class ScriptFunctionCreator extends AbstractFunctionCreator {
         this._language = language;
     }
 
-    public async promptForSettings(ui: IUserInterface): Promise<void> {
-        const defaultFunctionName: string | undefined = await fsUtil.getUniqueFsPath(this._functionAppPath, this._template.defaultFunctionName);
-        const prompt: string = localize('azFunc.funcNamePrompt', 'Provide a function name');
-        const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
-        this._functionName = await ui.showInputBox(placeHolder, prompt, false, (s: string) => this.validateTemplateName(s), defaultFunctionName || this._template.defaultFunctionName);
+    public async promptForSettings(ui: IUserInterface, functionName: string | undefined): Promise<void> {
+        if (!functionName) {
+            const defaultFunctionName: string | undefined = await fsUtil.getUniqueFsPath(this._functionAppPath, this._template.defaultFunctionName);
+            const prompt: string = localize('azFunc.funcNamePrompt', 'Provide a function name');
+            const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
+            this._functionName = await ui.showInputBox(placeHolder, prompt, false, (s: string) => this.validateTemplateName(s), defaultFunctionName || this._template.defaultFunctionName);
+        } else {
+            this._functionName = functionName;
+        }
     }
 
     public async createFunction(userSettings: { [propertyName: string]: string; }): Promise<string | undefined> {

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -39,17 +39,21 @@ const funcProblemMatcher: {} = {
     }
 };
 
-export async function createNewProject(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, openFolder: boolean = true, ui: IUserInterface = new VSCodeUI()): Promise<void> {
+export async function createNewProject(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, language?: string, openFolder: boolean = true, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     if (functionAppPath === undefined) {
         functionAppPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
     }
+    await fse.ensureDir(functionAppPath);
 
     // Only display 'supported' languages that can be debugged in VS Code
     const languagePicks: Pick[] = [
         new Pick(ProjectLanguage.JavaScript),
         new Pick(ProjectLanguage.Java)
     ];
-    const language: string = (await ui.showQuickPick(languagePicks, localize('azFunc.selectFuncTemplate', 'Select a language for your function project'))).label;
+
+    if (!language) {
+        language = (await ui.showQuickPick(languagePicks, localize('azFunc.selectFuncTemplate', 'Select a language for your function project'))).label;
+    }
     telemetryProperties.projectLanguage = language;
 
     let projectCreator: IProjectCreator;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { TemplateData } from './templates/TemplateData';
 import { FunctionAppProvider } from './tree/FunctionAppProvider';
 import { FunctionAppTreeItem } from './tree/FunctionAppTreeItem';
 import { FunctionTreeItem } from './tree/FunctionTreeItem';
+import { VSCodeUI } from './VSCodeUI';
 
 let reporter: TelemetryReporter | undefined;
 
@@ -58,14 +59,16 @@ export function activate(context: vscode.ExtensionContext): void {
         actionHandler.registerCommand('azureFunctions.refresh', async (node?: IAzureNode) => await tree.refresh(node));
         actionHandler.registerCommand('azureFunctions.loadMore', async (node: IAzureNode) => await tree.loadMore(node));
         actionHandler.registerCommand('azureFunctions.openInPortal', async (node?: IAzureNode<FunctionAppTreeItem>) => await openInPortal(tree, node));
-        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createFunction', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements) => await createFunction(properties, outputChannel, azureAccount, templateData));
-        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createNewProject', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements) => await createNewProject(properties, outputChannel));
+        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createFunction', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, templateId?: string, functionName?: string, ...functionSettings: string[]) => {
+            await createFunction(properties, outputChannel, azureAccount, templateData, new VSCodeUI(), functionAppPath, templateId, functionName, ...functionSettings);
+        });
+        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createNewProject', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, language?: string, openFolder?: boolean | undefined) => await createNewProject(properties, outputChannel, functionAppPath, language, openFolder));
         actionHandler.registerCommand('azureFunctions.createFunctionApp', async (node?: IAzureParentNode) => await createChildNode(tree, AzureTreeDataProvider.subscriptionContextValue, node));
         actionHandler.registerCommand('azureFunctions.startFunctionApp', async (node?: IAzureNode<FunctionAppTreeItem>) => await startFunctionApp(tree, node));
         actionHandler.registerCommand('azureFunctions.stopFunctionApp', async (node?: IAzureNode<FunctionAppTreeItem>) => await stopFunctionApp(tree, node));
         actionHandler.registerCommand('azureFunctions.restartFunctionApp', async (node?: IAzureNode<FunctionAppTreeItem>) => await restartFunctionApp(tree, node));
         actionHandler.registerCommand('azureFunctions.deleteFunctionApp', async (node?: IAzureParentNode) => await deleteNode(tree, FunctionAppTreeItem.contextValue, node));
-        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.deploy', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, arg?: IAzureParentNode<FunctionAppTreeItem> | vscode.Uri) => await deploy(properties, tree, outputChannel, arg));
+        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.deploy', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, deployPath: vscode.Uri | string, functionAppId?: string) => await deploy(properties, tree, outputChannel, deployPath, functionAppId));
         actionHandler.registerCommandWithCustomTelemetry('azureFunctions.configureDeploymentSource', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, node?: IAzureNode<FunctionAppTreeItem>) => await configureDeploymentSource(properties, tree, outputChannel, node));
         actionHandler.registerCommand('azureFunctions.copyFunctionUrl', async (node?: IAzureNode<FunctionTreeItem>) => await copyFunctionUrl(tree, node));
         actionHandler.registerCommand('azureFunctions.deleteFunction', async (node?: IAzureNode) => await deleteNode(tree, FunctionTreeItem.contextValue, node));

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -173,7 +173,7 @@ export class TemplateData {
         for (const rawTemplate of rawTemplates) {
             try {
                 this._templatesMap[runtime].push(new Template(rawTemplate, resources));
-            } catch {
+            } catch (error) {
                 // Ignore errors so that a single poorly formed template does not affect other templates
             }
         }

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -16,14 +16,22 @@ import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
 import { getResourceTypeLabel, ResourceType } from '../templates/ConfigSetting';
 
-function getResourceGroupFromId(id: string): string {
+function parseResourceId(id: string): RegExpMatchArray {
     const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/(.*)\/(.*)/);
 
     if (matches === null || matches.length < 3) {
         throw new Error(localize('azFunc.InvalidResourceId', 'Invalid Azure Resource Id'));
     }
 
-    return matches[2];
+    return matches;
+}
+
+function getResourceGroupFromId(id: string): string {
+    return parseResourceId(id) [2];
+}
+
+export function getSubscriptionFromId(id: string): string {
+    return parseResourceId(id) [1];
 }
 
 interface IBaseResourceWithName extends BaseResource {

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -12,7 +12,7 @@ export namespace gitUtils {
         try {
             await cpUtils.executeCommand(undefined, workingDirectory, gitCommand, '--version');
             return true;
-        } catch {
+        } catch (error) {
             return false;
         }
     }

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -11,7 +11,7 @@ export namespace mavenUtils {
     export async function validateMavenInstalled(workingDirectory: string): Promise<void> {
         try {
             await cpUtils.executeCommand(undefined, workingDirectory, mvnCommand, '--version');
-        } catch {
+        } catch (error) {
             throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
         }
     }

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -13,15 +13,9 @@ import { ProjectLanguage } from '../src/ProjectSettings';
 import * as fsUtil from '../src/utils/fs';
 import { TestUI } from './TestUI';
 
-const testFolderPath: string = path.join(os.tmpdir(), `azFunc.createNewProjectTests${fsUtil.getRandomHexString()}`);
-const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions Test');
-
-suite('Create New Java Project Tests', () => {
-
-    suiteSetup(async () => {
-        await fse.ensureDir(testFolderPath);
-    });
-
+suite('Create New Project Tests', () => {
+    const testFolderPath: string = path.join(os.tmpdir(), `azFunc.createNewProjectTests${fsUtil.getRandomHexString()}`);
+    const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions Test');
     suiteTeardown(async () => {
         outputChannel.dispose();
         await fse.remove(testFolderPath);
@@ -29,7 +23,9 @@ suite('Create New Java Project Tests', () => {
 
     const javaProject: string = 'JavaProject';
     test(javaProject, async () => {
+        const projectPath: string = path.join(testFolderPath, javaProject);
         await testCreateNewProject(
+            projectPath,
             ProjectLanguage.Java,
             undefined,
             undefined,
@@ -37,54 +33,49 @@ suite('Create New Java Project Tests', () => {
             undefined,
             undefined
         );
-        await testJavaProjectFilesExist(testFolderPath);
+        await testJavaProjectFilesExist(projectPath);
     }).timeout(60 * 1000);
-});
-
-suite('Create New JavaScript Project Tests', () => {
-
-    suiteSetup(async () => {
-        await fse.ensureDir(testFolderPath);
-    });
-
-    suiteTeardown(async () => {
-        outputChannel.dispose();
-        await fse.remove(testFolderPath);
-    });
 
     const javaScriptProject: string = 'JavaScriptProject';
     test(javaScriptProject, async () => {
-        await testCreateNewProject(ProjectLanguage.JavaScript);
-        await testProjectFilesExist(testFolderPath);
-    }).timeout(10 * 1000);
-});
+        const projectPath: string = path.join(testFolderPath, javaScriptProject);
+        await testCreateNewProject(projectPath, ProjectLanguage.JavaScript);
+        await testProjectFilesExist(projectPath);
+    });
 
-async function testCreateNewProject(language: string, ...inputs: (string | undefined)[]): Promise<void> {
-    // Setup common inputs
-    inputs.unshift(language); // Specify the function name
-    inputs.unshift(testFolderPath); // Select the test func app folder
-    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-        inputs.unshift('$(file-directory) Browse...'); // If the test environment has an open workspace, select the 'Browse...' option
+    test('createNewProject API', async () => {
+        const projectPath: string = path.join(testFolderPath, 'createNewProjectApi');
+        await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', false /* openFolder */);
+        await testProjectFilesExist(projectPath);
+    });
+
+    async function testCreateNewProject(projectPath: string, language: string, ...inputs: (string | undefined)[]): Promise<void> {
+        // Setup common inputs
+        inputs.unshift(language); // Specify the function name
+        inputs.unshift(projectPath); // Select the test func app folder
+        if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+            inputs.unshift('$(file-directory) Browse...'); // If the test environment has an open workspace, select the 'Browse...' option
+        }
+
+        const ui: TestUI = new TestUI(inputs);
+        await createNewProject({}, outputChannel, undefined, undefined, false, ui);
+        assert.equal(inputs.length, 0, 'Not all inputs were used.');
     }
 
-    const ui: TestUI = new TestUI(inputs);
-    await createNewProject({}, outputChannel, undefined, false, ui);
-    assert.equal(inputs.length, 0, 'Not all inputs were used.');
-}
+    async function testProjectFilesExist(projectPath: string): Promise<void> {
+        assert.equal(await fse.pathExists(path.join(projectPath, '.gitignore')), true, '.gitignore does not exist');
+        assert.equal(await fse.pathExists(path.join(projectPath, 'host.json')), true, 'host.json does not exist');
+        assert.equal(await fse.pathExists(path.join(projectPath, 'local.settings.json')), true, 'function.json does not exist');
+        assert.equal(await fse.pathExists(path.join(projectPath, '.git')), true, '.git folder does not exist');
+        const vscodePath: string = path.join(projectPath, '.vscode');
+        assert.equal(await fse.pathExists(path.join(vscodePath, 'settings.json')), true, 'settings.json does not exist');
+        assert.equal(await fse.pathExists(path.join(vscodePath, 'launch.json')), true, 'launch.json does not exist');
+        assert.equal(await fse.pathExists(path.join(vscodePath, 'tasks.json')), true, 'tasks.json does not exist');
+    }
 
-async function testProjectFilesExist(projectPath: string): Promise<void> {
-    assert.equal(await fse.pathExists(path.join(projectPath, '.gitignore')), true, '.gitignore does not exist');
-    assert.equal(await fse.pathExists(path.join(projectPath, 'host.json')), true, 'host.json does not exist');
-    assert.equal(await fse.pathExists(path.join(projectPath, 'local.settings.json')), true, 'function.json does not exist');
-    assert.equal(await fse.pathExists(path.join(projectPath, '.git')), true, '.git folder does not exist');
-    const vscodePath: string = path.join(projectPath, '.vscode');
-    assert.equal(await fse.pathExists(path.join(vscodePath, 'settings.json')), true, 'settings.json does not exist');
-    assert.equal(await fse.pathExists(path.join(vscodePath, 'launch.json')), true, 'launch.json does not exist');
-    assert.equal(await fse.pathExists(path.join(vscodePath, 'tasks.json')), true, 'tasks.json does not exist');
-}
-
-async function testJavaProjectFilesExist(projectPath: string): Promise<void> {
-    await testProjectFilesExist(projectPath);
-    assert.equal(await fse.pathExists(path.join(projectPath, 'src')), true, 'src folder does not exist');
-    assert.equal(await fse.pathExists(path.join(projectPath, 'pom.xml')), true, 'pom.xml does not exist');
-}
+    async function testJavaProjectFilesExist(projectPath: string): Promise<void> {
+        await testProjectFilesExist(projectPath);
+        assert.equal(await fse.pathExists(path.join(projectPath, 'src')), true, 'src folder does not exist');
+        assert.equal(await fse.pathExists(path.join(projectPath, 'pom.xml')), true, 'pom.xml does not exist');
+    }
+});


### PR DESCRIPTION
We have a partner team that is interested in using these methods.