### PR TITLE
 Improve error handling for child processes

### DIFF
--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -39,12 +39,13 @@ export namespace cpUtils {
             childProc.on('error', reject);
             childProc.on('close', (code: number) => {
                 if (code !== 0) {
+                    // We want to make sure the full error message is displayed to the user, not just the error code.
+                    // If outputChannel is defined, then we simply call 'outputChannel.show()' and throw a generic error telling the user to check the output window
+                    // If outputChannel is _not_ defined, then we include the command's output in the error itself and rely on AzureActionHandler to display it properly
                     if (outputChannel) {
                         outputChannel.show();
                         reject(new Error(localize('azFunc.commandErrorWithOutput', 'Failed to run "{0}" command. Check output window for more details.', command)));
                     } else {
-                        // Include as much information as possible in the error since we couldn't display it directly in the outputChannel
-                        // The AzureActionHandler will handle this multi-line error and display it in the outputChannel anyways
                         reject(new Error(localize('azFunc.commandError', 'Command "{0} {1}" failed with exit code "{2}":{3}{4}', command, formattedArgs, code, os.EOL, result)));
                     }
                 } else {

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -43,7 +43,8 @@ export namespace cpUtils {
                         outputChannel.show();
                         reject(new Error(localize('azFunc.commandErrorWithOutput', 'Failed to run "{0}" command. Check output window for more details.', command)));
                     } else {
-                        // Include all of the output in the error since we couldn't display it directly in the outputChannel
+                        // Include as much information as possible in the error since we couldn't display it directly in the outputChannel
+                        // The AzureActionHandler will handle this multi-line error and display it in the outputChannel anyways
                         reject(new Error(localize('azFunc.commandError', 'Command "{0} {1}" failed with exit code "{2}":{3}{4}', command, formattedArgs, code, os.EOL, result)));
                     }
                 } else {

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -12,12 +12,17 @@ export namespace cpUtils {
     export async function executeCommand(outputChannel: vscode.OutputChannel | undefined, workingDirectory: string | undefined, command: string, ...args: string[]): Promise<string> {
         let result: string = '';
         workingDirectory = workingDirectory || os.tmpdir();
+        const formattedArgs: string = args.join(' ');
         await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
             const options: cp.SpawnOptions = {
                 cwd: workingDirectory,
                 shell: true
             };
             const childProc: cp.ChildProcess = cp.spawn(command, args, options);
+
+            if (outputChannel) {
+                outputChannel.appendLine(localize('runningCommand', 'Running command: "{0} {1}"...', command, formattedArgs));
+            }
 
             childProc.stdout.on('data', (data: string | Buffer) => {
                 data = data.toString();
@@ -34,8 +39,17 @@ export namespace cpUtils {
             childProc.on('error', reject);
             childProc.on('close', (code: number) => {
                 if (code !== 0) {
-                    reject(new Error(localize('azFunc.commandError', 'Command "{0} {1}" failed with exit code "{2}".', command, args.toString(), code)));
+                    if (outputChannel) {
+                        outputChannel.show();
+                        reject(new Error(localize('azFunc.commandErrorWithOutput', 'Failed to run "{0}" command. Check output window for more details.', command)));
+                    } else {
+                        // Include all of the output in the error since we couldn't display it directly in the outputChannel
+                        reject(new Error(localize('azFunc.commandError', 'Command "{0} {1}" failed with exit code "{2}":{3}{4}', command, formattedArgs, code, os.EOL, result)));
+                    }
                 } else {
+                    if (outputChannel) {
+                        outputChannel.appendLine(localize('finishedRunningCommand', 'Finished running command: "{0} {1}".', command, formattedArgs));
+                    }
                     resolve();
                 }
             });


### PR DESCRIPTION
## Scenario 1

User tries to create a new C# project in a folder that already has a project (related to #184).

BEFORE (NOTE: I explicitly opened up the output channel for the screenshot. It was not opened for me):
![screen shot 2018-02-07 at 1 59 42 pm](https://user-images.githubusercontent.com/11282622/35943949-a203e290-0c0f-11e8-951d-9ec5c4b9473f.png)

AFTER:
![screen shot 2018-02-07 at 1 34 32 pm](https://user-images.githubusercontent.com/11282622/35943950-a3d7ebe8-0c0f-11e8-9d88-0088afd25ad9.png)

## Scenario 2

User tries to install .NET templates with no internet connection
> NOTE: This scenario covers the case where we don't pass 'outputChannel' to 'cpUtils.executeCommand'. (Aka situations where we  don't want the user to see output from the command - maybe because it's ugly and we print better output for them manually)

BEFORE:
![screen shot 2018-02-07 at 1 58 45 pm](https://user-images.githubusercontent.com/11282622/35944118-402ac3da-0c10-11e8-93df-77c3aba39f92.png)

AFTER:
![screen shot 2018-02-07 at 1 57 49 pm](https://user-images.githubusercontent.com/11282622/35944123-443c15d2-0c10-11e8-973c-29fd58b732b2.png)
