### PR TITLE
Typo: langauge -> language

### DIFF
--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -42,7 +42,7 @@ local.settings.json
  */
 export class ScriptProjectCreatorBase extends ProjectCreatorBase {
     public static defaultRuntime: ProjectRuntime = ProjectRuntime.one;
-    // Default template filter to 'All' since preview langauges have not been 'verified'
+    // Default template filter to 'All' since preview languages have not been 'verified'
     public readonly templateFilter: TemplateFilter = TemplateFilter.All;
 
     public async getRuntime(): Promise<ProjectRuntime> {

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -30,7 +30,7 @@ export async function initProjectForVSCode(telemetryProperties: TelemetryPropert
     telemetryProperties.projectLanguage = language;
 
     outputChannel.show();
-    outputChannel.appendLine(localize('usingLanguage', 'Using "{0}" as the project langauge...', language));
+    outputChannel.appendLine(localize('usingLanguage', 'Using "{0}" as the project language...', language));
 
     if (!projectCreator) {
         projectCreator = getProjectCreator(language, functionAppPath, telemetryProperties);

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -64,7 +64,7 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 }
 
 function isInitializedProject(folderPath: string): boolean {
-    const langauge: string | undefined = getFuncExtensionSetting(projectLanguageSetting, folderPath);
+    const language: string | undefined = getFuncExtensionSetting(projectLanguageSetting, folderPath);
     const runtime: string | undefined = getFuncExtensionSetting(projectRuntimeSetting, folderPath);
-    return !!langauge && !!runtime;
+    return !!language && !!runtime;
 }


### PR DESCRIPTION
Fixed a few occurences of "langauge" instead of "language".