### PR TITLE
Only use global settings when creating a new project

### DIFF
--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -95,7 +95,7 @@ export function getFuncExtensionSetting<T>(key: string, ignoreWorkspaceSettings:
     const projectConfiguration: WorkspaceConfiguration = vscode.workspace.getConfiguration(extensionPrefix);
     if (ignoreWorkspaceSettings) {
         const result: { globalValue?: T } | undefined = projectConfiguration.inspect<T>(key);
-        return result ? result.globalValue : undefined;
+        return result && result.globalValue;
     } else {
         // tslint:disable-next-line:no-backbone-get-set-outside-model
         return projectConfiguration.get<T>(key);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import { ArgumentError } from '../errors';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { IUserInterface } from '../IUserInterface';
 import { localize } from '../localize';
-import { convertStringToRuntime, deploySubPathSetting, extensionPrefix, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
+import { convertStringToRuntime, deploySubPathSetting, extensionPrefix, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
@@ -32,9 +32,7 @@ import { VSCodeUI } from '../VSCodeUI';
 export async function deploy(telemetryProperties: TelemetryProperties, tree: AzureTreeDataProvider, outputChannel: vscode.OutputChannel, deployPath?: vscode.Uri | string, functionAppId?: string | {}, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     let deployFsPath: string;
     if (!deployPath) {
-        const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(extensionPrefix);
-        // tslint:disable-next-line:no-backbone-get-set-outside-model
-        const defaultSubPath: string | undefined = configuration.get(deploySubPathSetting);
+        const defaultSubPath: string | undefined = getFuncExtensionSetting(deploySubPathSetting);
         deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), defaultSubPath);
     } else if (deployPath instanceof vscode.Uri) {
         deployFsPath = deployPath.fsPath;


### PR DESCRIPTION
Since a project is basically a new workspace, it doesn't make sense to use settings from the "previous" workspace. Instead, only respect global settings.

This is based on top of my currently opened PR here: https://github.com/Microsoft/vscode-azurefunctions/pull/173