### PR TITLE
remove redundent await

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -157,7 +157,7 @@ async function verifyRuntimeIsCompatible(localRuntime: ProjectRuntime, outputCha
 
 async function getFunctionAppNameInPom(pomLocation: string): Promise<string | undefined> {
     const pomString: string = await fse.readFile(pomLocation, 'utf-8');
-    return await new Promise((resolve: (ret: string | undefined) => void): void => {
+    return new Promise((resolve: (ret: string | undefined) => void): void => {
         // tslint:disable-next-line:no-any
         xml2js.parseString(pomString, { explicitArray: false }, (err: any, result: any): void => {
             if (result && !err) {


### PR DESCRIPTION
Remove the redundent `await` since there is already an `await` when calling the method:
https://github.com/Microsoft/vscode-azurefunctions/blob/master/src/commands/deploy.ts#L117