### PR TITLE
Allow function to be created with project from api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,9 @@ Commands:
 |language|string|The currently supported languages are 'JavaScript', 'C#', and 'Java'.|
 |runtime|string|The currently supported runtimes are "~1" and "beta".|
 |openFolder|boolean|(Defaulted to true) Represents whether or not to open the project folder after it has been created. If true, the extension host may be restarted when the folder is opened.|
+|templateId|string|The id of an optional template you want to create with the new project.|
+|functionName|string|The name of the optional function to be created with the new project.|
+|functionSettings|{ [key: string]: string; }|Any settings unique to the optional function template. For example, the HttpTrigger template requires an AuthorizationLevel parameter.|
 
 ### Example Usage
 

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -4,14 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
-import { OutputChannel, QuickPickItem, QuickPickOptions } from 'vscode';
+import { QuickPickItem, QuickPickOptions } from 'vscode';
 import * as vscode from 'vscode';
-import { IAzureUserInput, TelemetryProperties } from 'vscode-azureextensionui';
-import { ProjectLanguage, projectLanguageSetting } from '../../constants';
+import { TelemetryProperties } from 'vscode-azureextensionui';
+import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../constants';
+import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { getGlobalFuncExtensionSetting } from '../../ProjectSettings';
 import { gitUtils } from '../../utils/gitUtils';
 import * as workspaceUtil from '../../utils/workspace';
+import { createFunction } from '../createFunction/createFunction';
 import { CSharpProjectCreator } from './CSharpProjectCreator';
 import { CSharpScriptProjectCreator } from './CSharpScriptProjectCreator';
 import { initProjectForVSCode } from './initProjectForVSCode';
@@ -20,9 +22,18 @@ import { JavaProjectCreator } from './JavaProjectCreator';
 import { JavaScriptProjectCreator } from './JavaScriptProjectCreator';
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
-export async function createNewProject(telemetryProperties: TelemetryProperties, outputChannel: OutputChannel, ui: IAzureUserInput, functionAppPath?: string, language?: string, runtime?: string, openFolder: boolean = true): Promise<void> {
+export async function createNewProject(
+    telemetryProperties: TelemetryProperties,
+    functionAppPath?: string,
+    language?: string,
+    runtime?: string,
+    openFolder: boolean = true,
+    templateId?: string,
+    functionName?: string,
+    caseSensitiveFunctionSettings?: { [key: string]: string | undefined; }): Promise<void> {
+
     if (functionAppPath === undefined) {
-        functionAppPath = await workspaceUtil.selectWorkspaceFolder(ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
+        functionAppPath = await workspaceUtil.selectWorkspaceFolder(ext.ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));
     }
     await fse.ensureDir(functionAppPath);
 
@@ -37,18 +48,22 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
                 { label: ProjectLanguage.Java, description: '' }
             ];
             const options: QuickPickOptions = { placeHolder: localize('azFunc.selectFuncTemplate', 'Select a language for your function project') };
-            language = (await ui.showQuickPick(languagePicks, options)).label;
+            language = (await ext.ui.showQuickPick(languagePicks, options)).label;
         }
     }
     telemetryProperties.projectLanguage = language;
 
-    const projectCreator: ProjectCreatorBase = getProjectCreator(language, functionAppPath, outputChannel, ui, telemetryProperties);
+    const projectCreator: ProjectCreatorBase = getProjectCreator(language, functionAppPath, telemetryProperties);
     await projectCreator.addNonVSCodeFiles();
 
-    await initProjectForVSCode(telemetryProperties, ui, outputChannel, functionAppPath, language, runtime, projectCreator);
+    await initProjectForVSCode(telemetryProperties, ext.ui, ext.outputChannel, functionAppPath, language, runtime, projectCreator);
 
     if (await gitUtils.isGitInstalled(functionAppPath)) {
-        await gitUtils.gitInit(outputChannel, functionAppPath);
+        await gitUtils.gitInit(ext.outputChannel, functionAppPath);
+    }
+
+    if (templateId) {
+        await createFunction(telemetryProperties, functionAppPath, templateId, functionName, caseSensitiveFunctionSettings, <ProjectLanguage>language, <ProjectRuntime>runtime);
     }
 
     if (openFolder && !workspaceUtil.isFolderOpenInWorkspace(functionAppPath)) {
@@ -57,17 +72,17 @@ export async function createNewProject(telemetryProperties: TelemetryProperties,
     }
 }
 
