### PR TITLE
Support Function projects in multi-root workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -374,6 +374,7 @@
                         "description": "%azFunc.showExplorerDescription%"
                     },
                     "azureFunctions.templateFilter": {
+                        "scope": "resource",
                         "type": "string",
                         "default": "Verified",
                         "enum": [
@@ -384,16 +385,19 @@
                         "description": "%azFunc.templateFilterDescription%"
                     },
                     "azureFunctions.zipGlobPattern": {
+                        "scope": "resource",
                         "type": "string",
                         "default": "**/*",
                         "description": "Defines which files in the workspace to deploy. This applies to Zip deploy only, has no effect on other deployment methods."
                     },
                     "azureFunctions.zipIgnorePattern": {
+                        "scope": "resource",
                         "type": "string",
                         "default": "",
                         "description": "Defines which files in the workspace to ignore for Zip deploy. This applies to Zip deploy only, has no effect on other deployment methods."
                     },
                     "azureFunctions.projectRuntime": {
+                        "scope": "resource",
                         "type": "string",
                         "enum": [
                             "~1",
@@ -402,6 +406,7 @@
                         "description": "%azFunc.projectRuntimeDescription%"
                     },
                     "azureFunctions.projectLanguage": {
+                        "scope": "resource",
                         "type": "string",
                         "enum": [
                             "Bash",
@@ -419,6 +424,7 @@
                         "description": "%azFunc.projectLanguageDescription%"
                     },
                     "azureFunctions.deploySubpath": {
+                        "scope": "resource",
                         "type": "string",
                         "description": "%azFunc.deploySubpathDescription%"
                     }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -99,9 +99,9 @@ export async function createFunction(
 
     const language: ProjectLanguage = await getProjectLanguage(functionAppPath, ui);
     telemetryProperties.projectLanguage = language;
-    const runtime: ProjectRuntime = await getProjectRuntime(language, ui);
+    const runtime: ProjectRuntime = await getProjectRuntime(language, functionAppPath, ui);
     telemetryProperties.projectRuntime = runtime;
-    const templateFilter: TemplateFilter = await getTemplateFilter();
+    const templateFilter: TemplateFilter = await getTemplateFilter(functionAppPath);
     telemetryProperties.templateFilter = templateFilter;
 
     let template: Template;

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -106,12 +106,12 @@ export async function createFunction(
 
     let template: Template;
     if (!templateId) {
-        const templates: Template[] = await templateData.getTemplates(language, runtime, templateFilter, ui);
+        const templates: Template[] = await templateData.getTemplates(functionAppPath, language, runtime, templateFilter, ui);
         const templatePicks: PickWithData<Template>[] = templates.map((t: Template) => new PickWithData<Template>(t, t.name));
         const templatePlaceHolder: string = localize('azFunc.selectFuncTemplate', 'Select a function template');
         template = (await ui.showQuickPick<Template>(templatePicks, templatePlaceHolder)).data;
     } else {
-        const templates: Template[] = await templateData.getTemplates(language, runtime, TemplateFilter.All, ui);
+        const templates: Template[] = await templateData.getTemplates(functionAppPath, language, runtime, TemplateFilter.All, ui);
         const foundTemplate: Template | undefined = templates.find((t: Template) => t.id === templateId);
         if (foundTemplate) {
             template = foundTemplate;

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -10,7 +10,7 @@ import { OutputChannel } from 'vscode';
 import { TelemetryProperties } from 'vscode-azureextensionui';
 import { IUserInterface, Pick } from '../../IUserInterface';
 import { localize } from '../../localize';
-import { deploySubpathSetting, extensionPrefix, getFuncExtensionSetting, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../ProjectSettings';
+import { deploySubpathSetting, extensionPrefix, getGlobalFuncExtensionSetting, ProjectLanguage, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../ProjectSettings';
 import * as fsUtil from '../../utils/fs';
 import { confirmOverwriteFile } from '../../utils/fs';
 import { gitUtils } from '../../utils/gitUtils';
@@ -30,7 +30,7 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
     await fse.ensureDir(functionAppPath);
 
     if (!language) {
-        language = getFuncExtensionSetting(projectLanguageSetting, true /* ignoreWorkspaceSettings */);
+        language = getGlobalFuncExtensionSetting(projectLanguageSetting);
 
         if (!language) {
             // Only display 'supported' languages that can be debugged in VS Code
@@ -84,8 +84,8 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
         }
     }
 
-    const globalRuntimeSetting: string | undefined = getFuncExtensionSetting(projectRuntimeSetting, true /* ignoreWorkspaceSettings */);
-    const globalFilterSetting: string | undefined = getFuncExtensionSetting(templateFilterSetting, true /* ignoreWorkspaceSettings */);
+    const globalRuntimeSetting: string | undefined = getGlobalFuncExtensionSetting(projectRuntimeSetting);
+    const globalFilterSetting: string | undefined = getGlobalFuncExtensionSetting(templateFilterSetting);
     const runtime: string = globalRuntimeSetting ? globalRuntimeSetting : projectCreator.runtime;
     const templateFilter: string = globalFilterSetting ? globalFilterSetting : projectCreator.templateFilter;
     telemetryProperties.projectRuntime = runtime;

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import { ArgumentError } from '../errors';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { IUserInterface } from '../IUserInterface';
 import { localize } from '../localize';
-import { convertStringToRuntime, deploySubpathSetting, extensionPrefix, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
+import { convertStringToRuntime, deploySubpathSetting, extensionPrefix, getProjectLanguage, getProjectRuntime, ProjectLanguage, ProjectRuntime } from '../ProjectSettings';
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
@@ -32,8 +32,7 @@ import { VSCodeUI } from '../VSCodeUI';
 export async function deploy(telemetryProperties: TelemetryProperties, tree: AzureTreeDataProvider, outputChannel: vscode.OutputChannel, deployPath?: vscode.Uri | string, functionAppId?: string | {}, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     let deployFsPath: string;
     if (!deployPath) {
-        const defaultSubpath: string | undefined = getFuncExtensionSetting(deploySubpathSetting);
-        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), defaultSubpath);
+        deployFsPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectZipDeployFolder', 'Select the folder to zip and deploy'), deploySubpathSetting);
     } else if (deployPath instanceof vscode.Uri) {
         deployFsPath = deployPath.fsPath;
     } else {
@@ -59,7 +58,7 @@ export async function deploy(telemetryProperties: TelemetryProperties, tree: Azu
 
     const language: ProjectLanguage = await getProjectLanguage(deployFsPath, ui);
     telemetryProperties.projectLanguage = language;
-    const runtime: ProjectRuntime = await getProjectRuntime(language, ui);
+    const runtime: ProjectRuntime = await getProjectRuntime(language, deployFsPath, ui);
     telemetryProperties.projectRuntime = runtime;
 
     if (language === ProjectLanguage.Java) {

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -74,7 +74,7 @@ export class TemplateData {
         this._refreshTask = this.refreshTemplates(globalState);
     }
 
-    public async getTemplates(language: string, runtime: string = ProjectRuntime.one, templateFilter?: string, ui: IUserInterface = new VSCodeUI()): Promise<Template[]> {
+    public async getTemplates(projectPath: string, language: string, runtime: string = ProjectRuntime.one, templateFilter?: string, ui: IUserInterface = new VSCodeUI()): Promise<Template[]> {
         if (this._templatesMap[runtime] === undefined) {
             await this._refreshTask;
             if (this._templatesMap[runtime] === undefined) {
@@ -121,12 +121,12 @@ export class TemplateData {
                 if (result !== DialogResponses.yes) {
                     throw new UserCancelledError();
                 } else {
-                    language = await selectProjectLanguage(ui);
-                    runtime = await selectProjectRuntime(ui);
-                    templateFilter = await selectTemplateFilter(ui);
+                    language = await selectProjectLanguage(projectPath, ui);
+                    runtime = await selectProjectRuntime(projectPath, ui);
+                    templateFilter = await selectTemplateFilter(projectPath, ui);
 
                     // Try to get templates again
-                    return await this.getTemplates(language, runtime, templateFilter, ui);
+                    return await this.getTemplates(projectPath, language, runtime, templateFilter, ui);
                 }
             }
         }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -7,13 +7,19 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { IUserInterface, PickWithData } from '../IUserInterface';
 import { localize } from '../localize';
+import { getFuncExtensionSetting } from '../ProjectSettings';
 import * as fsUtils from './fs';
 
-export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string, subpath?: string): Promise<string> {
+export async function selectWorkspaceFolder(ui: IUserInterface, placeholder: string, subpathSettingKey?: string): Promise<string> {
     const browse: string = ':browse';
     let folder: PickWithData<string> | undefined;
     if (vscode.workspace.workspaceFolders) {
         const folderPicks: PickWithData<string>[] = vscode.workspace.workspaceFolders.map((f: vscode.WorkspaceFolder) => {
+            let subpath: string | undefined;
+            if (subpathSettingKey) {
+                subpath = getFuncExtensionSetting(subpathSettingKey, f.uri.fsPath);
+            }
+
             const fsPath: string = subpath ? path.join(f.uri.fsPath, subpath) : f.uri.fsPath;
             return new PickWithData('', fsPath);
         });

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -23,7 +23,7 @@ const templateData: TemplateData = new TemplateData();
 suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
     this.timeout(15 * 1000);
     // Ensure template data is initialized before any 'Create Function' test is run
-    await templateData.getTemplates('JavaScript');
+    await templateData.getTemplates('fakeProjectPath', 'JavaScript');
 });
 
 export abstract class FunctionTesterBase implements vscode.Disposable {

--- a/test/templateData.test.ts
+++ b/test/templateData.test.ts
@@ -12,17 +12,17 @@ suite('Template Data Tests', () => {
     const templateData: TemplateData = new TemplateData();
 
     test('Default JavaScript Templates Count', async () => {
-        const templates: Template[] = await templateData.getTemplates(ProjectLanguage.JavaScript, ProjectRuntime.one, TemplateFilter.Verified);
+        const templates: Template[] = await templateData.getTemplates('fakeProjectPath', ProjectLanguage.JavaScript, ProjectRuntime.one, TemplateFilter.Verified);
         assert.equal(templates.length, 8);
     });
 
     test('Default Java Templates Count', async () => {
-        const templates: Template[] = await templateData.getTemplates(ProjectLanguage.Java, ProjectRuntime.beta, TemplateFilter.Verified);
+        const templates: Template[] = await templateData.getTemplates('fakeProjectPath', ProjectLanguage.Java, ProjectRuntime.beta, TemplateFilter.Verified);
         assert.equal(templates.length, 4);
     });
 
     test('Default CSharp Templates Count', async () => {
-        const templates: Template[] = await templateData.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.beta, TemplateFilter.Verified);
+        const templates: Template[] = await templateData.getTemplates('fakeProjectPath', ProjectLanguage.CSharp, ProjectRuntime.beta, TemplateFilter.Verified);
         assert.equal(templates.length, 4);
     });
 });


### PR DESCRIPTION
Our project settings were being completely ignored in multi-root workspaces. Here's what I did to fix that:
1. Declare our project-based settings as 'resource' scope (If you use the default scope of 'window', then settings only apply at the user/workspace level - not the workspaceFolder level)
1. Pass the projectPath in when getting settings so that the specific folder takes precedent
1. Modify the workspace folder picker so that it dynamically gets the subpath for each folder (rather than getting the subpath once for the entire workspace)

Fixes #208 