### PR TITLE
Add pickFuncProcessTimeout setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -490,9 +490,9 @@
                         "description": "%azFunc.showProjectWarningDescription%",
                         "default": true
                     },
-                    "azureFunctions.pickFuncProcessTimeout": {
+                    "azureFunctions.pickProcessTimeout": {
                         "type": "integer",
-                        "description": "%azFunc.pickFuncProcessTimeoutDescription%",
+                        "description": "%azFunc.pickProcessTimeoutDescription%",
                         "default": 60
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -489,6 +489,11 @@
                         "type": "boolean",
                         "description": "%azFunc.showProjectWarningDescription%",
                         "default": true
+                    },
+                    "azureFunctions.pickFuncProcessTimeout": {
+                        "type": "integer",
+                        "description": "%azFunc.pickFuncProcessTimeoutDescription%",
+                        "default": 60
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,5 +35,5 @@
     "azFunc.stopStreamingLogs": "Stop Streaming Logs",
     "azFunc.enableRemoteDebugging": "Enable remote debugging, an experimental feature that only supports Java-based Functions Apps.",
     "azFunc.deleteProxy": "Delete Proxy",
-    "azFunc.pickFuncProcessTimeoutDescription": "The timeout (in seconds) to be used when searching for the Azure Functions host process. Since a build is required every time you F5, you may need to adjust this based on how long your build takes."
+    "azFunc.pickProcessTimeoutDescription": "The timeout (in seconds) to be used when searching for the Azure Functions host process. Since a build is required every time you F5, you may need to adjust this based on how long your build takes."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,5 +34,6 @@
     "azFunc.startStreamingLogs": "Start Streaming Logs",
     "azFunc.stopStreamingLogs": "Stop Streaming Logs",
     "azFunc.enableRemoteDebugging": "Enable remote debugging, an experimental feature that only supports Java-based Functions Apps.",
-    "azFunc.deleteProxy": "Delete Proxy"
+    "azFunc.deleteProxy": "Delete Proxy",
+    "azFunc.pickFuncProcessTimeoutDescription": "The timeout (in seconds) to be used when searching for the Azure Functions host process. Since a build is required every time you F5, you may need to adjust this based on how long your build takes."
 }

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -22,7 +22,7 @@ export async function pickFuncProcess(): Promise<string | undefined> {
     // Start (or restart) functions host (which will also trigger a build)
     await vscode.commands.executeCommand('workbench.action.tasks.runTask', funcHostTaskId);
 
-    const settingKey: string = 'pickFuncProcessTimeout';
+    const settingKey: string = 'pickProcessTimeout';
     const settingValue: number | undefined = getFuncExtensionSetting<number>(settingKey);
     const timeoutInSeconds: number = Number(settingValue);
     if (isNaN(timeoutInSeconds)) {


### PR DESCRIPTION
We continue to see this timeout error in our telemetry. We'll never get the error percentage completely down to zero since the host won't start if the user had build errors, but hopefully this will mitigate the problem for some of our users. For example:
1. If they have a long build, they can increase the timeout
1. If they have a short build, they can decrease the timeout and we'll fail faster in the case of build failures