### PR TITLE
Use aka.ms link instead of direct link

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -49,7 +49,7 @@ export class CSharpProjectCreator implements IProjectCreator {
                 this.runtime = ProjectRuntime.beta;
             } else {
                 this.runtime = ProjectRuntime.one;
-                await vscode.window.showWarningMessage('In order to debug .NET Framework functions in VS Code, you must install a 64-bit version of the runtime. See https://github.com/Azure/azure-functions-cli/issues/117');
+                await vscode.window.showWarningMessage('In order to debug .NET Framework functions in VS Code, you must install a 64-bit version of the runtime. See https://aka.ms/azFunc64bit');
             }
             this.deploySubpath = `bin/Debug/${targetFramework}`;
         }


### PR DESCRIPTION
That way we can change the link (to better docs, etc.) without having to re-publish