### PR TITLE
Update functions sdk reference so that C# works on all OS's

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -6,8 +6,9 @@
 import * as fse from 'fs-extra';
 import * as opn from 'opn';
 import * as path from 'path';
-import { OutputChannel } from 'vscode';
+import { SemVer } from 'semver';
 import * as vscode from 'vscode';
+import { OutputChannel } from 'vscode';
 import { DialogResponses } from '../../DialogResponses';
 import { IUserInterface } from '../../IUserInterface';
 import { localize } from "../../localize";
@@ -42,6 +43,9 @@ export class CSharpProjectCreator implements IProjectCreator {
         const csProjName: string = `${path.basename(functionAppPath)}.csproj`;
         const csprojPath: string = path.join(functionAppPath, csProjName);
         const csprojContents: string = (await fse.readFile(csprojPath)).toString();
+
+        await this.validateFuncSdkVersion(csprojPath, csprojContents);
+
         const matches: RegExpMatchArray | null = csprojContents.match(/<TargetFramework>(.*)<\/TargetFramework>/);
         if (matches === null || matches.length < 1) {
             throw new Error(localize('unrecognizedTargetFramework', 'Unrecognized target framework in project file "{0}".', csProjName));
@@ -119,5 +123,29 @@ export class CSharpProjectCreator implements IProjectCreator {
 
     public getRecommendedExtensions(): string[] {
         return ['ms-vscode.csharp'];
+    }
+
+    /**
+     * Validates the project has the minimum Functions SDK version that works on all OS's
+     * See this bug for more info: https://github.com/Microsoft/vscode-azurefunctions/issues/164
+     */
+    private async validateFuncSdkVersion(csprojPath: string, csprojContents: string): Promise<void> {
+        try {
+            const minVersion: string = '1.0.8';
+            const lineMatches: RegExpMatchArray | null = /^.*Microsoft\.NET\.Sdk\.Functions.*$/gm.exec(csprojContents);
+            if (lineMatches !== null && lineMatches.length > 0) {
+                const line: string = lineMatches[0];
+                const versionMatches: RegExpMatchArray | null = /Version="(.*)"/g.exec(line);
+                if (versionMatches !== null && versionMatches.length > 1) {
+                    const version: SemVer = new SemVer(versionMatches[1]);
+                    if (version.compare(minVersion) < 0) {
+                        const newContents: string = csprojContents.replace(line, line.replace(version.raw, minVersion));
+                        await fse.writeFile(csprojPath, newContents);
+                    }
+                }
+            }
+        } catch (err) {
+            // ignore errors and assume the version of the templates installed on the user's machine works for them
+        }
     }
 }

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -53,7 +53,7 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
             projectCreator = new JavaScriptProjectCreator();
             break;
         case ProjectLanguage.CSharp:
-            projectCreator = new CSharpProjectCreator(outputChannel, ui);
+            projectCreator = new CSharpProjectCreator(outputChannel, ui, telemetryProperties);
             break;
         case ProjectLanguage.CSharpScript:
             projectCreator = new CSharpScriptProjectCreator();

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -20,8 +20,8 @@ import * as fsUtil from './fs';
 export namespace dotnetUtils {
     const projectPackageId: string = 'microsoft.azurefunctions.projecttemplates';
     const functionsPackageId: string = 'azure.functions.templates';
-    const betaTemplateVersion: string = '2.0.0-beta-10153';
-    const v1TemplateVersion: string = '1.0.3.10152';
+    const betaTemplateVersion: string = '2.0.0-beta-10167';
+    const v1TemplateVersion: string = '1.0.3.10168';
 
     function getPackagesCsproj(version: string): string {
         // tslint:disable:no-multiline-string


### PR DESCRIPTION
And bump the functions templates versions to the latest (We won't have to hard-code the versions anymore once [this](https://github.com/Microsoft/vscode-azurefunctions/issues/179) is fixed)

Fixes #164