### PR TITLE
Fix error on delete

### DIFF
--- a/src/tree/FunctionAppTreeItem.ts
+++ b/src/tree/FunctionAppTreeItem.ts
@@ -62,7 +62,11 @@ export class FunctionAppTreeItem implements ILogStreamTreeItem, IAzureParentTree
     }
 
     public async refreshLabel(): Promise<void> {
-        this._state = await this.client.getState();
+        try {
+            this._state = await this.client.getState();
+        } catch {
+            this._state = 'Unknown';
+        }
     }
 
     public async loadMoreChildren(): Promise<IAzureTreeItem[]> {


### PR DESCRIPTION
Same bug as in App Service: https://github.com/Microsoft/vscode-azureappservice/pull/382

When I added support for runWithTemporaryDescription, it had the side-effect of re-getting the state after the site was already deleted. We could fail to get the state in other cases as well and I think its best to just show the state as 'Unknown' instead of displaying an error message