### PR TITLE
Allow zipIgnore pattern to be an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -434,7 +434,10 @@
                     },
                     "azureFunctions.zipIgnorePattern": {
                         "scope": "resource",
-                        "type": "string",
+                        "type": [
+                            "string",
+                            "array"
+                        ],
                         "default": "",
                         "description": "Defines which files in the workspace to ignore for Zip deploy. This applies to Zip deploy only, has no effect on other deployment methods."
                     },


### PR DESCRIPTION

Requires this PR to get the resource scope to fully work: https://github.com/Microsoft/vscode-azuretools/pull/98