### PR TITLE
Remove '.vscode' folder from default gitignore

### DIFF
--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -17,7 +17,6 @@ csx
 .vs
 edge
 Publish
-.vscode
 
 *.user
 *.suo


### PR DESCRIPTION
We add a gitignore to each new project and we originally copied this from what 'func init' put down. However, we definitely want users to commit their vscode workspace settings, launch config, etc.