### PR TITLE
Add deploy support for C# class libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -372,6 +372,10 @@
                             "TypeScript"
                         ],
                         "description": "%azFunc.projectLanguageDescription%"
+                    },
+                    "azureFunctions.deploySubPath": {
+                        "type": "string",
+                        "description": "%azFunc.deploySubPathDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,5 +22,6 @@
     "azFunc.appSettings.edit": "Edit setting...",
     "azFunc.appSettings.rename": "Rename setting...",
     "azFunc.appSettings.delete": "Delete setting",
-    "azFunc.pickProcess": "Pick Process"
+    "azFunc.pickProcess": "Pick Process",
+    "azFunc.deploySubPathDescription": "The default subPath of a workspace folder to user when deploying."
 }

--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -16,6 +16,7 @@ export const extensionPrefix: string = 'azureFunctions';
 export const projectLanguageSetting: string = 'projectLanguage';
 export const projectRuntimeSetting: string = 'projectRuntime';
 export const templateFilterSetting: string = 'templateFilter';
+export const deploySubPathSetting: string = 'deploySubPath';
 
 const previewDescription: string = localize('previewDescription', '(Preview)');
 

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -11,6 +11,8 @@ import { dotnetUtils } from '../../utils/dotnetUtils';
 import { funcHostTaskId, IProjectCreator } from './IProjectCreator';
 
 export class CSharpProjectCreator implements IProjectCreator {
+    public readonly deploySubPath: string = 'bin/Debug/netstandard2.0';
+
     private _outputChannel: OutputChannel;
 
     constructor(outputChannel: OutputChannel) {

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -7,6 +7,8 @@ import { localize } from "../../localize";
 import { extensionPrefix, ProjectRuntime } from "../../ProjectSettings";
 
 export interface IProjectCreator {
+    deploySubPath?: string;
+
     /**
      * Add all project files not included in the '.vscode' folder
      */

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -10,7 +10,7 @@ import { OutputChannel } from 'vscode';
 import { TelemetryProperties } from 'vscode-azureextensionui';
 import { IUserInterface, Pick } from '../../IUserInterface';
 import { localize } from '../../localize';
-import { extensionPrefix, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, TemplateFilter, templateFilterSetting } from '../../ProjectSettings';
+import { deploySubPathSetting, extensionPrefix, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, TemplateFilter, templateFilterSetting } from '../../ProjectSettings';
 import * as fsUtil from '../../utils/fs';
 import { confirmOverwriteFile } from '../../utils/fs';
 import { gitUtils } from '../../utils/gitUtils';
@@ -79,6 +79,9 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
         settings[`${extensionPrefix}.${projectRuntimeSetting}`] = projectCreator.getRuntime();
         settings[`${extensionPrefix}.${projectLanguageSetting}`] = language;
         settings[`${extensionPrefix}.${templateFilterSetting}`] = TemplateFilter.Verified;
+        if (projectCreator.deploySubPath) {
+            settings[`${extensionPrefix}.${deploySubPathSetting}`] = projectCreator.deploySubPath;
+        }
         await fsUtil.writeFormattedJson(settingsJsonPath, settings);
     }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import { ArgumentError } from '../errors';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { IUserInterface } from '../IUserInterface';
 import { localize } from '../localize';
-import { convertStringToRuntime, extensionPrefix, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
+import { convertStringToRuntime, deploySubPathSetting, extensionPrefix, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
@@ -32,7 +32,10 @@ import { VSCodeUI } from '../VSCodeUI';
 export async function deploy(telemetryProperties: TelemetryProperties, tree: AzureTreeDataProvider, outputChannel: vscode.OutputChannel, deployPath?: vscode.Uri | string, functionAppId?: string | {}, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     let deployFsPath: string;
     if (!deployPath) {
-        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'));
+        const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(extensionPrefix);
+        // tslint:disable-next-line:no-backbone-get-set-outside-model
+        const defaultSubPath: string | undefined = configuration.get(deploySubPathSetting);
+        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), defaultSubPath);
     } else if (deployPath instanceof vscode.Uri) {
         deployFsPath = deployPath.fsPath;
     } else {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -3,16 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
 import * as fsUtils from './fs';
 
-export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string): Promise<string> {
+export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string, subPath?: string): Promise<string> {
     const browse: string = ':browse';
     let folder: PickWithData<string> | undefined;
     if (vscode.workspace.workspaceFolders) {
-        const folderPicks: PickWithData<string>[] = vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => new PickWithData('', f.uri.fsPath));
+        const folderPicks: PickWithData<string>[] = vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => {
+            const fsPath: string = subPath ? path.join(f.uri.fsPath, subPath) : f.uri.fsPath;
+            return new PickWithData('', fsPath);
+        });
         folderPicks.push(new PickWithData(browse, localize('azFunc.browse', '$(file-directory) Browse...')));
         folder = await ui.showQuickPick<string>(folderPicks, placeholder);
     }


### PR DESCRIPTION
When creating a new project, we set the 'azureFunctions.deploySubPath' setting to 'bin/debug/netstandard2.0'. The user can obviously change this setting if they change the path, or just use the 'Browse...' option.

The deploy subpath shows up in the workspace folder picker. This is the current version for JavaScript:
![screen shot 2018-01-18 at 3 38 37 pm](https://user-images.githubusercontent.com/11282622/35127782-5ac39d50-fc68-11e7-9cde-152d10a01345.png)

This is the new version (works on mac and windows) for c# class libraries:
![screen shot 2018-01-18 at 3 39 05 pm](https://user-images.githubusercontent.com/11282622/35127786-61864156-fc68-11e7-957e-2e223faa3195.png) ![screen shot 2018-01-18 at 3 55 13 pm](https://user-images.githubusercontent.com/11282622/35127788-62bf729a-fc68-11e7-8f5a-a41a6797ad16.png)


Fixes #160 