### PR TITLE
Improve C# template installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
         "onCommand:azureFunctions.appSettings.rename",
         "onCommand:azureFunctions.appSettings.delete",
         "onCommand:azureFunctions.pickProcess",
+        "onCommand:azureFunctions.installDotnetTemplates",
+        "onCommand:azureFunctions.uninstallDotnetTemplates",
         "onView:azureFunctionsExplorer"
     ],
     "main": "./out/src/extension",
@@ -162,6 +164,16 @@
             {
                 "command": "azureFunctions.pickProcess",
                 "title": "%azFunc.pickProcess%",
+                "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.installDotnetTemplates",
+                "title": "%azFunc.installDotnetTemplates%",
+                "category": "Azure Functions"
+            },
+            {
+                "command": "azureFunctions.uninstallDotnetTemplates",
+                "title": "%azFunc.uninstallDotnetTemplates%",
                 "category": "Azure Functions"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -386,9 +386,9 @@
                         ],
                         "description": "%azFunc.projectLanguageDescription%"
                     },
-                    "azureFunctions.deploySubPath": {
+                    "azureFunctions.deploySubpath": {
                         "type": "string",
-                        "description": "%azFunc.deploySubPathDescription%"
+                        "description": "%azFunc.deploySubpathDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,7 +23,7 @@
     "azFunc.appSettings.rename": "Rename setting...",
     "azFunc.appSettings.delete": "Delete setting",
     "azFunc.pickProcess": "Pick Process",
-    "azFunc.deploySubPathDescription": "The default subPath of a workspace folder to user when deploying.",
+    "azFunc.deploySubpathDescription": "The default subpath of a workspace folder to use when deploying.",
     "azFunc.installDotnetTemplates": "Install templates for the dotnet cli",
     "azFunc.uninstallDotnetTemplates": "Uninstall templates for the dotnet cli"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,5 +23,7 @@
     "azFunc.appSettings.rename": "Rename setting...",
     "azFunc.appSettings.delete": "Delete setting",
     "azFunc.pickProcess": "Pick Process",
-    "azFunc.deploySubPathDescription": "The default subPath of a workspace folder to user when deploying."
+    "azFunc.deploySubPathDescription": "The default subPath of a workspace folder to user when deploying.",
+    "azFunc.installDotnetTemplates": "Install templates for the dotnet cli",
+    "azFunc.uninstallDotnetTemplates": "Uninstall templates for the dotnet cli"
 }

--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -16,7 +16,7 @@ export const extensionPrefix: string = 'azureFunctions';
 export const projectLanguageSetting: string = 'projectLanguage';
 export const projectRuntimeSetting: string = 'projectRuntime';
 export const templateFilterSetting: string = 'templateFilter';
-export const deploySubPathSetting: string = 'deploySubPath';
+export const deploySubpathSetting: string = 'deploySubpath';
 
 const previewDescription: string = localize('previewDescription', '(Preview)');
 

--- a/src/commands/createFunction/CSharpFunctionCreator.ts
+++ b/src/commands/createFunction/CSharpFunctionCreator.ts
@@ -21,10 +21,12 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
     private _outputChannel: OutputChannel;
     private _functionName: string;
     private _namespace: string;
+    private _ui: IUserInterface;
 
-    constructor(functionAppPath: string, template: Template, outputChannel: OutputChannel) {
+    constructor(functionAppPath: string, template: Template, outputChannel: OutputChannel, ui: IUserInterface) {
         super(functionAppPath, template);
         this._outputChannel = outputChannel;
+        this._ui = ui;
     }
 
     public async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: string[]): Promise<void> {
@@ -47,7 +49,7 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
     }
 
     public async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined> {
-        await dotnetUtils.validateTemplatesInstalled(this._outputChannel, this._functionAppPath);
+        await dotnetUtils.validateTemplatesInstalled(this._outputChannel, this._functionAppPath, this._ui);
 
         const args: string[] = [];
         for (const key of Object.keys(userSettings)) {

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -132,7 +132,7 @@ export async function createFunction(
             functionCreator = new JavaFunctionCreator(functionAppPath, template, outputChannel);
             break;
         case ProjectLanguage.CSharp:
-            functionCreator = new CSharpFunctionCreator(functionAppPath, template, outputChannel);
+            functionCreator = new CSharpFunctionCreator(functionAppPath, template, outputChannel, ui);
             break;
         default:
             functionCreator = new ScriptFunctionCreator(functionAppPath, template, language);

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -14,7 +14,7 @@ import { dotnetUtils } from '../../utils/dotnetUtils';
 import { funcHostTaskId, IProjectCreator } from './IProjectCreator';
 
 export class CSharpProjectCreator implements IProjectCreator {
-    public deploySubPath: string;
+    public deploySubpath: string;
     public runtime: ProjectRuntime;
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
 
@@ -49,7 +49,7 @@ export class CSharpProjectCreator implements IProjectCreator {
             } else {
                 this.runtime = ProjectRuntime.one;
             }
-            this.deploySubPath = `bin/Debug/${targetFramework}`;
+            this.deploySubpath = `bin/Debug/${targetFramework}`;
         }
     }
 
@@ -76,7 +76,7 @@ export class CSharpProjectCreator implements IProjectCreator {
                     type: 'shell',
                     dependsOn: 'build',
                     options: {
-                        cwd: `\${workspaceFolder}/${this.deploySubPath}`
+                        cwd: `\${workspaceFolder}/${this.deploySubpath}`
                     },
                     command: 'func host start',
                     isBackground: true,

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -9,7 +9,7 @@ import { funcHostTaskId, funcHostTaskLabel } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
-    public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
+    public readonly templateFilter: TemplateFilter = TemplateFilter.Core;
     public readonly runtime: ProjectRuntime = ProjectRuntime.beta;
 
     public getTasksJson(): {} {

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -7,7 +7,7 @@ import { localize } from "../../localize";
 import { extensionPrefix, ProjectRuntime, TemplateFilter } from "../../ProjectSettings";
 
 export interface IProjectCreator {
-    deploySubPath?: string;
+    deploySubpath?: string;
     runtime: ProjectRuntime;
     templateFilter: TemplateFilter;
 

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -53,7 +53,7 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
             projectCreator = new JavaScriptProjectCreator();
             break;
         case ProjectLanguage.CSharp:
-            projectCreator = new CSharpProjectCreator(outputChannel);
+            projectCreator = new CSharpProjectCreator(outputChannel, ui);
             break;
         case ProjectLanguage.CSharpScript:
             projectCreator = new CSharpScriptProjectCreator();

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -10,7 +10,7 @@ import { OutputChannel } from 'vscode';
 import { TelemetryProperties } from 'vscode-azureextensionui';
 import { IUserInterface, Pick } from '../../IUserInterface';
 import { localize } from '../../localize';
-import { deploySubPathSetting, extensionPrefix, getFuncExtensionSetting, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../ProjectSettings';
+import { deploySubpathSetting, extensionPrefix, getFuncExtensionSetting, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../ProjectSettings';
 import * as fsUtil from '../../utils/fs';
 import { confirmOverwriteFile } from '../../utils/fs';
 import { gitUtils } from '../../utils/gitUtils';
@@ -97,8 +97,8 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
         settings[`${extensionPrefix}.${projectRuntimeSetting}`] = runtime;
         settings[`${extensionPrefix}.${projectLanguageSetting}`] = language;
         settings[`${extensionPrefix}.${templateFilterSetting}`] = templateFilter;
-        if (projectCreator.deploySubPath) {
-            settings[`${extensionPrefix}.${deploySubPathSetting}`] = projectCreator.deploySubPath;
+        if (projectCreator.deploySubpath) {
+            settings[`${extensionPrefix}.${deploySubpathSetting}`] = projectCreator.deploySubpath;
         }
         await fsUtil.writeFormattedJson(settingsJsonPath, settings);
     }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import { ArgumentError } from '../errors';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { IUserInterface } from '../IUserInterface';
 import { localize } from '../localize';
-import { convertStringToRuntime, deploySubPathSetting, extensionPrefix, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
+import { convertStringToRuntime, deploySubpathSetting, extensionPrefix, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
@@ -32,8 +32,8 @@ import { VSCodeUI } from '../VSCodeUI';
 export async function deploy(telemetryProperties: TelemetryProperties, tree: AzureTreeDataProvider, outputChannel: vscode.OutputChannel, deployPath?: vscode.Uri | string, functionAppId?: string | {}, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     let deployFsPath: string;
     if (!deployPath) {
-        const defaultSubPath: string | undefined = getFuncExtensionSetting(deploySubPathSetting);
-        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), defaultSubPath);
+        const defaultSubpath: string | undefined = getFuncExtensionSetting(deploySubpathSetting);
+        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), defaultSubpath);
     } else if (deployPath instanceof vscode.Uri) {
         deployFsPath = deployPath.fsPath;
     } else {

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -16,8 +16,8 @@ export async function pickFuncProcess(): Promise<string | undefined> {
         // If the functions host isn't running, start the task for the user
         await vscode.commands.executeCommand('workbench.action.tasks.runTask', funcHostTaskId);
 
-        const timeout: number = 15;
-        const maxTime: number = Date.now() + timeout * 1000;
+        const timeoutSeconds: number = 60;
+        const maxTime: number = Date.now() + timeoutSeconds * 1000;
         while (Date.now() < maxTime) {
             // Wait one second between each attempt
             await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
@@ -28,7 +28,7 @@ export async function pickFuncProcess(): Promise<string | undefined> {
             }
         }
 
-        throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds.', timeout));
+        throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds.', timeoutSeconds));
     } else {
         return funcProcess;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import { TemplateData } from './templates/TemplateData';
 import { FunctionAppProvider } from './tree/FunctionAppProvider';
 import { FunctionAppTreeItem } from './tree/FunctionAppTreeItem';
 import { FunctionTreeItem } from './tree/FunctionTreeItem';
+import { dotnetUtils } from './utils/dotnetUtils';
 import { VSCodeUI } from './VSCodeUI';
 
 let reporter: TelemetryReporter | undefined;
@@ -79,6 +80,8 @@ export function activate(context: vscode.ExtensionContext): void {
         actionHandler.registerCommand('azureFunctions.appSettings.edit', async (node: IAzureNode<AppSettingTreeItem>) => await editAppSetting(tree, node));
         actionHandler.registerCommand('azureFunctions.appSettings.rename', async (node: IAzureNode<AppSettingTreeItem>) => await renameAppSetting(tree, node));
         actionHandler.registerCommand('azureFunctions.appSettings.delete', async (node: IAzureNode<AppSettingTreeItem>) => await deleteNode(tree, AppSettingTreeItem.contextValue, node));
+        actionHandler.registerCommand('azureFunctions.installDotnetTemplates', async () => await dotnetUtils.installDotnetTemplates(outputChannel));
+        actionHandler.registerCommand('azureFunctions.uninstallDotnetTemplates', async () => await dotnetUtils.uninstallDotnetTemplates(outputChannel));
     }
 }
 

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -40,7 +40,10 @@ export class TemplateData {
         'HttpTriggerWithParameters-JavaScript',
         'ManualTrigger-JavaScript',
         'QueueTrigger-JavaScript',
-        'TimerTrigger-JavaScript',
+        'TimerTrigger-JavaScript'
+    ];
+
+    private readonly _cSharpTemplates: string[] = [
         'HttpTrigger-CSharp',
         'BlobTrigger-CSharp',
         'QueueTrigger-CSharp',
@@ -85,6 +88,9 @@ export class TemplateData {
             // See issue here: https://github.com/Microsoft/vscode-azurefunctions/issues/84
             const javaTemplates: Template[] = this._templatesMap[runtime].filter((t: Template) => t.language === ProjectLanguage.JavaScript);
             return javaTemplates.filter((t: Template) => this._javaTemplates.find((vt: string) => vt === removeLanguageFromId(t.id)));
+        } else if (language === ProjectLanguage.CSharp) {
+            // https://github.com/Microsoft/vscode-azurefunctions/issues/179
+            return this._templatesMap[runtime].filter((t: Template) => this._cSharpTemplates.some((id: string) => id === t.id));
         } else {
             switch (language) {
                 case ProjectLanguage.CSharpScript:

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -174,10 +174,10 @@ export class TemplateData {
         return runtime === ProjectRuntime.one ? baseKey : `${baseKey}.${runtime}`;
     }
 
-    private async requestFunctionPortal<T>(subPath: string, runtime: string, param?: string): Promise<T> {
+    private async requestFunctionPortal<T>(subpath: string, runtime: string, param?: string): Promise<T> {
         const options: request.OptionsWithUri = {
             method: 'GET',
-            uri: `https://functions.azure.com/api/${subPath}?runtime=${runtime}&${param}`,
+            uri: `https://functions.azure.com/api/${subpath}?runtime=${runtime}&${param}`,
             headers: {
                 'User-Agent': 'Mozilla/5.0' // Required otherwise we get Unauthorized
             }

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -7,27 +7,36 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { OutputChannel } from "vscode";
+import * as vscode from 'vscode';
+import { UserCancelledError } from 'vscode-azureextensionui';
+import { DialogResponses } from '../DialogResponses';
+import { IUserInterface, Pick } from '../IUserInterface';
 import { localize } from "../localize";
+import { ProjectRuntime } from '../ProjectSettings';
+import { VSCodeUI } from '../VSCodeUI';
 import { cpUtils } from "./cpUtils";
 import * as fsUtil from './fs';
 
 export namespace dotnetUtils {
     const projectPackageId: string = 'microsoft.azurefunctions.projecttemplates';
     const functionsPackageId: string = 'azure.functions.templates';
-    const templateVersion: string = '2.0.0-beta-10138';
+    const betaTemplateVersion: string = '2.0.0-beta-10153';
+    const v1TemplateVersion: string = '1.0.3.10152';
 
-    // tslint:disable:no-multiline-string
-    const packagesCsproj: string = `<?xml version="1.0" encoding="utf-8"?>
+    function getPackagesCsproj(version: string): string {
+        // tslint:disable:no-multiline-string
+        return `<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="${projectPackageId}" Version="${templateVersion}" />
-    <PackageReference Include="${functionsPackageId}" Version="${templateVersion}" />
+    <PackageReference Include="${projectPackageId}" Version="${version}" />
+    <PackageReference Include="${functionsPackageId}" Version="${version}" />
   </ItemGroup>
 </Project>
 `;
+    }
 
     async function validateDotnetInstalled(workingDirectory: string): Promise<void> {
         try {
@@ -39,33 +48,70 @@ export namespace dotnetUtils {
 
     export const funcProjectId: string = 'azureFunctionsProjectTemplates';
 
-    export async function validateTemplatesInstalled(outputChannel: OutputChannel, workingDirectory: string): Promise<void> {
+    export async function validateTemplatesInstalled(outputChannel: OutputChannel, workingDirectory: string, ui: IUserInterface): Promise<void> {
         await validateDotnetInstalled(workingDirectory);
         const listOutput: string = await cpUtils.executeCommand(undefined, workingDirectory, 'dotnet', 'new', '--list');
         if (!listOutput.includes(funcProjectId) || !listOutput.includes('HttpTrigger')) {
-            const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());
-            await fse.ensureDir(tempFolder);
-            try {
-                await fse.writeFile(path.join(tempFolder, 'packages.csproj'), packagesCsproj);
-
-                // 'dotnet new --install' doesn't allow you to specify a source when installing templates
-                // Once these templates are published to Nuget.org, we can just call 'dotnet new --install' directly and skip all the tempFolder/restore stuff
-                outputChannel.show();
-                outputChannel.appendLine(localize('installingTemplates', 'Downloading dotnet templates for Azure Functions...'));
-                await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'restore', '--packages', '.', '--source', 'https://www.myget.org/F/azure-appservice/api/v3/index.json', '--source', 'https://api.nuget.org/v3/index.json');
-
-                const fullProjectPackageId: string = `${projectPackageId}.${templateVersion}`;
-                outputChannel.appendLine(localize('projectPackageId', 'Installing  "{0}"', fullProjectPackageId));
-                await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(projectPackageId, templateVersion, `${fullProjectPackageId}.nupkg`));
-
-                const fullFunctionsPackageId: string = `${functionsPackageId}.${templateVersion}`;
-                outputChannel.appendLine(localize('functionsPackageId', 'Installing  "{0}"', fullFunctionsPackageId));
-                await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(functionsPackageId, templateVersion, `${fullFunctionsPackageId}.nupkg`));
-
-                outputChannel.appendLine(localize('finishedInstallingTemplates', 'Finished installing Azure Functions templates.'));
-            } finally {
-                await fse.remove(tempFolder);
+            const installTemplates: vscode.MessageItem = { title: localize('installTemplates', 'Install Templates') };
+            const result: vscode.MessageItem | undefined = await vscode.window.showWarningMessage(localize('noDotnetFuncTemplates', 'You must have the Azure Functions templates installed for the dotnet cli.'), installTemplates, DialogResponses.cancel);
+            if (result === installTemplates) {
+                await installDotnetTemplates(outputChannel, ui);
+            } else {
+                throw new UserCancelledError();
             }
+        }
+    }
+
+    export async function uninstallDotnetTemplates(outputChannel: OutputChannel): Promise<void> {
+        const tempFolder: string = os.tmpdir();
+
+        outputChannel.show();
+        outputChannel.appendLine(localize('uninstallFuncProject', 'Uninstalling "{0}"', projectPackageId));
+        await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--uninstall', projectPackageId);
+        outputChannel.appendLine(localize('uninstallFuncs', 'Uninstalling "{0}"', functionsPackageId));
+        await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--uninstall', functionsPackageId);
+        outputChannel.appendLine(localize('finishedUninstallingTemplates', 'Finished uninstalling Azure Functions templates.'));
+    }
+
+    export async function installDotnetTemplates(outputChannel: OutputChannel, ui: IUserInterface = new VSCodeUI()): Promise<void> {
+        let templateVersion: string = betaTemplateVersion;
+
+        if (/^win/.test(process.platform)) {
+            const picks: Pick[] = [
+                new Pick(ProjectRuntime.beta, '(.NET Core)'),
+                new Pick(ProjectRuntime.one, '(.NET Framework)')
+            ];
+            const placeholder: string = localize('pickTemplateVersion', 'Select the template version to install');
+            const versionResult: Pick = await ui.showQuickPick(picks, placeholder);
+            if (versionResult.label === ProjectRuntime.one) {
+                templateVersion = v1TemplateVersion;
+            }
+        }
+
+        const packagesCsproj: string = getPackagesCsproj(templateVersion);
+
+        const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());
+        await fse.ensureDir(tempFolder);
+        try {
+            await fse.writeFile(path.join(tempFolder, 'packages.csproj'), packagesCsproj);
+
+            // 'dotnet new --install' doesn't allow you to specify a source when installing templates
+            // Once these templates are published to Nuget.org, we can just call 'dotnet new --install' directly and skip all the tempFolder/restore stuff
+            outputChannel.show();
+            outputChannel.appendLine(localize('downloadingTemplates', 'Downloading dotnet templates for Azure Functions...'));
+            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'restore', '--packages', '.', '--source', 'https://www.myget.org/F/azure-appservice/api/v3/index.json', '--source', 'https://api.nuget.org/v3/index.json');
+
+            const fullProjectPackageId: string = `${projectPackageId}.${templateVersion}`;
+            outputChannel.appendLine(localize('installFuncProject', 'Installing "{0}"', fullProjectPackageId));
+            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(projectPackageId, templateVersion, `${fullProjectPackageId}.nupkg`));
+
+            const fullFunctionsPackageId: string = `${functionsPackageId}.${templateVersion}`;
+            outputChannel.appendLine(localize('installFuncs', 'Installing "{0}"', fullFunctionsPackageId));
+            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(functionsPackageId, templateVersion, `${fullFunctionsPackageId}.nupkg`));
+
+            outputChannel.appendLine(localize('finishedInstallingTemplates', 'Finished installing Azure Functions templates.'));
+        } finally {
+            await fse.remove(tempFolder);
         }
     }
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -76,7 +76,7 @@ export function isPathEqual(fsPath1: string, fsPath2: string, relativeFunc: path
     return relativePath === '';
 }
 
-export function isSubPath(expectedParent: string, expectedChild: string, relativeFunc: pathRelativeFunc = path.relative): boolean {
+export function isSubpath(expectedParent: string, expectedChild: string, relativeFunc: pathRelativeFunc = path.relative): boolean {
     const relativePath: string = relativeFunc(expectedParent, expectedChild);
     return relativePath !== '' && !relativePath.startsWith('..') && relativePath !== expectedChild;
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -9,12 +9,12 @@ import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
 import * as fsUtils from './fs';
 
-export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string, subPath?: string): Promise<string> {
+export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string, subpath?: string): Promise<string> {
     const browse: string = ':browse';
     let folder: PickWithData<string> | undefined;
     if (vscode.workspace.workspaceFolders) {
         const folderPicks: PickWithData<string>[] = vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => {
-            const fsPath: string = subPath ? path.join(f.uri.fsPath, subPath) : f.uri.fsPath;
+            const fsPath: string = subpath ? path.join(f.uri.fsPath, subpath) : f.uri.fsPath;
             return new PickWithData('', fsPath);
         });
         folderPicks.push(new PickWithData(browse, localize('azFunc.browse', '$(file-directory) Browse...')));
@@ -27,7 +27,7 @@ export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: str
 export function isFolderOpenInWorkspace(fsPath: string): boolean {
     if (vscode.workspace.workspaceFolders) {
         const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.find((f: vscode.WorkspaceFolder): boolean => {
-            return fsUtils.isPathEqual(f.uri.fsPath, fsPath) || fsUtils.isSubPath(f.uri.fsPath, fsPath);
+            return fsUtils.isPathEqual(f.uri.fsPath, fsPath) || fsUtils.isSubpath(f.uri.fsPath, fsPath);
         });
 
         return folder !== undefined;

--- a/test/createFunction/createFunction.C#.test.ts
+++ b/test/createFunction/createFunction.C#.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ProjectLanguage, ProjectRuntime } from '../../src/ProjectSettings';
 import { dotnetUtils } from '../../src/utils/dotnetUtils';
+import { TestUI } from '../TestUI';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpFunctionTester extends FunctionTesterBase {
@@ -31,7 +32,7 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
     suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
         this.timeout(60 * 1000);
         await csTester.initAsync();
-        await dotnetUtils.validateTemplatesInstalled(csTester.outputChannel, csTester.testFolder);
+        await dotnetUtils.installDotnetTemplates(csTester.outputChannel, new TestUI([]));
     });
 
     suiteTeardown(async () => {

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -26,7 +26,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
     suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
         this.timeout(60 * 1000);
         await fse.ensureDir(testFolderPath);
-        await dotnetUtils.validateTemplatesInstalled(outputChannel, testFolderPath);
+        await dotnetUtils.installDotnetTemplates(outputChannel, new TestUI([]));
     });
 
     suiteTeardown(async () => {

--- a/test/fsUtils.test.ts
+++ b/test/fsUtils.test.ts
@@ -49,7 +49,7 @@ suite('fsUtils Tests', () => {
         // completely different path
         fsPath1 = '/test/sub';
         fsPath2 = '/test2/sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), false);
     });
 
     test('isPathEqual, win32, false', () => {
@@ -62,64 +62,64 @@ suite('fsUtils Tests', () => {
         // completely different path
         fsPath1 = 'C:\\test\\sub';
         fsPath2 = 'D:\\test2\\sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), false);
     });
 
-    test('isSubPath, posix, true', () => {
+    test('isSubpath, posix, true', () => {
         // sub path
         let fsPath1: string = '/test/';
         let fsPath2: string = '/test/sub';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), true);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), true);
 
         // nested sub path
         fsPath1 = '/test/';
         fsPath2 = '/test/sub2/sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), true);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), true);
     });
 
-    test('isSubPath, win32, true', () => {
+    test('isSubpath, win32, true', () => {
         // sub path
         let fsPath1: string = 'C:\\test';
         let fsPath2: string = 'C:\\test\\sub';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), true);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), true);
 
         // nested sub path
         fsPath1 = 'C:\\test';
         fsPath2 = 'C:\\test\\sub\\sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), true);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), true);
     });
 
-    test('isSubPath, posix, false', () => {
+    test('isSubpath, posix, false', () => {
         // opposite of subpath
         let fsPath1: string = '/test/sub';
         let fsPath2: string = '/test/';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), false);
 
         // completely different path
         fsPath1 = '/test/sub';
         fsPath2 = '/test2/sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), false);
 
         // same path
         fsPath1 = '/test/';
         fsPath2 = '/test/';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.posix.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.posix.relative), false);
     });
 
-    test('isSubPath, win32, false', () => {
+    test('isSubpath, win32, false', () => {
         // opposite of subpath
         let fsPath1: string = 'C:\\test\\sub\\';
         let fsPath2: string = 'C:\\test\\';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), false);
 
         // completely different path
         fsPath1 = 'C:\\test\\sub';
         fsPath2 = 'D:\\test2\\sub2';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), false);
 
         // same path
         fsPath1 = 'C:\\test\\';
         fsPath2 = 'C:\\test\\';
-        assert.equal(fsUtils.isSubPath(fsPath1, fsPath2, path.win32.relative), false);
+        assert.equal(fsUtils.isSubpath(fsPath1, fsPath2, path.win32.relative), false);
     });
 });


### PR DESCRIPTION
1. Allow windows users to install either the .NET Core _or_ .NET Framework templates
1. Provide commands to install/uninstall the templates
1. Limit function templates to just the main 4
1. Detect if the project created was .NET Core or .NET Framework and set runtime accordingly