### PR TITLE
Validate func installed when debugging C# projects

### DIFF
--- a/src/commands/createNewProject/validateFuncCoreToolsInstalled.ts
+++ b/src/commands/createNewProject/validateFuncCoreToolsInstalled.ts
@@ -5,7 +5,7 @@
 
 import * as opn from 'opn';
 import { MessageItem } from 'vscode';
-import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext } from 'vscode-azureextensionui';
 import { Platform } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -7,14 +7,19 @@
 import ps = require('ps-node');
 import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
-import { IActionContext } from 'vscode-azureextensionui';
+import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { extensionPrefix, isWindows } from '../constants';
 import { localize } from '../localize';
 import { getFuncExtensionSetting } from '../ProjectSettings';
 import { cpUtils } from '../utils/cpUtils';
 import { funcHostTaskId } from './createNewProject/IProjectCreator';
+import { validateFuncCoreToolsInstalled } from './createNewProject/validateFuncCoreToolsInstalled';
 
 export async function pickFuncProcess(actionContext: IActionContext): Promise<string | undefined> {
+    if (!await validateFuncCoreToolsInstalled(true /* forcePrompt */)) {
+        throw new UserCancelledError();
+    }
+
     let funcHostPid: string | undefined = await getFuncHostPid();
     if (funcHostPid !== undefined) {
         // Stop the functions host to prevent build errors like "Cannot access the file '...' because it is being used by another process."

--- a/src/utils/functionRuntimeUtils.ts
+++ b/src/utils/functionRuntimeUtils.ts
@@ -9,7 +9,7 @@ import request = require('request-promise');
 import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { callWithTelemetryAndErrorHandling, DialogResponses, IActionContext, parseError } from 'vscode-azureextensionui';
-import { attemptToInstallLatestFunctionRuntime, brewOrNpmInstalled } from '../commands/createNewProject/validateFuncCoreToolsInstalled';
+import { attemptToInstallLatestFunctionRuntime, canInstallFuncCoreTools } from '../commands/createNewProject/validateFuncCoreToolsInstalled';
 import { isWindows, ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
@@ -41,7 +41,7 @@ export namespace functionRuntimeUtils {
                     }
 
                     if (semver.gt(newestVersion, localVersion)) {
-                        const canUpdate: boolean = await brewOrNpmInstalled();
+                        const canUpdate: boolean = await canInstallFuncCoreTools();
                         let message: string = localize(
                             'azFunc.outdatedFunctionRuntime',
                             'Update your Azure Functions Core Tools ({0}) to the latest ({1}) for the best experience.',


### PR DESCRIPTION
Fixes #340 (hopefully - this is my best guess unless we get more detailed feedback from the user)

I had to refactor `validateFuncCoreToolsInstalled` to accept a `forcePrompt` boolean that basically says "The user MUST be prompted and MUST interact with the prompt" since they can't debug until this prompt is done. I messed with the prompt a little bit because I thought it was too dense with the command in there. Let me know what you think:

||forcePrompt=true|forcePrompt=false|
|---|---|---|
|canInstall=true|![screen shot 2018-05-07 at 2 38 29 pm](https://user-images.githubusercontent.com/11282622/39727514-d12a8270-5207-11e8-9320-cc004a40d83a.png)|![screen shot 2018-05-07 at 2 38 59 pm](https://user-images.githubusercontent.com/11282622/39727518-d9af7f04-5207-11e8-9839-11b22e47ab55.png)|
|canInstall=false|![screen shot 2018-05-07 at 2 54 59 pm](https://user-images.githubusercontent.com/11282622/39727522-df67e850-5207-11e8-8393-e1003a3ada83.png)|![screen shot 2018-05-07 at 2 53 30 pm](https://user-images.githubusercontent.com/11282622/39727529-e3b851ce-5207-11e8-86ea-89738830b2e7.png)|

Finally - I think this will be a good test to see if we should do the same for other languages. It's definitely easier to do for C# since we have pickProcess and I don't know how we'd do it otherwise, but at least this will tell us if it's worth investigating.