### PR TITLE
Fix function.json parsing for C# functions

### DIFF
--- a/src/FunctionConfig.ts
+++ b/src/FunctionConfig.ts
@@ -55,29 +55,31 @@ export class FunctionConfig {
                 this.disabled = data.disabled === true;
 
                 // tslint:disable-next-line:no-unsafe-any
-                if (!data.bindings || !(data.bindings instanceof Array)) {
+                if (!data.bindings || !(data.bindings instanceof Array) || data.bindings.length === 0) {
                     errMessage = localize('expectedBindings', 'Expected "bindings" element of type "Array".');
                 } else {
                     this.functionJson = <IFunctionJson>data;
 
                     const inBinding: IFunctionBinding | undefined = this.functionJson.bindings.find((b: IFunctionBinding) => b.direction === BindingDirection.in);
                     if (inBinding === undefined) {
-                        errMessage = localize('noInBindingError', 'Expected a binding with direction "in".');
+                        // The generated 'function.json' file for C# class libraries doesn't have direction information (by design), so just use the first
+                        this.inBinding = this.functionJson.bindings[0];
                     } else {
                         this.inBinding = inBinding;
-                        if (!inBinding.type) {
-                            errMessage = localize('inBindingTypeError', 'The binding with direction "in" must have a type.');
-                        } else {
-                            this.inBindingType = inBinding.type;
-                            if (inBinding.type.toLowerCase() === 'httptrigger') {
-                                this.isHttpTrigger = true;
-                                if (inBinding.authLevel) {
-                                    const authLevel: HttpAuthLevel | undefined = <HttpAuthLevel>HttpAuthLevel[inBinding.authLevel.toLowerCase()];
-                                    if (authLevel === undefined) {
-                                        errMessage = localize('unrecognizedAuthLevel', 'Unrecognized auth level "{0}".', inBinding.authLevel);
-                                    } else {
-                                        this.authLevel = authLevel;
-                                    }
+                    }
+
+                    if (!this.inBinding.type) {
+                        errMessage = localize('inBindingTypeError', 'The binding with direction "in" must have a type.');
+                    } else {
+                        this.inBindingType = this.inBinding.type;
+                        if (this.inBinding.type.toLowerCase() === 'httptrigger') {
+                            this.isHttpTrigger = true;
+                            if (this.inBinding.authLevel) {
+                                const authLevel: HttpAuthLevel | undefined = <HttpAuthLevel>HttpAuthLevel[this.inBinding.authLevel.toLowerCase()];
+                                if (authLevel === undefined) {
+                                    errMessage = localize('unrecognizedAuthLevel', 'Unrecognized auth level "{0}".', this.inBinding.authLevel);
+                                } else {
+                                    this.authLevel = authLevel;
                                 }
                             }
                         }

--- a/test/functionConfig.test.ts
+++ b/test/functionConfig.test.ts
@@ -21,10 +21,10 @@ suite('Function Config Tests', () => {
             (error: Error) => error.message.includes('bindings')
         );
 
-        // there's no binding with directon 'in'
+        // there's no binding
         assert.throws(
             () => new FunctionConfig({ bindings: [] }),
-            (error: Error) => error.message.includes('direction') && error.message.includes('in')
+            (error: Error) => error.message.includes('bindings')
         );
 
         // in binding does not have type
@@ -118,6 +118,17 @@ suite('Function Config Tests', () => {
             },
             {
                 direction: 'in',
+                type: 'httpTrigger',
+                authLevel: 'function'
+            }]
+        });
+        assert.equal(config.disabled, false);
+        assert.equal(config.isHttpTrigger, true);
+        assert.equal(config.authLevel, HttpAuthLevel.function);
+
+        // validate generated function.json that doesn't have 'in' binding
+        config = new FunctionConfig({
+            bindings: [{
                 type: 'httpTrigger',
                 authLevel: 'function'
             }]


### PR DESCRIPTION
C# class library functions don't require the direction information per [this article](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library#conversion-to-functionjson):
> The purpose of this file is to provide information to the scale controller to use for scaling decisions on the consumption plan. For this reason, the file only has trigger info, not input or output bindings.