### PR TITLE
Automatically start the functions host when F5ing C# projects

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -8,7 +8,7 @@ import { localize } from "../../localize";
 import { ProjectRuntime } from '../../ProjectSettings';
 import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
-import { funcHostProblemMatcher, funcHostTaskId, IProjectCreator } from './IProjectCreator';
+import { funcHostTaskId, IProjectCreator } from './IProjectCreator';
 
 export class CSharpProjectCreator implements IProjectCreator {
     private _outputChannel: OutputChannel;
@@ -61,10 +61,7 @@ export class CSharpProjectCreator implements IProjectCreator {
                     isBackground: true,
                     presentation: {
                         reveal: 'always'
-                    },
-                    problemMatcher: [
-                        funcHostProblemMatcher
-                    ]
+                    }
                 }
             ]
         };

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -23,7 +23,7 @@ class CSharpFunctionTester extends FunctionTesterBase {
 
 // tslint:disable-next-line:no-function-expression
 suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): Promise<void> {
-    this.timeout(10 * 1000);
+    this.timeout(20 * 1000);
 
     const csTester: CSharpFunctionTester = new CSharpFunctionTester();
 

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -17,7 +17,7 @@ import { TestUI } from './TestUI';
 
 // tslint:disable-next-line:no-function-expression
 suite('Create New Project Tests', async function (this: ISuiteCallbackContext): Promise<void> {
-    this.timeout(15 * 1000);
+    this.timeout(30 * 1000);
 
     const testFolderPath: string = path.join(os.tmpdir(), `azFunc.createNewProjectTests${fsUtil.getRandomHexString()}`);
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions Test');


### PR DESCRIPTION
And remove the problemMatcher since it's not used for C# projects

Fixes #167 