### PR TITLE
Generate and upload vsix to storage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ install:
   - npm install
 
 script:
-  - npm run vscode:prepublish
+  - gulp package
+  - gulp upload-vsix
   - npm run lint
   - gulp test
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,9 @@ const path = require('path');
 const os = require('os');
 const fse = require('fs-extra');
 const cp = require('child_process');
+const azureStorage = require('azure-storage');
+const vsce = require('vsce');
+const packageJson = require('./package.json');
 
 gulp.task('test', ['install-azure-account'], (cb) => {
     const cmd = cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit' });
@@ -33,5 +36,41 @@ gulp.task('install-azure-account', async () => {
             .pipe(gulp.dest(extensionPath));
     } else {
         console.log('Azure Account extension already installed.');
+    }
+});
+
+gulp.task('package', async () => {
+    await vsce.createVSIX();
+});
+
+gulp.task('upload-vsix', (callback) => {
+    if (process.env.TRAVIS_PULL_REQUEST_BRANCH) {
+        console.log('Skipping upload-vsix for PR build.');
+    } else {
+        const containerName = packageJson.name;
+        const vsixName = `${packageJson.name}-${packageJson.version}.vsix`;
+        const blobPath = path.join(process.env.TRAVIS_BRANCH, process.env.TRAVIS_BUILD_NUMBER, vsixName);
+        const blobService = azureStorage.createBlobService(process.env.STORAGE_NAME, process.env.STORAGE_KEY);
+        blobService.createContainerIfNotExists(containerName, { publicAccessLevel: "blob" }, (err) => {
+            if (err) {
+                callback(err);
+            } else {
+                blobService.createBlockBlobFromLocalFile(containerName, blobPath, vsixName, (err) => {
+                    if (err) {
+                        callback(err);
+                    } else {
+                        const brightYellowFormatting = '\x1b[33m\x1b[1m%s\x1b[0m';
+                        const brightWhiteFormatting = '\x1b[1m%s\x1b[0m';
+                        console.log();
+                        console.log(brightYellowFormatting, '================================================ vsix url ================================================');
+                        console.log();
+                        console.log(brightWhiteFormatting, blobService.getUrl(containerName, blobPath));
+                        console.log();
+                        console.log(brightYellowFormatting, '==========================================================================================================');
+                        console.log();
+                    }
+                });
+            }
+        });
     }
 });

--- a/package.json
+++ b/package.json
@@ -521,6 +521,7 @@
         "@types/websocket": "^0.0.37",
         "@types/xml2js": "^0.4.2",
         "@types/xregexp": "^3.0.29",
+        "azure-storage": "^2.8.1",
         "gulp": "^3.9.1",
         "gulp-decompress": "^2.0.1",
         "gulp-download": "^0.0.1",
@@ -528,7 +529,8 @@
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.0.1",
         "typescript": "^2.0.3",
-        "vscode": "^1.0.0"
+        "vscode": "^1.0.0",
+        "vsce": "^1.37.5"
     },
     "dependencies": {
         "azure-arm-cosmosdb": "^1.0.0-preview",


### PR DESCRIPTION
No more building a vsix manually! Now you just have to check the travis build log and copy the url. It will look like this (except probably with a different storage account name):

![screen shot 2018-03-09 at 3 21 03 pm](https://user-images.githubusercontent.com/11282622/37234588-8aeae706-23ad-11e8-85c9-26206ccfcb38.png)