-export function getProjectCreator(language: string, functionAppPath: string, outputChannel: OutputChannel, ui: IAzureUserInput, telemetryProperties: TelemetryProperties): ProjectCreatorBase {
+export function getProjectCreator(language: string, functionAppPath: string, telemetryProperties: TelemetryProperties): ProjectCreatorBase {
     switch (language) {
         case ProjectLanguage.Java:
-            return new JavaProjectCreator(functionAppPath, outputChannel, ui, telemetryProperties);
+            return new JavaProjectCreator(functionAppPath, ext.outputChannel, ext.ui, telemetryProperties);
         case ProjectLanguage.JavaScript:
-            return new JavaScriptProjectCreator(functionAppPath, outputChannel, ui, telemetryProperties);
+            return new JavaScriptProjectCreator(functionAppPath, ext.outputChannel, ext.ui, telemetryProperties);
         case ProjectLanguage.CSharp:
-            return new CSharpProjectCreator(functionAppPath, outputChannel, ui, telemetryProperties);
+            return new CSharpProjectCreator(functionAppPath, ext.outputChannel, ext.ui, telemetryProperties);
         case ProjectLanguage.CSharpScript:
-            return new CSharpScriptProjectCreator(functionAppPath, outputChannel, ui, telemetryProperties);
+            return new CSharpScriptProjectCreator(functionAppPath, ext.outputChannel, ext.ui, telemetryProperties);
         default:
-            return new ScriptProjectCreatorBase(functionAppPath, outputChannel, ui, telemetryProperties);
+            return new ScriptProjectCreatorBase(functionAppPath, ext.outputChannel, ext.ui, telemetryProperties);
     }
 }

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -33,7 +33,7 @@ export async function initProjectForVSCode(telemetryProperties: TelemetryPropert
     outputChannel.appendLine(localize('usingLanguage', 'Using "{0}" as the project langauge...', language));
 
     if (!projectCreator) {
-        projectCreator = getProjectCreator(language, functionAppPath, outputChannel, ui, telemetryProperties);
+        projectCreator = getProjectCreator(language, functionAppPath, telemetryProperties);
     }
 
     // tslint:disable-next-line:strict-boolean-expressions

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,8 @@ import { renameAppSetting } from './commands/renameAppSetting';
 import { restartFunctionApp } from './commands/restartFunctionApp';
 import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
-import { getTemplateDataFromBackup, TemplateData, tryGetTemplateDataFromCache, tryGetTemplateDataFromFuncPortal } from './templates/TemplateData';
+import { ext } from './extensionVariables';
+import { getTemplateDataFromBackup, tryGetTemplateDataFromCache, tryGetTemplateDataFromFuncPortal } from './templates/TemplateData';
 import { FunctionAppProvider } from './tree/FunctionAppProvider';
 import { FunctionAppTreeItem } from './tree/FunctionAppTreeItem';
 import { FunctionTreeItem } from './tree/FunctionTreeItem';
@@ -49,16 +50,19 @@ export function activate(context: vscode.ExtensionContext): void {
     }
 
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions');
+    ext.outputChannel = outputChannel;
     context.subscriptions.push(outputChannel);
 
     callWithTelemetryAndErrorHandling('azureFunctions.activate', reporter, outputChannel, async function (this: IActionContext): Promise<void> {
         this.properties.isActivationEvent = 'true';
         const ui: IAzureUserInput = new AzureUserInput(context.globalState);
+        ext.ui = ui;
 
         // tslint:disable-next-line:no-floating-promises
         functionRuntimeUtils.validateFunctionRuntime(reporter, ui, outputChannel);
 
         const tree: AzureTreeDataProvider = new AzureTreeDataProvider(new FunctionAppProvider(outputChannel), 'azureFunctions.loadMore', ui, reporter);
+        ext.tree = tree;
         context.subscriptions.push(tree);
         context.subscriptions.push(vscode.window.registerTreeDataProvider('azureFunctionsExplorer', tree));
 
@@ -73,7 +77,7 @@ export function activate(context: vscode.ExtensionContext): void {
             await validateFunctionProjects(this, ui, outputChannel, event.added);
         });
 
-        const templateDataTask: Promise<TemplateData> = getTemplateData(reporter, context);
+        const templateDataTask: Promise<void> = getTemplateData(reporter, context);
 
         actionHandler.registerCommand('azureFunctions.selectSubscriptions', () => vscode.commands.executeCommand('azure-account.selectSubscriptions'));
         actionHandler.registerCommand('azureFunctions.refresh', async (node?: IAzureNode) => await tree.refresh(node));
@@ -81,10 +85,13 @@ export function activate(context: vscode.ExtensionContext): void {
         actionHandler.registerCommand('azureFunctions.loadMore', async (node: IAzureNode) => await tree.loadMore(node));
         actionHandler.registerCommand('azureFunctions.openInPortal', async (node?: IAzureNode<FunctionAppTreeItem>) => await openInPortal(tree, node));
         actionHandler.registerCommand('azureFunctions.createFunction', async function (this: IActionContext, functionAppPath?: string, templateId?: string, functionName?: string, functionSettings?: {}): Promise<void> {
-            const templateData: TemplateData = await templateDataTask;
-            await createFunction(this.properties, outputChannel, tree, templateData, ui, functionAppPath, templateId, functionName, functionSettings);
+            await templateDataTask;
+            await createFunction(this.properties, functionAppPath, templateId, functionName, functionSettings);
         });
-        actionHandler.registerCommand('azureFunctions.createNewProject', async function (this: IActionContext, functionAppPath?: string, language?: string, runtime?: string, openFolder?: boolean | undefined): Promise<void> { await createNewProject(this.properties, outputChannel, ui, functionAppPath, language, runtime, openFolder); });
+        actionHandler.registerCommand('azureFunctions.createNewProject', async function (this: IActionContext, functionAppPath?: string, language?: string, runtime?: string, openFolder?: boolean | undefined, templateId?: string, functionName?: string, functionSettings?: {}): Promise<void> {
+            await templateDataTask;
+            await createNewProject(this.properties, functionAppPath, language, runtime, openFolder, templateId, functionName, functionSettings);
+        });
         actionHandler.registerCommand('azureFunctions.initProjectForVSCode', async function (this: IActionContext): Promise<void> { await initProjectForVSCode(this.properties, ui, outputChannel); });
         actionHandler.registerCommand('azureFunctions.createFunctionApp', async function (this: IActionContext, arg?: IAzureParentNode | string): Promise<string> { return await createFunctionApp(this, tree, arg); });
         actionHandler.registerCommand('azureFunctions.startFunctionApp', async (node?: IAzureNode<FunctionAppTreeItem>) => await startFunctionApp(tree, node));
@@ -108,9 +115,9 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 }
 
-async function getTemplateData(reporter: TelemetryReporter | undefined, context: vscode.ExtensionContext): Promise<TemplateData> {
+async function getTemplateData(reporter: TelemetryReporter | undefined, context: vscode.ExtensionContext): Promise<void> {
     // tslint:disable-next-line:strict-boolean-expressions
-    return await tryGetTemplateDataFromFuncPortal(reporter, context.globalState) || await tryGetTemplateDataFromCache(reporter, context.globalState) || await getTemplateDataFromBackup(reporter, context.extensionPath);
+    ext.templateData = await tryGetTemplateDataFromFuncPortal(reporter, context.globalState) || await tryGetTemplateDataFromCache(reporter, context.globalState) || await getTemplateDataFromBackup(reporter, context.extensionPath);
 }
 
 // tslint:disable-next-line:no-empty

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { OutputChannel } from "vscode";
+import { AzureTreeDataProvider, IAzureUserInput } from "vscode-azureextensionui";
+import { TemplateData } from "./templates/TemplateData";
+
+/**
+ * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
+ */
+export namespace ext {
+    export let tree: AzureTreeDataProvider;
+    export let outputChannel: OutputChannel;
+    export let ui: IAzureUserInput;
+    export let templateData: TemplateData;
+}

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -9,9 +9,10 @@ import { IHookCallbackContext } from 'mocha';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { AzureTreeDataProvider, TestUserInput } from 'vscode-azureextensionui';
+import { TestUserInput } from 'vscode-azureextensionui';
 import { createFunction } from '../../src/commands/createFunction/createFunction';
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TemplateFilter, templateFilterSetting } from '../../src/constants';
+import { ext } from '../../src/extensionVariables';
 import { getGlobalFuncExtensionSetting, updateGlobalSetting } from '../../src/ProjectSettings';
 import { getTemplateDataFromBackup, TemplateData, tryGetTemplateDataFromFuncPortal } from '../../src/templates/TemplateData';
 import * as fsUtil from '../../src/utils/fs';
@@ -49,6 +50,7 @@ export abstract class FunctionTesterBase implements vscode.Disposable {
         this.funcPortalTestFolder = path.join(this._testFolder, 'funcPortal');
         this.funcStagingPortalTestFolder = path.join(this._testFolder, 'funcStagingPortal');
         this.outputChannel = vscode.window.createOutputChannel('Azure Functions Test');
+        ext.outputChannel = this.outputChannel;
     }
 
     public async initAsync(): Promise<void> {
@@ -112,8 +114,9 @@ export abstract class FunctionTesterBase implements vscode.Disposable {
             inputs.unshift('$(file-directory) Browse...'); // If the test environment has an open workspace, select the 'Browse...' option
         }
 
-        const ui: TestUserInput = new TestUserInput(inputs);
-        await createFunction({ isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '' }, this.outputChannel, <AzureTreeDataProvider>{}, templateData, ui);
+        ext.ui = new TestUserInput(inputs);
+        ext.templateData = templateData;
+        await createFunction({ isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '' });
         assert.equal(inputs.length, 0, 'Not all inputs were used.');
 
         await this.validateFunction(testFolder, funcName);

--- a/test/createFunction/createFunction.C#Script.test.ts
+++ b/test/createFunction/createFunction.C#Script.test.ts
@@ -8,7 +8,10 @@ import * as fse from 'fs-extra';
 import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { DialogResponses, TestUserInput } from 'vscode-azureextensionui';
 import { ProjectLanguage, ProjectRuntime } from '../../src/constants';
+import { ext } from '../../src/extensionVariables';
+import { validateVSCodeProjectFiles } from '../initProjectForVSCode.test';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpScriptFunctionTester extends FunctionTesterBase {
@@ -43,11 +46,23 @@ suite('Create C# Script Function Tests', async () => {
         );
     });
 
+    // Intentionally testing IoTHub trigger since a partner team plans to use that
+    const iotTemplateId: string = 'IoTHubTrigger-CSharp';
+    const iotFunctionName: string = 'createFunctionApi';
+    const iotFunctionSettings: {} = { connection: 'test_EVENTHUB', path: 'sample-workitems', consumerGroup: '$Default' };
+
     test('createFunction API', async () => {
         // Intentionally testing IoTHub trigger since a partner team plans to use that
-        const templateId: string = 'IoTHubTrigger-CSharp';
-        const functionName: string = 'createFunctionApi';
-        await vscode.commands.executeCommand('azureFunctions.createFunction', tester.funcPortalTestFolder, templateId, functionName, { connection: 'test_EVENTHUB', path: 'sample-workitems', consumerGroup: '$Default' });
-        await tester.validateFunction(tester.funcPortalTestFolder, functionName);
+
+        await vscode.commands.executeCommand('azureFunctions.createFunction', tester.funcPortalTestFolder, iotTemplateId, iotFunctionName, iotFunctionSettings);
+        await tester.validateFunction(tester.funcPortalTestFolder, iotFunctionName);
+    });
+
+    test('createNewProjectAndFunction API', async () => {
+        const projectPath: string = path.join(tester.funcPortalTestFolder, 'createNewProjectAndFunction');
+        ext.ui = new TestUserInput([DialogResponses.skipForNow.title]);
+        await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'C#Script', '~1', false /* openFolder */, iotTemplateId, iotFunctionName, iotFunctionSettings);
+        await tester.validateFunction(projectPath, iotFunctionName);
+        await validateVSCodeProjectFiles(projectPath);
     });
 });

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode';
 import { TestUserInput } from 'vscode-azureextensionui';
 import { createNewProject } from '../src/commands/createNewProject/createNewProject';
 import { ProjectLanguage } from '../src/constants';
+import { ext } from '../src/extensionVariables';
 import { dotnetUtils } from '../src/utils/dotnetUtils';
 import * as fsUtil from '../src/utils/fs';
 import { validateVSCodeProjectFiles } from './initProjectForVSCode.test';
@@ -22,6 +23,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
 
     const testFolderPath: string = path.join(os.tmpdir(), `azFunc.createNewProjectTests${fsUtil.getRandomHexString()}`);
     const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Azure Functions Test');
+    ext.outputChannel = outputChannel;
 
     // tslint:disable-next-line:no-function-expression
     suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
@@ -143,7 +145,8 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         }
 
         const ui: TestUserInput = new TestUserInput(inputs);
-        await createNewProject({ isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '' }, outputChannel, ui, undefined, previewLanguage ? language : undefined, undefined, false);
+        ext.ui = ui;
+        await createNewProject({ isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '' }, undefined, previewLanguage ? language : undefined, undefined, false);
         assert.equal(inputs.length, 0, 'Not all inputs were used.');
 
         assert.equal(await fse.pathExists(path.join(projectPath, '.gitignore')), true, '.gitignore does not exist');


### PR DESCRIPTION
Fixes #296 

I'm also experimenting with an 'extensionVariables' file so that we don't have to pass around common variables as much. Something similar has been discussed in several places throughout our repos. I chose as short a name as possible for the namespace since we'll probably be using this a lot ('ext', short for 'extension'). If people like this pattern we can shift the whole repo to do it eventually