### PR TITLE
Allow users to specify open behavior for new project

### DIFF
--- a/package.json
+++ b/package.json
@@ -579,6 +579,15 @@
                         "type": "boolean",
                         "description": "%azFunc.showFuncInstallationDescription%",
                         "default": true
+                    },
+                    "azureFunctions.projectOpenBehavior": {
+                        "type": "string",
+                        "enum": [
+                            "AddToWorkspace",
+                            "OpenInNewWindow",
+                            "OpenInCurrentWindow"
+                        ],
+                        "description": "%azFunc.projectOpenBehaviorDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -40,5 +40,6 @@
     "azFunc.enableRemoteDebugging": "Enable remote debugging, an experimental feature that only supports Java-based Functions Apps.",
     "azFunc.deleteProxy": "Delete Proxy",
     "azFunc.pickProcessTimeoutDescription": "The timeout (in seconds) to be used when searching for the Azure Functions host process. Since a build is required every time you F5, you may need to adjust this based on how long your build takes.",
-    "azFunc.showFuncInstallationDescription": "Show a warning to install Azure Functions Core Tools CLI when you create a new project if the CLI is not installed."
+    "azFunc.showFuncInstallationDescription": "Show a warning to install Azure Functions Core Tools CLI when you create a new project if the CLI is not installed.",
+    "azFunc.projectOpenBehaviorDescription": "The behavior to use after creating a new project. The options are \"AddToWorkspace\", \"OpenInNewWindow\", or \"OpenInCurrentWindow\"."
 }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -66,6 +66,7 @@ async function promptForStringSetting(setting: ConfigSetting, defaultValue?: str
     return await ext.ui.showInputBox(options);
 }
 
