### PR TITLE
Fix C# debugging for v1 (.NET Framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@
 * .NET Templates for Azure Functions
   * You will be automatically prompted to install these templates when you first create a project/function
     * If you are using v2.0 of the Azure Functions runtime, you must install the beta (.NET Core) templates
-    * If you are using v1.0 of the Azure Functions runtime, you must install the v1.0 (.NET Framework) templates
+    * If you are using v1.0 of the Azure Functions runtime, you must install the v1.0 (.NET Framework) templates.
+    > NOTE: The VS Code Debugger for C# [only supports](https://github.com/OmniSharp/omnisharp-vscode/issues/1716) attaching to 64-bit processes. v1.0 of the Azure Functions runtime defaults to 32-bit and you must install a 64-bit version. See [here](https://github.com/Azure/azure-functions-cli/issues/117) for instructions.
   * You may uninstall or reinstall the templates with the following steps:
     1. Open Command Palette (View -> Command Palette...)
     1. Search for "Azure Functions" and "install" or "uninstall"

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -6,6 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { OutputChannel } from 'vscode';
+import * as vscode from 'vscode';
 import { IUserInterface } from '../../IUserInterface';
 import { localize } from "../../localize";
 import { ProjectRuntime, TemplateFilter } from '../../ProjectSettings';
@@ -48,6 +49,7 @@ export class CSharpProjectCreator implements IProjectCreator {
                 this.runtime = ProjectRuntime.beta;
             } else {
                 this.runtime = ProjectRuntime.one;
+                await vscode.window.showWarningMessage('In order to debug .NET Framework functions in VS Code, you must install a 64-bit version of the runtime. See https://github.com/Azure/azure-functions-cli/issues/117');
             }
             this.deploySubpath = `bin/Debug/${targetFramework}`;
         }
@@ -95,7 +97,7 @@ export class CSharpProjectCreator implements IProjectCreator {
             configurations: [
                 {
                     name: localize('azFunc.attachToNetCoreFunc', "Attach to C# Functions"),
-                    type: 'coreclr',
+                    type: this.runtime === ProjectRuntime.beta ? 'coreclr' : 'clr',
                     request: 'attach',
                     processId: '\${command:azureFunctions.pickProcess}'
                 }

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -45,7 +45,7 @@ async function getFuncHostPid(): Promise<string | undefined> {
         // Ideally we could use 'ps.lookup' for all OS's, but unfortunately it's very slow on windows
         // Instead, we will call 'wmic' manually and parse the results
         const processList: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'get', 'CommandLine,Name,ProcessId', '/FORMAT:csv');
-        const regExp: RegExp = new RegExp(/^.*,.*azure.*functions.*host.*start.*,(?:dotnet\.exe|func\.exe),(\d+)$/gmi);
+        const regExp: RegExp = new RegExp(/^.*,.*azure.*functions.*host.*start.*,(?:dotnet\.exe|func.*\.exe),(\d+)$/gmi);
         const matches: RegExpMatchArray | null = regExp.exec(processList);
         if (matches === null) {
             return undefined;

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -44,8 +44,8 @@ async function getFuncHostPid(): Promise<string | undefined> {
     if (isWindows()) {
         // Ideally we could use 'ps.lookup' for all OS's, but unfortunately it's very slow on windows
         // Instead, we will call 'wmic' manually and parse the results
-        const processList: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'get', 'ProcessId,CommandLine', '/FORMAT:csv');
-        const regExp: RegExp = new RegExp(/^.*,.*Azure\.Functions\.Cli.*host.*start.*,(\d+)$/gm);
+        const processList: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'get', 'CommandLine,Name,ProcessId', '/FORMAT:csv');
+        const regExp: RegExp = new RegExp(/^.*,.*azure.*functions.*host.*start.*,(?:dotnet\.exe|func\.exe),(\d+)$/gmi);
         const matches: RegExpMatchArray | null = regExp.exec(processList);
         if (matches === null) {
             return undefined;


### PR DESCRIPTION
1. The type for the launch.json should be 'clr' instead of 'coreclr'
2. We have to show a warning about attaching to 64 bit processes
3. The regex for the process was wrong. Specifically, we want to match these two strings (v1 and v2 of the runtime)
```
emjdev3,C:\Users\erijiz\AppData\Roaming\npm\node_modules\azure-functions-core-tools\bin/func.exe host start,func.exe,10608
emjdev3,dotnet C:\Users\erijiz\AppData\Roaming\npm\node_modules\azure-functions-core-tools\bin/Azure.Functions.Cli.dll host start,dotnet.exe,10528
```

But we don't want to match these (other languages than C#):
```
emjdev3,C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe -Command func host start,powershell.exe,10020
emjdev3,C:\WINDOWS\system32\cmd.exe /c ""C:\Users\erijiz\AppData\Roaming\npm\func.cmd" host start",cmd.exe,3664
emjdev3,node   "C:\Users\erijiz\AppData\Roaming\npm\\node_modules\azure-functions-core-tools\lib\main.js" host start,node.exe,8700
```

This time I made sure to verify this code for v1 and v2 (not sure how I missed that last time 😅). I also verified the workaround with the x64 version of the runtime. Hopefully we can get some others to verify as well