### PR TITLE
Fix multiple prompts if language not set

### DIFF
--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -53,6 +53,8 @@ async function updateWorkspaceSetting(section: string, value: string): Promise<v
 export async function selectProjectLanguage(ui: IUserInterface): Promise<ProjectLanguage> {
     const picks: Pick[] = [
         new Pick(ProjectLanguage.JavaScript),
+        new Pick(ProjectLanguage.CSharp),
+        new Pick(ProjectLanguage.CSharpScript),
         new Pick(ProjectLanguage.FSharpScript),
         new Pick(ProjectLanguage.Bash, previewDescription),
         new Pick(ProjectLanguage.Batch, previewDescription),
@@ -106,8 +108,8 @@ export async function getProjectLanguage(projectPath: string, ui: IUserInterface
     if (await fse.pathExists(path.join(projectPath, 'pom.xml'))) {
         return ProjectLanguage.Java;
     } else {
-        let language: ProjectLanguage | undefined = getFuncExtensionSetting(projectLanguageSetting);
-        if (language === undefined) {
+        let language: string | undefined = getFuncExtensionSetting(projectLanguageSetting);
+        if (!language) {
             const message: string = localize('noLanguage', 'You must have a project language set to perform this operation.');
             const selectLanguage: MessageItem = { title: localize('selectLanguageButton', 'Select Language') };
             const result: MessageItem | undefined = await vscode.window.showWarningMessage(message, selectLanguage, DialogResponses.cancel);


### PR DESCRIPTION
This is what currently happens if you try to create a function without a language/runtime set:
1. Language is an empty string, but user isn't prompted to set it
1. Runtime is an empty string, and user _is_ prompted
1. We try to find the templates matching the user's settings, but we can't find any so we prompt them for all three values again (language, runtime, and filter)

Instead, we should prompt them in step 1 & 2 and then we don't have to prompt for step 3. (Step 3 is only meant to happen if the user changes their settings to something like 'Python', 'beta', and 'Verified' - which has no templates)

Fixes part of #203