+// tslint:disable-next-line:max-func-body-length
 export async function createFunction(
     actionContext: IActionContext,
     functionAppPath?: string,
@@ -85,12 +86,14 @@ export async function createFunction(
         functionAppPath = await workspaceUtil.selectWorkspaceFolder(ext.ui, folderPlaceholder);
     }
 
+    let isNewProject: boolean = false;
     let templateFilter: TemplateFilter;
     if (!await isFunctionProject(functionAppPath)) {
         const message: string = localize('azFunc.notFunctionApp', 'The selected folder is not a function app project. Initialize Project?');
         const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.skipForNow, DialogResponses.cancel);
         if (result === DialogResponses.yes) {
             await createNewProject(actionContext, functionAppPath, undefined, undefined, false);
+            isNewProject = true;
             // Get the settings used to create the project
             language = <ProjectLanguage>actionContext.properties.projectLanguage;
             runtime = <ProjectRuntime>actionContext.properties.projectRuntime;
@@ -168,6 +171,10 @@ export async function createFunction(
 
     if (!template.functionConfig.isHttpTrigger) {
         await validateAzureWebJobsStorage(actionContext, localSettingsPath);
+    }
+
+    if (isNewProject) {
+        await workspaceUtil.ensureFolderIsOpen(functionAppPath, actionContext);
     }
 }
 

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
-import * as vscode from 'vscode';
 import { QuickPickItem, QuickPickOptions } from 'vscode';
 import { IActionContext, TelemetryProperties } from 'vscode-azureextensionui';
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../constants';
@@ -68,9 +67,8 @@ export async function createNewProject(
     }
     await validateFuncCoreToolsInstalled();
 
-    if (openFolder && !workspaceUtil.isFolderOpenInWorkspace(functionAppPath)) {
-        // If the selected folder is not open in a workspace, open it now. NOTE: This may restart the extension host
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(functionAppPath), false);
+    if (openFolder) {
+        await workspaceUtil.ensureFolderIsOpen(functionAppPath, actionContext);
     }
 }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
+import { isBoolean } from 'util';
 import * as vscode from 'vscode';
-import { IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
+import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, IAzureUserInput } from 'vscode-azureextensionui';
+import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { getFuncExtensionSetting, updateGlobalSetting } from '../ProjectSettings';
 import * as fsUtils from './fs';
 
 export async function selectWorkspaceFolder(ui: IAzureUserInput, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined): Promise<string> {
@@ -66,14 +69,77 @@ export async function selectWorkspaceItem(ui: IAzureUserInput, placeHolder: stri
     return folder && folder.data ? folder.data : (await ui.showOpenDialog(options))[0].fsPath;
 }
 
-export function isFolderOpenInWorkspace(fsPath: string): boolean {
-    if (vscode.workspace.workspaceFolders) {
-        const folder: vscode.WorkspaceFolder | undefined = vscode.workspace.workspaceFolders.find((f: vscode.WorkspaceFolder): boolean => {
-            return fsUtils.isPathEqual(f.uri.fsPath, fsPath) || fsUtils.isSubpath(f.uri.fsPath, fsPath);
-        });
+enum OpenBehavior {
+    AddToWorkspace = 'AddToWorkspace',
+    OpenInNewWindow = 'OpenInNewWindow',
+    OpenInCurrentWindow = 'OpenInCurrentWindow'
+}
 
-        return folder !== undefined;
+const projectOpenBehaviorSetting: string = 'projectOpenBehavior';
+
+/**
+ * If the selected folder is not open in a workspace, open it now. NOTE: This may restart the extension host
+ */
+export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionContext): Promise<void> {
+    // tslint:disable-next-line:strict-boolean-expressions
+    const openFolders: vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
+    const folder: vscode.WorkspaceFolder | undefined = openFolders.find((f: vscode.WorkspaceFolder): boolean => {
+        return fsUtils.isPathEqual(f.uri.fsPath, fsPath);
+    });
+
+    if (folder) {
+        actionContext.properties.openBehavior = 'AlreadyOpen';
     } else {
-        return false;
+        actionContext.properties.openBehaviorFromSetting = 'false';
+        const setting: string | undefined = getFuncExtensionSetting(projectOpenBehaviorSetting);
+        let openBehavior: OpenBehavior | undefined;
+        if (setting) {
+            for (const key of Object.keys(OpenBehavior)) {
+                const value: OpenBehavior = <OpenBehavior>OpenBehavior[key];
+                if (value.toLowerCase() === setting.toLowerCase()) {
+                    openBehavior = value;
+                    actionContext.properties.openBehaviorFromSetting = 'true';
+                    break;
+                }
+            }
+        }
+
+        const notAlwaysPick: IAzureQuickPickItem<OpenBehavior | boolean> = { label: localize('notAlways', '$(circle-slash) Always use this choice'), description: '', data: false, suppressPersistence: true };
+        const alwaysPick: IAzureQuickPickItem<OpenBehavior | boolean> = { label: localize('always', '$(check) Always use this choice'), description: '', data: true, suppressPersistence: true };
+
+        const picks: IAzureQuickPickItem<OpenBehavior | boolean>[] = [
+            { label: localize('AddToWorkspace', 'Add to workspace'), description: '', data: OpenBehavior.AddToWorkspace },
+            { label: localize('OpenInNewWindow', 'Open in new window'), description: '', data: OpenBehavior.OpenInNewWindow },
+            { label: localize('OpenInCurrentWindow', 'Open in current window'), description: '', data: OpenBehavior.OpenInCurrentWindow },
+            notAlwaysPick
+        ];
+
+        const options: IAzureQuickPickOptions = { placeHolder: localize('selectOpenBehavior', 'Select how you would like to open your project'), suppressPersistence: true };
+
+        let result: OpenBehavior | boolean;
+        let alwaysUseThisChoice: boolean = false;
+        while (openBehavior === undefined) {
+            result = (await ext.ui.showQuickPick(picks, options)).data;
+            if (isBoolean(result)) {
+                alwaysUseThisChoice = !result; // The new value is the opposite of what the user just clicked in the quick pick
+                picks.pop();
+                picks.push(alwaysUseThisChoice ? alwaysPick : notAlwaysPick);
+            } else {
+                openBehavior = result;
+            }
+        }
+
+        actionContext.properties.openBehavior = openBehavior;
+
+        if (alwaysUseThisChoice) {
+            await updateGlobalSetting(projectOpenBehaviorSetting, openBehavior);
+        }
+
+        const uri: vscode.Uri = vscode.Uri.file(fsPath);
+        if (openBehavior === OpenBehavior.AddToWorkspace) {
+            vscode.workspace.updateWorkspaceFolders(openFolders.length, 0, { uri: uri });
+        } else {
+            await vscode.commands.executeCommand('vscode.openFolder', uri, openBehavior === OpenBehavior.OpenInNewWindow /* forceNewWindow */);
+        }
     }
 }


### PR DESCRIPTION
Fixes #39 

After creating a new project, the user will be given three options to open that project:
![screen shot 2018-05-08 at 11 13 47 am](https://user-images.githubusercontent.com/11282622/39774878-0c547f96-52b1-11e8-84c4-6107a58a1db6.png)

This is what it looks like if they select "Always use this choice":
![screen shot 2018-05-08 at 11 13 36 am](https://user-images.githubusercontent.com/11282622/39774881-0d6e54ce-52b1-11e8-8438-f95749abdcd2.png)

It's a user setting in the background, so people can always change it if they want. I also made sure to add telemetry to see if this kind of quick pick is worth doing in other places as well.