### PR TITLE
Improve C# F5 experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to the "azurefunctions" extension will be documented in this file.
 
+## 0.5.1 - 2018-02-01
+### [Fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.5.1%22+label%3Abug+is%3Aclosed)
+- C# local debugging
+  - Fixed "Cannot access the file because it is being used by another process." error by automatically restarting the functions host
+  - Fixed project being built twice for every F5
+  - Improved performance of 'azureFunctions.pickProcess' on Windows
+
 ## 0.5.0 - 2018-01-25
 ### Added
 - Create, Debug, and Deploy a C# class library project

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%extension.description%",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -82,7 +82,8 @@ export class CSharpProjectCreator implements IProjectCreator {
                     isBackground: true,
                     presentation: {
                         reveal: 'always'
-                    }
+                    },
+                    problemMatcher: []
                 }
             ]
         };
@@ -96,8 +97,7 @@ export class CSharpProjectCreator implements IProjectCreator {
                     name: localize('azFunc.attachToNetCoreFunc', "Attach to C# Functions"),
                     type: 'coreclr',
                     request: 'attach',
-                    processId: '\${command:azureFunctions.pickProcess}',
-                    preLaunchTask: 'build'
+                    processId: '\${command:azureFunctions.pickProcess}'
                 }
             ]
         };

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -24,7 +24,8 @@ export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
                     isBackground: true,
                     presentation: {
                         reveal: 'always'
-                    }
+                    },
+                    problemMatcher: []
                 }
             ]
         };

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -7,61 +7,112 @@
 import ps = require('ps-node');
 import * as vscode from 'vscode';
 import { localize } from '../localize';
+import { cpUtils } from '../utils/cpUtils';
 import { funcHostTaskId } from './createNewProject/IProjectCreator';
 
