### PR TITLE
add maven prerequisite description

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 * [VS Code Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug)
 * [JDK 1.8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * [Maven 3.0+](https://maven.apache.org/)
+  > NOTE: Once Maven is downloaded, you must ensure that Maven is in your PATH environment variable. You can check this by running: `mvn -v`.
 
 ## Contributing
 There are a couple of ways you can contribute to this repo:


### PR DESCRIPTION
I noticed that a lot of user encountered the error that mvn is not in path. So I add some description in the README.

I'm also thinking that if we could direct user to the prerequisite page when we detect mvn is not in path. Let's discuss this in #215 for more detail.