### PR TITLE
Activate extension if workspace contains function files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
         "onCommand:azureFunctions.startStreamingLogs",
         "onCommand:azureFunctions.stopStreamingLogs",
         "onCommand:azureFunctions.deleteProxy",
+        "workspaceContains:local.settings.json",
+        "workspaceContains:host.json",
         "onView:azureFunctionsExplorer"
     ],
     "main": "./out/src/extension",


### PR DESCRIPTION
Related to the [recent work](https://github.com/Microsoft/vscode-azurefunctions/pull/246) to better support projects created outside of VS Code, we want to activate if the workspace contains well-known function files. That way we can prompt them to "initialize for use with VS Code" (otherwise they only get the warning if they open the functions explorer, which is closed by default)