### PR TITLE
Change 'Create function api' to accept object for function settings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,12 +34,12 @@ await vscode.commands.executeCommand('azureFunctions.createNewProject', projectP
 |projectPath|string|Absolute file path that contains your project.|
 |templateId|string|The id of the template you want to create.|
 |functionName|string|The name of the function to be created.|
-|functionSettings|...string[]|Any settings unique to a template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
+|functionSettings|object|Any settings unique to a template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
 
 ### Example Usage
 
 ```typescript
-await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, 'HttpTrigger-JavaScript', 'HttpTrigger1', 'Anonymous');
+await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, 'HttpTrigger-JavaScript', 'HttpTrigger1', { authLevel: 'Anonymous' });
 ```
 
 ## Create Function App

--- a/docs/api.md
+++ b/docs/api.md
@@ -34,7 +34,7 @@ await vscode.commands.executeCommand('azureFunctions.createNewProject', projectP
 |projectPath|string|Absolute file path that contains your project.|
 |templateId|string|The id of the template you want to create.|
 |functionName|string|The name of the function to be created.|
-|functionSettings|object|Any settings unique to a template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
+|functionSettings|{ [key: string]: string; }|Any settings unique to a template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
 
 ### Example Usage
 

--- a/src/commands/createFunction/CSharpFunctionCreator.ts
+++ b/src/commands/createFunction/CSharpFunctionCreator.ts
@@ -29,7 +29,7 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
         this._ui = ui;
     }
 
-    public async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: {}): Promise<void> {
+    public async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: { [key: string]: string | undefined; }): Promise<void> {
         if (!functionName) {
             const defaultFunctionName: string | undefined = await fsUtil.getUniqueFsPath(this._functionAppPath, removeLanguageFromId(this._template.id), '.cs');
             const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
@@ -39,9 +39,8 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
             this._functionName = functionName;
         }
 
-        const namespaceKey: string = 'namespace';
-        if (functionSettings[namespaceKey]) {
-            this._namespace = <string>functionSettings[namespaceKey];
+        if (functionSettings.namespace !== undefined) {
+            this._namespace = functionSettings.namespace;
         } else {
             const namespacePlaceHolder: string = localize('azFunc.namespacePlaceHolder', 'Namespace');
             const namespacePrompt: string = localize('azFunc.namespacePrompt', 'Provide a namespace');

--- a/src/commands/createFunction/CSharpFunctionCreator.ts
+++ b/src/commands/createFunction/CSharpFunctionCreator.ts
@@ -29,7 +29,7 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
         this._ui = ui;
     }
 
-    public async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: string[]): Promise<void> {
+    public async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: {}): Promise<void> {
         if (!functionName) {
             const defaultFunctionName: string | undefined = await fsUtil.getUniqueFsPath(this._functionAppPath, removeLanguageFromId(this._template.id), '.cs');
             const placeHolder: string = localize('azFunc.funcNamePlaceholder', 'Function name');
@@ -39,8 +39,9 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
             this._functionName = functionName;
         }
 
-        if (functionSettings.length > 0) {
-            this._namespace = <string>functionSettings.shift();
+        const namespaceKey: string = 'namespace';
+        if (functionSettings[namespaceKey]) {
+            this._namespace = <string>functionSettings[namespaceKey];
         } else {
             const namespacePlaceHolder: string = localize('azFunc.namespacePlaceHolder', 'Namespace');
             const namespacePrompt: string = localize('azFunc.namespacePrompt', 'Provide a namespace');
@@ -55,9 +56,9 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
         for (const key of Object.keys(userSettings)) {
             let parameter: string = key.charAt(0).toUpperCase() + key.slice(1);
             // the parameters for dotnet templates are not consistent. Hence, we have to special-case a few of them:
-            if (parameter === 'AuthLevel') {
+            if (parameter.toLowerCase() === 'authlevel') {
                 parameter = 'AccessRights';
-            } else if (parameter === 'QueueName') {
+            } else if (parameter.toLowerCase() === 'queuename') {
                 parameter = 'Path';
             }
 

--- a/src/commands/createFunction/FunctionCreatorBase.ts
+++ b/src/commands/createFunction/FunctionCreatorBase.ts
@@ -20,6 +20,6 @@ export abstract class FunctionCreatorBase {
      * Prompt for any settings that are specific to this creator
      * This includes the function name (Since the name could have different restrictions for different languages)
      */
-    public abstract async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: {}): Promise<void>;
+    public abstract async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: { [key: string]: string | undefined; }): Promise<void>;
     public abstract async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined>;
 }

--- a/src/commands/createFunction/FunctionCreatorBase.ts
+++ b/src/commands/createFunction/FunctionCreatorBase.ts
@@ -20,6 +20,6 @@ export abstract class FunctionCreatorBase {
      * Prompt for any settings that are specific to this creator
      * This includes the function name (Since the name could have different restrictions for different languages)
      */
-    public abstract async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: string[]): Promise<void>;
+    public abstract async promptForSettings(ui: IUserInterface, functionName: string | undefined, functionSettings: {}): Promise<void>;
     public abstract async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined>;
 }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -86,7 +86,12 @@ export async function createFunction(
     functionAppPath?: string,
     templateId?: string,
     functionName?: string,
-    ...functionSettings: (string)[]): Promise<void> {
+    caseSensitiveFunctionSettings?: {}): Promise<void> {
+
+    const functionSettings: {} = {};
+    if (caseSensitiveFunctionSettings) {
+        Object.keys(caseSensitiveFunctionSettings).forEach((key: string) => functionSettings[key.toLowerCase()] = <string>caseSensitiveFunctionSettings[key]);
+    }
 
     if (functionAppPath === undefined) {
         const folderPlaceholder: string = localize('azFunc.selectFunctionAppFolderExisting', 'Select the folder containing your function app');
@@ -146,8 +151,8 @@ export async function createFunction(
         const setting: ConfigSetting | undefined = await templateData.getSetting(runtime, template.functionConfig.inBindingType, settingName);
         if (setting) {
             let settingValue: string | undefined;
-            if (functionSettings.length > 0) {
-                settingValue = functionSettings.shift();
+            if (functionSettings[settingName.toLowerCase()]) {
+                settingValue = <string>functionSettings[settingName.toLowerCase()];
             } else {
                 const defaultValue: string | undefined = template.functionConfig.inBinding[settingName];
                 settingValue = await promptForSetting(ui, localAppSettings, setting, defaultValue);

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -86,11 +86,11 @@ export async function createFunction(
     functionAppPath?: string,
     templateId?: string,
     functionName?: string,
-    caseSensitiveFunctionSettings?: {}): Promise<void> {
+    caseSensitiveFunctionSettings?: { [key: string]: string | undefined; }): Promise<void> {
 
-    const functionSettings: {} = {};
+    const functionSettings: { [key: string]: string | undefined; } = {};
     if (caseSensitiveFunctionSettings) {
-        Object.keys(caseSensitiveFunctionSettings).forEach((key: string) => functionSettings[key.toLowerCase()] = <string>caseSensitiveFunctionSettings[key]);
+        Object.keys(caseSensitiveFunctionSettings).forEach((key: string) => functionSettings[key.toLowerCase()] = caseSensitiveFunctionSettings[key]);
     }
 
     if (functionAppPath === undefined) {
@@ -151,8 +151,8 @@ export async function createFunction(
         const setting: ConfigSetting | undefined = await templateData.getSetting(runtime, template.functionConfig.inBindingType, settingName);
         if (setting) {
             let settingValue: string | undefined;
-            if (functionSettings[settingName.toLowerCase()]) {
-                settingValue = <string>functionSettings[settingName.toLowerCase()];
+            if (functionSettings[settingName.toLowerCase()] !== undefined) {
+                settingValue = functionSettings[settingName.toLowerCase()];
             } else {
                 const defaultValue: string | undefined = template.functionConfig.inBinding[settingName];
                 settingValue = await promptForSetting(ui, localAppSettings, setting, defaultValue);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,9 +71,9 @@ export function activate(context: vscode.ExtensionContext): void {
         actionHandler.registerCommand('azureFunctions.pickProcess', async () => await pickFuncProcess());
         actionHandler.registerCommand('azureFunctions.loadMore', async (node: IAzureNode) => await tree.loadMore(node));
         actionHandler.registerCommand('azureFunctions.openInPortal', async (node?: IAzureNode<FunctionAppTreeItem>) => await openInPortal(tree, node));
-        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createFunction', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, templateId?: string, functionName?: string, ...functionSettings: string[]) => {
+        actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createFunction', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, templateId?: string, functionName?: string, functionSettings?: {}) => {
             const templateData: TemplateData = await templateDataTask;
-            await createFunction(properties, outputChannel, azureAccount, templateData, new VSCodeUI(), functionAppPath, templateId, functionName, ...functionSettings);
+            await createFunction(properties, outputChannel, azureAccount, templateData, new VSCodeUI(), functionAppPath, templateId, functionName, functionSettings);
         });
         actionHandler.registerCommandWithCustomTelemetry('azureFunctions.createNewProject', async (properties: TelemetryProperties, _measurements: TelemetryMeasurements, functionAppPath?: string, language?: string, openFolder?: boolean | undefined) => await createNewProject(properties, outputChannel, functionAppPath, language, openFolder));
         actionHandler.registerCommand('azureFunctions.createFunctionApp', async (arg?: IAzureParentNode | string) => await createFunctionApp(tree, arg));

--- a/test/createFunction/createFunction.C#.test.ts
+++ b/test/createFunction/createFunction.C#.test.ts
@@ -88,7 +88,7 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
         const functionName: string = 'createFunctionApi';
         const namespace: string = 'Company.Function';
         const authLevel: string = 'Anonymous';
-        await vscode.commands.executeCommand('azureFunctions.createFunction', csTester.funcPortalTestFolder, templateId, functionName, namespace, authLevel);
+        await vscode.commands.executeCommand('azureFunctions.createFunction', csTester.funcPortalTestFolder, templateId, functionName, { namespace, authLevel });
         await csTester.validateFunction(csTester.funcPortalTestFolder, functionName);
     });
 });

--- a/test/createFunction/createFunction.JavaScript.test.ts
+++ b/test/createFunction/createFunction.JavaScript.test.ts
@@ -155,7 +155,8 @@ suite('Create JavaScript Function Tests', async function (this: ISuiteCallbackCo
         const templateId: string = 'HttpTrigger-JavaScript';
         const functionName: string = 'createFunctionApi';
         const authLevel: string = 'Anonymous';
-        await vscode.commands.executeCommand('azureFunctions.createFunction', jsTester.funcPortalTestFolder, templateId, functionName, authLevel);
+        // Intentionally testing weird casing for authLevel
+        await vscode.commands.executeCommand('azureFunctions.createFunction', jsTester.funcPortalTestFolder, templateId, functionName, { aUtHLevel: authLevel });
         await jsTester.validateFunction(jsTester.funcPortalTestFolder, functionName);
     });
 });


### PR DESCRIPTION
This is better in a few ways:
1. It eliminates the need for the settings to always be in the same order
1. It allows us to change the function signature in a backwards compatible format in the future

This is a breaking change and even though the api is still in preview, I wanted to change it before any partner team (that we know of) actually starts using the api