### PR TITLE
Use original install method when updating func cli

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,3 +46,10 @@ export enum Platform {
 export const hostFileName: string = 'host.json';
 export const localSettingsFileName: string = 'local.settings.json';
 export const gitignoreFileName: string = '.gitignore';
+
+export enum PackageManager {
+    npm,
+    brew
+}
+
+export const funcPackageName: string = 'azure-functions-core-tools';


### PR DESCRIPTION
Rather than always using brew first on Mac - detect if the user originally installed with brew or npm and use that.

Fixes #365 