### PR TITLE
Fix init project prompt after clicking 'see more info'

### DIFF
--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -46,7 +46,7 @@ async function promptToInitializeProject(folderPath: string): Promise<boolean> {
         } else if (result === DialogResponses.seeMoreInfo) {
             // tslint:disable-next-line:no-unsafe-any
             opn('https://aka.ms/azFuncProject');
-            await promptToInitializeProject(folderPath);
+            return await promptToInitializeProject(folderPath);
         } else {
             throw new UserCancelledError();
         }


### PR DESCRIPTION
Repro steps:
1. Open an un-initialized project
1. Wait for warning to pop up that says "Would you like to initialize for optimal use for VS Code?"
1. Click 'See more info'
1. Switch from the browser back to VS Code
1. Click 'Yes'

Expected: Project is initialized
Actual: Project is not initialized