### PR TITLE
Make warnings consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -432,6 +432,11 @@
                         "type": "boolean",
                         "description": "%azFunc.showCoreToolsWarningDescription%",
                         "default": true
+                    },
+                    "azureFunctions.show64BitWarning": {
+                        "type": "boolean",
+                        "description": "%azFunc.show64BitWarningDescription%",
+                        "default": true
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,6 +27,7 @@
     "azFunc.installDotnetTemplates": "Install templates for the .NET CLI",
     "azFunc.uninstallDotnetTemplates": "Uninstall templates for the .NET CLI",
     "azFunc.showCoreToolsWarningDescription": "Show a warning if your installed version of Azure Functions Core Tools is out-of-date.",
+    "azFunc.show64BitWarningDescription": "Show a warning to install a 64-bit version of the Azure Functions Core Tools when you create a .NET Framework project.",
     "azFunc.startStreamingLogs": "Start Streaming Logs",
     "azFunc.stopStreamingLogs": "Stop Streaming Logs"
 }

--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -45,7 +45,12 @@ export enum TemplateFilter {
     Verified = 'Verified'
 }
 
-async function updateWorkspaceSetting(section: string, value: string, fsPath: string): Promise<void> {
+export async function updateGlobalSetting<T = string>(section: string, value: T): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = vscode.workspace.getConfiguration(extensionPrefix);
+    await projectConfiguration.update(section, value, vscode.ConfigurationTarget.Global);
+}
+
+async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string): Promise<void> {
     const projectConfiguration: WorkspaceConfiguration = vscode.workspace.getConfiguration(extensionPrefix, vscode.Uri.file(fsPath));
     await projectConfiguration.update(section, value);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,6 @@ import { restartFunctionApp } from './commands/restartFunctionApp';
 import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
 import { localize } from './localize';
-import { getFuncExtensionSetting } from './ProjectSettings';
 import { TemplateData } from './templates/TemplateData';
 import { FunctionAppProvider } from './tree/FunctionAppProvider';
 import { FunctionAppTreeItem } from './tree/FunctionAppTreeItem';
@@ -55,11 +54,10 @@ export function activate(context: vscode.ExtensionContext): void {
         const azureAccount: AzureAccount = azureAccountExtension.exports;
 
         const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions');
-        if (getFuncExtensionSetting<boolean>('showCoreToolsWarning')) {
-            // tslint:disable-next-line:no-floating-promises
-            functionRuntimeUtils.validateFunctionRuntime(outputChannel);
-        }
         context.subscriptions.push(outputChannel);
+
+        // tslint:disable-next-line:no-floating-promises
+        functionRuntimeUtils.validateFunctionRuntime(outputChannel);
 
         const tree: AzureTreeDataProvider = new AzureTreeDataProvider(new FunctionAppProvider(context.globalState, outputChannel), 'azureFunctions.loadMore');
         context.subscriptions.push(tree);

--- a/src/utils/functionRuntimeUtils.ts
+++ b/src/utils/functionRuntimeUtils.ts
@@ -7,37 +7,45 @@ import * as opn from 'opn';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { parseError } from 'vscode-azureextensionui';
-import { extensionPrefix } from '../../src/ProjectSettings';
+import { getFuncExtensionSetting, updateGlobalSetting } from '../../src/ProjectSettings';
 import { DialogResponses } from '../DialogResponses';
 import { localize } from '../localize';
 import { cpUtils } from './cpUtils';
 
 export namespace functionRuntimeUtils {
-
     const runtimePackage: string = 'azure-functions-core-tools';
 
     export async function validateFunctionRuntime(outputChannel: vscode.OutputChannel): Promise<void> {
-        try {
-            const localVersion: string | null = await getLocalFunctionRuntimeVersion();
-            if (localVersion === null) {
-                return;
-            }
-            const newestVersion: string | null = await getNewestFunctionRuntimeVersion(semver.major(localVersion));
-            if (newestVersion === null) {
-                return;
-            }
-            if (semver.gt(newestVersion, localVersion)) {
-                await promptDocumentationAction(
-                    localize(
+        const settingKey: string = 'showCoreToolsWarning';
+        if (getFuncExtensionSetting<boolean>(settingKey)) {
+            try {
+                const localVersion: string | null = await getLocalFunctionRuntimeVersion();
+                if (localVersion === null) {
+                    return;
+                }
+                const newestVersion: string | null = await getNewestFunctionRuntimeVersion(semver.major(localVersion));
+                if (newestVersion === null) {
+                    return;
+                }
+                if (semver.gt(newestVersion, localVersion)) {
+                    const message: string = localize(
                         'azFunc.outdatedFunctionRuntime',
                         'Your version of the Azure Functions Core Tools ({0}) does not match the latest ({1}). Please update for the best experience.',
                         localVersion,
                         newestVersion
-                    )
-                );
+                    );
+
+                    const result: vscode.MessageItem | undefined = await vscode.window.showWarningMessage(message, DialogResponses.seeMoreInfo, DialogResponses.dontWarnAgain);
+                    if (result === DialogResponses.seeMoreInfo) {
+                        // tslint:disable-next-line:no-unsafe-any
+                        opn('https://aka.ms/azFuncOutdated');
+                    } else if (result === DialogResponses.dontWarnAgain) {
+                        await updateGlobalSetting(settingKey, false);
+                    }
+                }
+            } catch (error) {
+                outputChannel.appendLine(`Error occurred when checking the version of 'Azure Functions Core Tools': ${parseError(error).message}`);
             }
-        } catch (error) {
-            outputChannel.appendLine(`Error occurred when checking the version of 'Azure Functions Core Tools': ${parseError(error).message}`);
         }
     }
 
@@ -64,20 +72,6 @@ export namespace functionRuntimeUtils {
                 return semver.valid((await cpUtils.executeCommand(undefined, undefined, 'npm', 'view', runtimePackage, 'dist-tags.core')).trim());
             default:
                 return null;
-        }
-    }
-
-    async function promptDocumentationAction(message: string): Promise<void> {
-        const result: vscode.MessageItem | undefined = await vscode.window.showWarningMessage(message, DialogResponses.seeMoreInfo, DialogResponses.dontWarnAgain);
-        if (result === DialogResponses.seeMoreInfo) {
-            // tslint:disable-next-line:no-unsafe-any
-            opn('https://aka.ms/azFuncOutdated');
-        } else if (result === DialogResponses.dontWarnAgain) {
-            await vscode.workspace.getConfiguration(extensionPrefix).update(
-                'showCoreToolsWarning',
-                false /* value */,
-                true /* User Setting */
-            );
         }
     }
 }


### PR DESCRIPTION
For the 64 bit warning, it now opens the link directly with a 'See more info' instead of having to copy the link. There's also a 'Don't warn again' option