### PR TITLE
Allow runtime in createNewProject api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,13 +16,14 @@ Commands:
 |Name|Type|Description|
 |---|---|---|
 |projectPath|string|Absolute file path that will contain your new project. If the path doesn't exist, it will be created.|
-|language|string|The currently supported languages are 'JavaScript' and 'Java'.|
+|language|string|The currently supported languages are 'JavaScript', 'C#', and 'Java'.|
+|runtime|string|The currently supported runtimes are "~1" and "beta".|
 |openFolder|boolean|(Defaulted to true) Represents whether or not to open the project folder after it has been created. If true, the extension host may be restarted when the folder is opened.|
 
 ### Example Usage
 
 ```typescript
-await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', false /* openFolder */);
+await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', "~1", false /* openFolder */);
 ```
 
 ## Create Local Function

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -30,7 +30,7 @@ async function validateIsFunctionApp(telemetryProperties: TelemetryProperties, o
         const message: string = localize('azFunc.notFunctionApp', 'The selected folder is not a function app project. Initialize Project?');
         const result: vscode.MessageItem | undefined = await vscode.window.showWarningMessage(message, DialogResponses.yes, DialogResponses.skipForNow, DialogResponses.cancel);
         if (result === DialogResponses.yes) {
-            await createNewProject(telemetryProperties, outputChannel, functionAppPath, undefined, false, ui);
+            await createNewProject(telemetryProperties, outputChannel, functionAppPath, undefined, undefined, false, ui);
         } else if (result !== DialogResponses.skipForNow) {
             throw new UserCancelledError();
         }

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -21,7 +21,7 @@ import { JavaProjectCreator } from './JavaProjectCreator';
 import { JavaScriptProjectCreator } from './JavaScriptProjectCreator';
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
-export async function createNewProject(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, language?: string, openFolder: boolean = true, ui: IUserInterface = new VSCodeUI()): Promise<void> {
+export async function createNewProject(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, language?: string, runtime?: string, openFolder: boolean = true, ui: IUserInterface = new VSCodeUI()): Promise<void> {
     if (functionAppPath === undefined) {
         functionAppPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
     }
@@ -45,7 +45,7 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
     const projectCreator: ProjectCreatorBase = getProjectCreator(language, functionAppPath, outputChannel, ui, telemetryProperties);
     await projectCreator.addNonVSCodeFiles();
 
-    await initProjectForVSCode(telemetryProperties, outputChannel, functionAppPath, language, ui, projectCreator);
+    await initProjectForVSCode(telemetryProperties, outputChannel, functionAppPath, language, runtime, ui, projectCreator);
 
     if (await gitUtils.isGitInstalled(functionAppPath)) {
         await gitUtils.gitInit(outputChannel, functionAppPath);

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -18,7 +18,7 @@ import { getProjectCreator } from './createNewProject';
 import { detectProjectLanguage } from './detectProjectLanguage';
 import { ProjectCreatorBase } from './IProjectCreator';
 
-export async function initProjectForVSCode(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, language?: string, ui: IUserInterface = new VSCodeUI(), projectCreator?: ProjectCreatorBase): Promise<ProjectCreatorBase> {
+export async function initProjectForVSCode(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, functionAppPath?: string, language?: string, runtime?: string, ui: IUserInterface = new VSCodeUI(), projectCreator?: ProjectCreatorBase): Promise<ProjectCreatorBase> {
     if (functionAppPath === undefined) {
         functionAppPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder to initialize for use with VS Code'));
     }
@@ -37,13 +37,14 @@ export async function initProjectForVSCode(telemetryProperties: TelemetryPropert
         projectCreator = getProjectCreator(language, functionAppPath, outputChannel, ui, telemetryProperties);
     }
 
-    const globalRuntimeSetting: string | undefined = getGlobalFuncExtensionSetting(projectRuntimeSetting);
-    const globalFilterSetting: string | undefined = getGlobalFuncExtensionSetting(templateFilterSetting);
-    const runtime: string = globalRuntimeSetting ? globalRuntimeSetting : await projectCreator.getRuntime();
+    // tslint:disable-next-line:strict-boolean-expressions
+    runtime = runtime || getGlobalFuncExtensionSetting(projectRuntimeSetting) || await projectCreator.getRuntime();
     outputChannel.appendLine(localize('usingRuntime', 'Using "{0}" as the project runtime...', runtime));
-    const templateFilter: string = globalFilterSetting ? globalFilterSetting : projectCreator.templateFilter;
-    outputChannel.appendLine(localize('usingTemplateFilter', 'Using "{0}" as the project templateFilter...', templateFilter));
     telemetryProperties.projectRuntime = runtime;
+
+    // tslint:disable-next-line:strict-boolean-expressions
+    const templateFilter: string = getGlobalFuncExtensionSetting(templateFilterSetting) || projectCreator.templateFilter;
+    outputChannel.appendLine(localize('usingTemplateFilter', 'Using "{0}" as the project templateFilter...', templateFilter));
     telemetryProperties.templateFilter = templateFilter;
 
     const vscodePath: string = path.join(functionAppPath, '.vscode');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ export function activate(context: vscode.ExtensionContext): void {
             const templateData: TemplateData = await templateDataTask;
             await createFunction(this.properties, outputChannel, azureAccount, templateData, new VSCodeUI(), functionAppPath, templateId, functionName, functionSettings);
         });
-        actionHandler.registerCommand('azureFunctions.createNewProject', async function (this: IActionContext, functionAppPath?: string, language?: string, openFolder?: boolean | undefined): Promise<void> { await createNewProject(this.properties, outputChannel, functionAppPath, language, openFolder); });
+        actionHandler.registerCommand('azureFunctions.createNewProject', async function (this: IActionContext, functionAppPath?: string, language?: string, runtime?: string, openFolder?: boolean | undefined): Promise<void> { await createNewProject(this.properties, outputChannel, functionAppPath, language, runtime, openFolder); });
         actionHandler.registerCommand('azureFunctions.initProjectForVSCode', async function (this: IActionContext): Promise<void> { await initProjectForVSCode(this.properties, outputChannel); });
         actionHandler.registerCommand('azureFunctions.createFunctionApp', async (arg?: IAzureParentNode | string) => await createFunctionApp(tree, arg));
         actionHandler.registerCommand('azureFunctions.startFunctionApp', async (node?: IAzureNode<FunctionAppTreeItem>) => await startFunctionApp(tree, node));

--- a/test/createFunction/createFunction.C#Script.test.ts
+++ b/test/createFunction/createFunction.C#Script.test.ts
@@ -7,12 +7,13 @@ import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { ProjectLanguage, ProjectRuntime } from '../../src/ProjectSettings';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpScriptFunctionTester extends FunctionTesterBase {
     protected _language: ProjectLanguage = ProjectLanguage.CSharpScript;
-    protected _runtime: ProjectRuntime = ProjectRuntime.beta;
+    protected _runtime: ProjectRuntime = ProjectRuntime.one;
 
     public async validateFunction(testFolder: string, funcName: string): Promise<void> {
         const functionPath: string = path.join(testFolder, funcName);
@@ -40,5 +41,13 @@ suite('Create C# Script Function Tests', async () => {
             httpTrigger,
             undefined // Use default Authorization level
         );
+    });
+
+    test('createFunction API', async () => {
+        // Intentionally testing IoTHub trigger since a partner team plans to use that
+        const templateId: string = 'IoTHubTrigger-CSharp';
+        const functionName: string = 'createFunctionApi';
+        await vscode.commands.executeCommand('azureFunctions.createFunction', tester.funcPortalTestFolder, templateId, functionName, { connection: 'test_EVENTHUB', path: 'sample-workitems', consumerGroup: '$Default' });
+        await tester.validateFunction(tester.funcPortalTestFolder, functionName);
     });
 });

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -127,7 +127,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
 
     test('createNewProject API', async () => {
         const projectPath: string = path.join(testFolderPath, 'createNewProjectApi');
-        await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', false /* openFolder */);
+        await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', '~1', false /* openFolder */);
         await validateVSCodeProjectFiles(projectPath);
     });
 
@@ -143,7 +143,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         }
 
         const ui: TestUI = new TestUI(inputs);
-        await createNewProject({}, outputChannel, undefined, previewLanguage ? language : undefined, false, ui);
+        await createNewProject({}, outputChannel, undefined, previewLanguage ? language : undefined, undefined, false, ui);
         assert.equal(inputs.length, 0, 'Not all inputs were used.');
 
         assert.equal(await fse.pathExists(path.join(projectPath, '.gitignore')), true, '.gitignore does not exist');

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -145,7 +145,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         }
 
         const ui: TestUI = new TestUI(inputs);
-        await initProjectForVSCode({}, outputChannel, undefined, undefined, ui);
+        await initProjectForVSCode({}, outputChannel, undefined, undefined, undefined, ui);
         assert.equal(inputs.length, 0, 'Not all inputs were used.');
     }
 });


### PR DESCRIPTION
Currently the IoT trigger is only available for C#Script and runtime "~1", so our partner team needs to pass in the runtime. Ideally it was available for C# and runtime "beta" that works on all OS's, but in any case we should let consumers of the api pass in the runtime they want.

Fixes #249 