-export async function pickFuncProcess(outputChannel: vscode.OutputChannel): Promise<string | undefined> {
-    outputChannel.show();
-    outputChannel.appendLine(localize('searchingFuncHost', 'Searching for Azure Functions host process...'));
-    let funcProcess: string | undefined = await getFuncPid();
-
-    if (funcProcess === undefined) {
-        // If the functions host isn't running, start the task for the user
-        await vscode.commands.executeCommand('workbench.action.tasks.runTask', funcHostTaskId);
-
-        const timeoutSeconds: number = 60;
-        const maxTime: number = Date.now() + timeoutSeconds * 1000;
-        while (Date.now() < maxTime) {
-            // Wait one second between each attempt
-            await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
-
-            funcProcess = await getFuncPid();
-            if (funcProcess !== undefined) {
-                return funcProcess;
-            }
-        }
-
-        throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds.', timeoutSeconds));
-    } else {
-        return funcProcess;
+export async function pickFuncProcess(): Promise<string | undefined> {
+    let funcHostPid: string | undefined = await getFuncHostPid();
+    if (funcHostPid !== undefined) {
+        // Stop the functions host to prevent build errors like "Cannot access the file '...' because it is being used by another process."
+        await killProcess(funcHostPid);
     }
+
+    // Start (or restart) functions host (which will also trigger a build)
+    await vscode.commands.executeCommand('workbench.action.tasks.runTask', funcHostTaskId);
+
+    const timeoutSeconds: number = 60;
+    const maxTime: number = Date.now() + timeoutSeconds * 1000;
+    while (Date.now() < maxTime) {
+        // Wait one second between each attempt
+        await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
+
+        funcHostPid = await getFuncHostPid();
+        if (funcHostPid !== undefined) {
+            return funcHostPid;
+        }
+    }
+
+    throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds.', timeoutSeconds));
 }
 
-async function getFuncPid(): Promise<string | undefined> {
-    const processList: IProcess[] = await new Promise((resolve: (processList: IProcess[]) => void, reject: (e: Error) => void): void => {
-        //tslint:disable-next-line:no-unsafe-any
-        ps.lookup(
-            {
-                command: '.*dotnet.*',
-                arguments: '.*Azure\.Functions.*host.*start'
-            },
-            (error: Error | undefined, result: IProcess[]): void => {
-                if (error) {
-                    reject(error);
-                } else {
-                    resolve(result);
-                }
-            });
-    });
+function isWindows(): boolean {
+    return /^win/.test(process.platform);
+}
 
-    if (processList.length === 0) {
-        return undefined;
-    } else if (processList.length === 1) {
-        return processList[0].pid;
+async function getFuncHostPid(): Promise<string | undefined> {
+    const multipleProcError: Error = new Error(localize('multipleFuncHost', 'Detected multiple processes running the Functions host. Stop all but one process in order to debug.'));
+    if (isWindows()) {
+        // Ideally we could use 'ps.lookup' for all OS's, but unfortunately it's very slow on windows
+        // Instead, we will call 'wmic' manually and parse the results
+        const processList: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'get', 'ProcessId,CommandLine', '/FORMAT:csv');
+        const regExp: RegExp = new RegExp(/^.*,.*Azure\.Functions\.Cli.*host.*start.*,(\d+)$/gm);
+        const matches: RegExpMatchArray | null = regExp.exec(processList);
+        if (matches === null) {
+            return undefined;
+        } else if (matches.length === 2) {
+            return matches[1];
+        } else {
+            throw multipleProcError;
+        }
     } else {
-        throw new Error(localize('multipleFuncHost', 'Detected multiple processes running the Functions host. Stop all but one process in order to debug.'));
+        const processList: IProcess[] = await new Promise((resolve: (processList: IProcess[]) => void, reject: (e: Error) => void): void => {
+            //tslint:disable-next-line:no-unsafe-any
+            ps.lookup(
+                {
+                    command: '.*dotnet.*',
+                    arguments: '.*Azure\.Functions.*host.*start'
+                },
+                (error: Error | undefined, result: IProcess[]): void => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(result);
+                    }
+                });
+        });
+
+        if (processList.length === 0) {
+            return undefined;
+        } else if (processList.length === 1) {
+            return processList[0].pid;
+        } else {
+            throw multipleProcError;
+        }
     }
 }
 
 interface IProcess {
     pid: string;
+}
+
+async function killProcess(pid: string, timeoutInSeconds: number = 60): Promise<void> {
+    if (isWindows()) {
+        // Just like 'ps.lookup', 'ps.kill' is very slow on windows
+        // We can use it to kill the process, but we have to implement our own 'wait' logic to make sure the process actually stopped
+        //tslint:disable-next-line:no-unsafe-any
+        ps.kill(pid);
+        const maxTime: number = Date.now() + timeoutInSeconds * 1000;
+        while (Date.now() < maxTime) {
+            // Wait one second between each attempt
+            await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
+
+            const oldProcess: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'where', `ProcessId="${pid}"`, 'get', 'ProcessId', '/FORMAT:csv');
+            if (oldProcess.indexOf(pid) === -1) {
+                return;
+            }
+        }
+
+        throw new Error(localize('failedToTerminateProcess', 'Failed to terminate process with pid "{0}" in "{1}" seconds.', pid, timeoutInSeconds));
+    } else {
+        await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
+            //tslint:disable-next-line:no-unsafe-any
+            ps.kill(pid, (err: Error | undefined) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         const actionHandler: AzureActionHandler = new AzureActionHandler(context, outputChannel, reporter);
         actionHandler.registerCommand('azureFunctions.refresh', async (node?: IAzureNode) => await tree.refresh(node));
-        actionHandler.registerCommand('azureFunctions.pickProcess', async () => await pickFuncProcess(outputChannel));
+        actionHandler.registerCommand('azureFunctions.pickProcess', async () => await pickFuncProcess());
         actionHandler.registerCommand('azureFunctions.loadMore', async (node: IAzureNode) => await tree.loadMore(node));
         actionHandler.registerCommand('azureFunctions.openInPortal', async (node?: IAzureNode<FunctionAppTreeItem>) => await openInPortal(tree, node));
         actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createFunction', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, templateId?: string, functionName?: string, ...functionSettings: string[]) => {

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -11,7 +11,7 @@ import { localize } from '../localize';
 export namespace cpUtils {
     export async function executeCommand(outputChannel: vscode.OutputChannel | undefined, workingDirectory: string | undefined, command: string, ...args: string[]): Promise<string> {
         let result: string = '';
-        workingDirectory = workingDirectory !== undefined ? workingDirectory : os.tmpdir();
+        workingDirectory = workingDirectory || os.tmpdir();
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             const options: cp.SpawnOptions = {
                 cwd: workingDirectory,

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as cp from 'child_process';
+import * as os from 'os';
 import * as vscode from 'vscode';
 import { localize } from '../localize';
 
 export namespace cpUtils {
-    export async function executeCommand(outputChannel: vscode.OutputChannel | undefined, workingDirectory: string, command: string, ...args: string[]): Promise<string> {
+    export async function executeCommand(outputChannel: vscode.OutputChannel | undefined, workingDirectory: string | undefined, command: string, ...args: string[]): Promise<string> {
         let result: string = '';
+        workingDirectory = workingDirectory !== undefined ? workingDirectory : os.tmpdir();
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             const options: cp.SpawnOptions = {
                 cwd: workingDirectory,


### PR DESCRIPTION
1. Switch away from ps-node on windows because it is very slow
1. Stop and restart the functions host if it is running when the user starts debugging
1. Only build once when the user F5's instead of twice

Fixes #194 
Fixes #185 
