### PR TITLE
Add docs for installing 64-bit version of func cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
   * You will be automatically prompted to install these templates when you first create a project/function
     * If you are using v2.0 of the Azure Functions runtime, you must install the beta (.NET Core) templates
     * If you are using v1.0 of the Azure Functions runtime, you must install the v1.0 (.NET Framework) templates.
-    > NOTE: The VS Code Debugger for C# [only supports](https://github.com/OmniSharp/omnisharp-vscode/issues/1716) attaching to 64-bit processes. v1.0 of the Azure Functions runtime defaults to 32-bit and you must install a 64-bit version. See [here](https://github.com/Azure/azure-functions-cli/issues/117) for instructions.
+    > NOTE: The VS Code Debugger for C# [only supports](https://github.com/OmniSharp/omnisharp-vscode/issues/1716) attaching to 64-bit processes. v1.0 of the Azure Functions runtime defaults to 32-bit and you must install a 64-bit version. See [here](https://aka.ms/azFunc64bit) for instructions.
   * You may uninstall or reinstall the templates with the following steps:
     1. Open Command Palette (View -> Command Palette...)
     1. Search for "Azure Functions" and "install" or "uninstall"

--- a/docs/func64bit.md
+++ b/docs/func64bit.md
@@ -1,0 +1,9 @@
+# Debugging .NET Framework functions in VS Code
+
+The VS Code Debugger for C# [only supports](https://github.com/OmniSharp/omnisharp-vscode/issues/1716) attaching to 64-bit processes. However, v1.0 of the Azure Functions runtime defaults to 32-bit (See [this issue](https://github.com/Azure/azure-functions-cli/issues/117) for more info). Follow these instructions to install a 64-bit version:
+1. Install the 32-bit version of the cli with the command `npm install -g azure-functions-core-tools`
+1. Download a 64-bit version of the v1.0 cli from [here](https://github.com/Azure/azure-functions-core-tools/releases). The file name will look similar to "1.0.8-x64.zip".
+1. Run `npm root -g` to find the root folder containing your global npm packages (likely `%USERPROFILE%\AppData\Roaming\npm\node_modules`)
+1. Replace the files in `<npm global packages root>\azure-functions-core-tools\bin` with the un-zipped files
+
+> NOTE: The VS Code extension for Azure Functions will warn you to install the 64-bit version of the Azure Functions CLI every time you create a .NET Framework based project (even after you have installed the 64-bit version). You may ignore that warning once you follow the above steps.


### PR DESCRIPTION
The aka.ms link displayed in the following warning is currently pointing to [this issue](https://github.com/Azure/azure-functions-cli/issues/117), which doesn't have clear instructions to fix the issue.  ![screen shot 2018-02-05 at 9 00 13 am](https://user-images.githubusercontent.com/11282622/35817793-347004d8-0a53-11e8-9336-fbdea428475e.png)

Once these changes get pushed to master, I'll redirect it to this doc.