### PR TITLE
Update versions of common packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.17.0"
+        "vscode": "^1.20.0"
     },
     "repository": {
         "type": "git",
@@ -224,13 +224,18 @@
             "view/item/context": [
                 {
                     "command": "azureFunctions.createFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureSubscription",
+                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "1@1"
                 },
                 {
-                    "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureSubscription",
+                    "command": "azureFunctions.openInPortal",
+                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
                     "group": "2@1"
+                },
+                {
+                    "command": "azureFunctions.refresh",
+                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
+                    "group": "3@1"
                 },
                 {
                     "command": "azureFunctions.openInPortal",
@@ -480,8 +485,8 @@
         "ps-node": "^0.1.6",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "~0.8.5",
-        "vscode-azureextensionui": "~0.5.1",
+        "vscode-azureappservice": "~0.9.0",
+        "vscode-azureextensionui": "~0.7.1",
         "vscode-azurekudu": "~0.1.4",
         "vscode-extension-telemetry": "^0.0.10",
         "vscode-nls": "^2.0.2",

--- a/src/commands/createFunctionApp.ts
+++ b/src/commands/createFunctionApp.ts
@@ -17,5 +17,5 @@ export async function createFunctionApp(tree: AzureTreeDataProvider, arg?: IAzur
     }
 
     const funcAppNode: IAzureNode = await node.createChild();
-    return funcAppNode.treeItem.id;
+    return funcAppNode.id;
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -22,7 +22,6 @@ import { convertStringToRuntime, deploySubpathSetting, extensionPrefix, getProje
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
-import * as azUtils from '../utils/azure';
 import { cpUtils } from '../utils/cpUtils';
 import { mavenUtils } from '../utils/mavenUtils';
 import { nodeUtils } from '../utils/nodeUtils';
@@ -43,9 +42,7 @@ export async function deploy(telemetryProperties: TelemetryProperties, tree: Azu
     if (!functionAppId || typeof functionAppId !== 'string') {
         node = <IAzureParentNode<FunctionAppTreeItem>>await tree.showNodePicker(FunctionAppTreeItem.contextValue);
     } else {
-        const subscriptionId: string = azUtils.getSubscriptionFromId(functionAppId);
-        const subscriptionNode: IAzureParentNode = await nodeUtils.getSubscriptionNode(tree, subscriptionId);
-        const functionAppNode: IAzureNode | undefined = (await subscriptionNode.getCachedChildren()).find((n: IAzureNode) => n.treeItem.id === functionAppId);
+        const functionAppNode: IAzureNode | undefined = await tree.findNode(functionAppId);
         if (functionAppNode) {
             node = <IAzureParentNode<FunctionAppTreeItem>>functionAppNode;
         } else {

--- a/src/tree/FunctionTreeItem.ts
+++ b/src/tree/FunctionTreeItem.ts
@@ -26,25 +26,23 @@ export class FunctionTreeItem implements ILogStreamTreeItem {
     public logStreamOutputChannel: vscode.OutputChannel | undefined;
 
     private readonly _name: string;
-    private readonly _parentId: string;
     private readonly _outputChannel: OutputChannel;
     private _triggerUrl: string;
 
-    public constructor(siteWrapper: SiteWrapper, func: FunctionEnvelope, parentId: string, outputChannel: OutputChannel) {
+    public constructor(siteWrapper: SiteWrapper, func: FunctionEnvelope, outputChannel: OutputChannel) {
         if (!func.name) {
             throw new ArgumentError(func);
         }
 
         this.siteWrapper = siteWrapper;
         this._name = func.name;
-        this._parentId = parentId;
         this._outputChannel = outputChannel;
 
         this.config = new FunctionConfig(func.config);
     }
 
     public get id(): string {
-        return `${this._parentId}/${this._name}`;
+        return this._name;
     }
 
     public get label(): string {

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -27,7 +27,7 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
     }
 
     public get id(): string {
-        return `${this._siteWrapper.id}/functions`;
+        return 'functions';
     }
 
     public get iconPath(): nodeUtils.IThemedIconPath {
@@ -42,7 +42,7 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
         const client: KuduClient = await nodeUtils.getKuduClient(node, this._siteWrapper);
         const funcs: FunctionEnvelope[] = await client.functionModel.list();
         return await Promise.all(funcs.map(async (fe: FunctionEnvelope) => {
-            const treeItem: FunctionTreeItem = new FunctionTreeItem(this._siteWrapper, fe, this.id, this._outputChannel);
+            const treeItem: FunctionTreeItem = new FunctionTreeItem(this._siteWrapper, fe, this._outputChannel);
             if (treeItem.config.isHttpTrigger) {
                 // We want to cache the trigger url so that it is instantaneously copied when the user performs the copy action
                 // (Otherwise there might be a second or two delay which could lead to confusion)


### PR DESCRIPTION
There are several benefits here:
1. Refreshing a node's label doesn't collapse a node anymore
1. id field is now optional and mostly handled for us
1. We can leverage tree.findNode()
1. We can add an 'openInPortal' action to the subscription