### PR TITLE
Rename attach task for c#

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the "azurefunctions" extension will be documented in this
 - [Bugs fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.5.0%22+label%3Abug+is%3Aclosed)
 
 ### Known Issues
+- The Functions host must be stopped after making changes and before rebuilding to C# functions [#185](https://github.com/Microsoft/vscode-azurefunctions/issues/185)
 - C# class library functions fail to run on Mac [#164](https://github.com/Microsoft/vscode-azurefunctions/issues/164)
 - C# script functions fail to attach on Windows [#180](https://github.com/Microsoft/vscode-azurefunctions/issues/180)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   * [Node 8.0+](https://nodejs.org/)
 * For C# based Functions:
   * [VS Code Debugger for C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+  * If you are using the beta version of the functions cli (as described above), you must install the beta (.NET Core) templates when prompted
+  * If you are using v1 of the functions cli (Windows only), you must install the v1 (.NET Framework) templates when prompted
   > NOTE: The default experience for C# uses class libraries (&ast;.cs files), which provide superior performance, scalability, and versatility over C# Scripts (&ast;.csx files). If you want to use C# Scripts, you may change your `azureFunctions.projectLanguage` user setting to `C#Script`.
 * For Java based Functions:
   * [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -93,7 +93,7 @@ export class CSharpProjectCreator implements IProjectCreator {
             version: '0.2.0',
             configurations: [
                 {
-                    name: localize('azFunc.attachToNetCoreFunc', "Attach to .NET Core Functions"),
+                    name: localize('azFunc.attachToNetCoreFunc', "Attach to C# Functions"),
                     type: 'coreclr',
                     request: 'attach',
                     processId: '\${command:azureFunctions.pickProcess}',

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -35,7 +35,7 @@ export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
             version: '0.2.0',
             configurations: [
                 {
-                    name: localize('azFunc.attachToNetCoreFunc', "Attach to .NET Core Functions"),
+                    name: localize('azFunc.attachToNetCoreFunc', "Attach to C# Script Functions"),
                     type: 'coreclr',
                     request: 'attach',
                     processId: '\${command:azureFunctions.pickProcess}'


### PR DESCRIPTION
(Since it could be .NET Framework instead of .NET Core)

Fixes #187 