### PR TITLE
Allow users to change settings when picking templates

### DIFF
--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -4,18 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from "../../localize";
-import { ProjectRuntime, TemplateFilter } from "../../ProjectSettings";
+import { TemplateFilter } from "../../ProjectSettings";
 import { funcHostTaskId } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
-    public static defaultRuntime: ProjectRuntime = ProjectRuntime.one;
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
-
-    public async getRuntime(): Promise<ProjectRuntime> {
-        // Always use projectruntime.one for JavaScript since it has more templates and there were no major changes across runtime
-        return JavaScriptProjectCreator.defaultRuntime;
-    }
 
     public getLaunchJson(): {} {
         return {

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { ProjectRuntime, TemplateFilter } from '../../ProjectSettings';
 import { confirmOverwriteFile } from "../../utils/fs";
 import * as fsUtil from '../../utils/fs';
+import { functionRuntimeUtils } from '../../utils/functionRuntimeUtils';
 import { funcHostProblemMatcher, funcHostTaskId, funcHostTaskLabel, ProjectCreatorBase } from './IProjectCreator';
 
 // tslint:disable-next-line:no-multiline-string
@@ -41,9 +42,13 @@ local.settings.json
  */
 export class ScriptProjectCreatorBase extends ProjectCreatorBase {
     public static defaultRuntime: ProjectRuntime = ProjectRuntime.one;
-    public readonly runtime: ProjectRuntime = ScriptProjectCreatorBase.defaultRuntime;
     // Default template filter to 'All' since preview langauges have not been 'verified'
     public readonly templateFilter: TemplateFilter = TemplateFilter.All;
+
+    public async getRuntime(): Promise<ProjectRuntime> {
+        // tslint:disable-next-line:strict-boolean-expressions
+        return await functionRuntimeUtils.tryGetLocalRuntimeVersion() || ScriptProjectCreatorBase.defaultRuntime;
+    }
 
     public getTasksJson(): {} {
         return {

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -38,7 +38,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await testInitProjectForVSCode(projectPath);
         await validateVSCodeProjectFiles(projectPath);
         await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.JavaScript);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.one);
+        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.beta);
     });
 
     const csharpProject: string = 'AutoDetectCSharpProject';
@@ -77,7 +77,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
         await validateVSCodeProjectFiles(projectPath, false);
         await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.JavaScript);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.one);
+        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.beta);
     });
 
     const goodExtensionFile: string = 'Existing Extensions File';

--- a/test/templateData.test.ts
+++ b/test/templateData.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert';
 import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
-import { TestUserInput } from 'vscode-azureextensionui';
 import { JavaProjectCreator } from '../src/commands/createNewProject/JavaProjectCreator';
 import { JavaScriptProjectCreator } from '../src/commands/createNewProject/JavaScriptProjectCreator';
 import { ProjectLanguage, ProjectRuntime, TemplateFilter } from '../src/ProjectSettings';
@@ -44,16 +43,15 @@ suite('Template Data Tests', async () => {
 });
 
 async function validateTemplateData(templateData: TemplateData): Promise<void> {
-    const ui: TestUserInput = new TestUserInput([]);
-    const jsTemplates: Template[] = await templateData.getTemplates(ui, 'fakeProjectPath', ProjectLanguage.JavaScript, JavaScriptProjectCreator.defaultRuntime, TemplateFilter.Verified);
+    const jsTemplates: Template[] = await templateData.getTemplates(ProjectLanguage.JavaScript, JavaScriptProjectCreator.defaultRuntime, TemplateFilter.Verified);
     assert.equal(jsTemplates.length, 8, 'Unexpected JavaScript templates count.');
 
-    const javaTemplates: Template[] = await templateData.getTemplates(ui, 'fakeProjectPath', ProjectLanguage.Java, JavaProjectCreator.defaultRuntime, TemplateFilter.Verified);
+    const javaTemplates: Template[] = await templateData.getTemplates(ProjectLanguage.Java, JavaProjectCreator.defaultRuntime, TemplateFilter.Verified);
     assert.equal(javaTemplates.length, 4, 'Unexpected Java templates count.');
 
-    const cSharpTemplates: Template[] = await templateData.getTemplates(ui, 'fakeProjectPath', ProjectLanguage.CSharp, ProjectRuntime.one, TemplateFilter.Verified);
+    const cSharpTemplates: Template[] = await templateData.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.one, TemplateFilter.Verified);
     assert.equal(cSharpTemplates.length, 4, 'Unexpected CSharp (.NET Framework) templates count.');
 
-    const cSharpTemplatesv2: Template[] = await templateData.getTemplates(ui, 'fakeProjectPath', ProjectLanguage.CSharp, ProjectRuntime.beta, TemplateFilter.Verified);
+    const cSharpTemplatesv2: Template[] = await templateData.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.beta, TemplateFilter.Verified);
     assert.equal(cSharpTemplatesv2.length, 4, 'Unexpected CSharp (.NET Core) templates count.');
 }


### PR DESCRIPTION
Partial fix for #278 (I still want to change the "compatible" message to be more clear)

Here's what it looks like:
![screen shot 2018-03-21 at 3 48 34 pm](https://user-images.githubusercontent.com/11282622/37741684-9f2f5e6a-2d1f-11e8-84a7-bfc35c729e6d.png)

Here it is in action:
![settings](https://user-images.githubusercontent.com/11282622/37741688-a3b80fa4-2d1f-11e8-866e-a3269703a72c.gif)

I honestly don't think users will change their runtime/language very often - this is much more about the visibility of the settings. Previously user's didn't know the settings even existed and didn't know what it was set to. That's why I wanted to make sure these never show up at the top as "(recently used)". See this PR for more info: https://github.com/Microsoft/vscode-azuretools/pull/128

The other big difference is that JavaScript projects will now default the runtime to the user's locally installed runtime (if we can detect the version). The positive: Users will have more consistent behavior between their local/remote function apps. The negative: "beta" users will see many fewer templates since "beta" doesn't have as many as "~1"