### PR TITLE
Automatically retrieve dotnet templates from cli feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "onCommand:azureFunctions.appSettings.encrypt",
         "onCommand:azureFunctions.appSettings.decrypt",
         "onCommand:azureFunctions.pickProcess",
-        "onCommand:azureFunctions.installDotnetTemplates",
         "onCommand:azureFunctions.uninstallDotnetTemplates",
         "onCommand:azureFunctions.startStreamingLogs",
         "onCommand:azureFunctions.stopStreamingLogs",
@@ -213,11 +212,6 @@
             {
                 "command": "azureFunctions.pickProcess",
                 "title": "%azFunc.pickProcess%",
-                "category": "Azure Functions"
-            },
-            {
-                "command": "azureFunctions.installDotnetTemplates",
-                "title": "%azFunc.installDotnetTemplates%",
                 "category": "Azure Functions"
             },
             {

--- a/src/commands/createFunction/CSharpFunctionCreator.ts
+++ b/src/commands/createFunction/CSharpFunctionCreator.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { OutputChannel } from "vscode";
-import { IAzureUserInput } from 'vscode-azureextensionui';
+import { IActionContext, IAzureUserInput } from 'vscode-azureextensionui';
 // tslint:disable-next-line:no-require-imports
 import XRegExp = require('xregexp');
 import { localize } from "../../localize";
@@ -21,12 +21,10 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
     private _outputChannel: OutputChannel;
     private _functionName: string;
     private _namespace: string;
-    private _ui: IAzureUserInput;
 
-    constructor(functionAppPath: string, template: Template, outputChannel: OutputChannel, ui: IAzureUserInput) {
+    constructor(functionAppPath: string, template: Template, outputChannel: OutputChannel) {
         super(functionAppPath, template);
         this._outputChannel = outputChannel;
-        this._ui = ui;
     }
 
     public async promptForSettings(ui: IAzureUserInput, functionName: string | undefined, functionSettings: { [key: string]: string | undefined; }): Promise<void> {
@@ -54,8 +52,8 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
         }
     }
 
-    public async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined> {
-        await dotnetUtils.validateTemplatesInstalled(this._outputChannel, this._ui);
+    public async createFunction(userSettings: { [propertyName: string]: string }, actionContext: IActionContext): Promise<string | undefined> {
+        await dotnetUtils.validateTemplatesInstalled(actionContext);
 
         const args: string[] = [];
         for (const key of Object.keys(userSettings)) {
@@ -63,8 +61,6 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
             // the parameters for dotnet templates are not consistent. Hence, we have to special-case a few of them:
             if (parameter.toLowerCase() === 'authlevel') {
                 parameter = 'AccessRights';
-            } else if (parameter.toLowerCase() === 'queuename') {
-                parameter = 'Path';
             }
 
             // https://github.com/Microsoft/vscode-azurefunctions/issues/166

--- a/src/commands/createFunction/FunctionCreatorBase.ts
+++ b/src/commands/createFunction/FunctionCreatorBase.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureUserInput } from "vscode-azureextensionui";
+import { IActionContext, IAzureUserInput } from "vscode-azureextensionui";
 import { Template } from "../../templates/Template";
 
 export abstract class FunctionCreatorBase {
@@ -21,5 +21,5 @@ export abstract class FunctionCreatorBase {
      * This includes the function name (Since the name could have different restrictions for different languages)
      */
     public abstract async promptForSettings(ui: IAzureUserInput, functionName: string | undefined, functionSettings: { [key: string]: string | undefined; }): Promise<void>;
-    public abstract async createFunction(userSettings: { [propertyName: string]: string }): Promise<string | undefined>;
+    public abstract async createFunction(userSettings: { [propertyName: string]: string }, actionContext: IActionContext): Promise<string | undefined>;
 }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -138,7 +138,7 @@ export async function createFunction(
             functionCreator = new JavaFunctionCreator(functionAppPath, template, ext.outputChannel);
             break;
         case ProjectLanguage.CSharp:
-            functionCreator = new CSharpFunctionCreator(functionAppPath, template, ext.outputChannel, ext.ui);
+            functionCreator = new CSharpFunctionCreator(functionAppPath, template, ext.outputChannel);
             break;
         default:
             functionCreator = new ScriptFunctionCreator(functionAppPath, template, language);
@@ -163,7 +163,7 @@ export async function createFunction(
         }
     }
 
-    const newFilePath: string | undefined = await functionCreator.createFunction(userSettings);
+    const newFilePath: string | undefined = await functionCreator.createFunction(userSettings, actionContext);
     if (newFilePath && (await fse.pathExists(newFilePath))) {
         const newFileUri: vscode.Uri = vscode.Uri.file(newFilePath);
         vscode.window.showTextDocument(await vscode.workspace.openTextDocument(newFileUri));

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -8,7 +8,7 @@ import * as opn from 'opn';
 import * as path from 'path';
 import { SemVer } from 'semver';
 import * as vscode from 'vscode';
-import { DialogResponses, parseError } from 'vscode-azureextensionui';
+import { DialogResponses, IActionContext, parseError } from 'vscode-azureextensionui';
 import { gitignoreFileName, hostFileName, isWindows, localSettingsFileName, ProjectRuntime, TemplateFilter } from '../../constants';
 import { localize } from "../../localize";
 import { getFuncExtensionSetting, updateGlobalSetting } from '../../ProjectSettings';
@@ -22,8 +22,8 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
 
     private _runtime: ProjectRuntime;
 
-    public async addNonVSCodeFiles(): Promise<void> {
-        await dotnetUtils.validateTemplatesInstalled(this.outputChannel, this.ui);
+    public async addNonVSCodeFiles(actionContext: IActionContext): Promise<void> {
+        await dotnetUtils.validateTemplatesInstalled(actionContext);
 
         const csProjName: string = `${path.basename(this.functionAppPath)}.csproj`;
         const overwriteExisting: boolean = await this.confirmOverwriteExisting(this.functionAppPath, csProjName);

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { OutputChannel } from "vscode";
-import { IAzureUserInput, TelemetryProperties } from "vscode-azureextensionui";
+import { IActionContext, IAzureUserInput, TelemetryProperties } from "vscode-azureextensionui";
 import { extensionPrefix, ProjectRuntime, TemplateFilter } from "../../constants";
 import { localize } from "../../localize";
 import { promptForProjectRuntime } from "../../ProjectSettings";
@@ -39,7 +39,7 @@ export abstract class ProjectCreatorBase {
     /**
      * Add all project files not included in the '.vscode' folder
      */
-    public abstract addNonVSCodeFiles(): Promise<void>;
+    public abstract addNonVSCodeFiles(actionContext: IActionContext): Promise<void>;
     public abstract getTasksJson(): {} | Promise<{}>;
     public getRecommendedExtensions(): string[] {
         return ['ms-azuretools.vscode-azurefunctions'];

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -54,7 +54,7 @@ export async function createNewProject(
     actionContext.properties.projectLanguage = language;
 
     const projectCreator: ProjectCreatorBase = getProjectCreator(language, functionAppPath, actionContext.properties);
-    await projectCreator.addNonVSCodeFiles();
+    await projectCreator.addNonVSCodeFiles(actionContext);
 
     await initProjectForVSCode(actionContext.properties, ext.ui, ext.outputChannel, functionAppPath, language, runtime, projectCreator);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,8 @@ import { dotnetUtils } from './utils/dotnetUtils';
 import { functionRuntimeUtils } from './utils/functionRuntimeUtils';
 
 export function activate(context: vscode.ExtensionContext): void {
+    ext.context = context;
+
     let reporter: TelemetryReporter | undefined;
     try {
         const packageInfo: IPackageInfo = (<(id: string) => IPackageInfo>require)(context.asAbsolutePath('./package.json'));
@@ -117,8 +119,7 @@ export function activate(context: vscode.ExtensionContext): void {
         actionHandler.registerCommand('azureFunctions.appSettings.decrypt', async (uri?: vscode.Uri) => await decryptLocalSettings(uri));
         actionHandler.registerCommand('azureFunctions.appSettings.encrypt', async (uri?: vscode.Uri) => await encryptLocalSettings(uri));
         actionHandler.registerCommand('azureFunctions.appSettings.delete', async (node?: IAzureNode<AppSettingTreeItem>) => await deleteNode(tree, AppSettingTreeItem.contextValue, node));
-        actionHandler.registerCommand('azureFunctions.installDotnetTemplates', async () => await dotnetUtils.installDotnetTemplates(ui, outputChannel));
-        actionHandler.registerCommand('azureFunctions.uninstallDotnetTemplates', async () => await dotnetUtils.uninstallDotnetTemplates(outputChannel));
+        actionHandler.registerCommand('azureFunctions.uninstallDotnetTemplates', async () => await dotnetUtils.uninstallTemplates());
         actionHandler.registerCommand('azureFunctions.debugFunctionAppOnAzure', async (node?: IAzureNode<FunctionAppTreeItem>) => await remoteDebugFunctionApp(outputChannel, ui, tree, node));
         actionHandler.registerCommand('azureFunctions.deleteProxy', async (node?: IAzureNode) => await deleteNode(tree, ProxyTreeItem.contextValue, node));
     });

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { OutputChannel } from "vscode";
+import { ExtensionContext, OutputChannel } from "vscode";
 import { AzureTreeDataProvider, IAzureUserInput } from "vscode-azureextensionui";
 import TelemetryReporter from "vscode-extension-telemetry";
 import { TemplateData } from "./templates/TemplateData";
@@ -12,6 +12,7 @@ import { TemplateData } from "./templates/TemplateData";
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
  */
 export namespace ext {
+    export let context: ExtensionContext;
     export let tree: AzureTreeDataProvider;
     export let outputChannel: OutputChannel;
     export let ui: IAzureUserInput;

--- a/src/templates/TemplateData.ts
+++ b/src/templates/TemplateData.ts
@@ -15,7 +15,7 @@ import { betaReleaseVersion, ProjectLanguage, ProjectRuntime, TemplateFilter, te
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { getFuncExtensionSetting, updateGlobalSetting } from '../ProjectSettings';
-import { cliFeedJsonResponse, tryGetCliFeedJson } from '../utils/getCliFeedJson';
+import { cliFeedJsonResponse, getFeedRuntime, tryGetCliFeedJson } from '../utils/getCliFeedJson';
 import { Config } from './Config';
 import { ConfigBinding } from './ConfigBinding';
 import { ConfigSetting } from './ConfigSetting';
@@ -288,18 +288,7 @@ async function downloadAndExtractTemplates(templateUrl: string, release: string)
     });
 }
 
-function getFeedRuntime(runtime: ProjectRuntime): string {
-    switch (runtime) {
-        case ProjectRuntime.beta:
-            return 'v2';
-        case ProjectRuntime.one:
-            return 'v1';
-        default:
-            throw new RangeError();
-    }
-}
-
-async function tryGetTemplateVersionSetting(context: IActionContext, cliFeedJson: cliFeedJsonResponse | undefined, runtime: ProjectRuntime): Promise<string | undefined> {
+export async function tryGetTemplateVersionSetting(context: IActionContext, cliFeedJson: cliFeedJsonResponse | undefined, runtime: ProjectRuntime): Promise<string | undefined> {
     const feedRuntime: string = getFeedRuntime(runtime);
     const userTemplateVersion: string | undefined = getFuncExtensionSetting(templateVersionSetting);
     try {

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -6,112 +6,114 @@
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import { MessageItem, OutputChannel, QuickPickItem, QuickPickOptions } from "vscode";
-import { DialogResponses, IAzureUserInput } from 'vscode-azureextensionui';
-import { isWindows, ProjectRuntime } from '../constants';
+// tslint:disable-next-line:no-require-imports
+import request = require('request-promise');
+import { QuickPickOptions } from "vscode";
+import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ProjectRuntime } from '../constants';
+import { ext } from '../extensionVariables';
 import { localize } from "../localize";
+import { tryGetTemplateVersionSetting } from '../templates/TemplateData';
+import { functionRuntimeUtils } from '../utils/functionRuntimeUtils';
 import { cpUtils } from "./cpUtils";
 import * as fsUtil from './fs';
+import { cliFeedJsonResponse, getFeedRuntime, tryGetCliFeedJson } from './getCliFeedJson';
+
+const projectPackageId: string = 'microsoft.azurefunctions.projecttemplates';
+const functionsPackageId: string = 'azure.functions.templates';
+const templatesKey: string = 'cSharpFunctionsTemplates';
+
+async function validateDotnetInstalled(): Promise<void> {
+    try {
+        await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--version');
+    } catch (error) {
+        throw new Error(localize('dotnetNotInstalled', 'You must have the .NET CLI installed to perform this operation.'));
+    }
+}
+
+async function downloadDotnetTemplates(url: string, tempFolder: string, packageId: string): Promise<string> {
+    const fullPath: string = path.join(tempFolder, `${packageId}.nupkg`);
+    return new Promise(async (resolve: (fullPath: string) => void, reject: (e: Error) => void): Promise<void> => {
+        const templateOptions: request.OptionsWithUri = {
+            method: 'GET',
+            uri: url
+        };
+
+        request(templateOptions, (err: Error) => {
+            // tslint:disable-next-line:strict-boolean-expressions
+            if (err) {
+                reject(err);
+            }
+        }).pipe(fse.createWriteStream(fullPath).on('finish', () => {
+            resolve(fullPath);
+        }));
+    });
+}
 
 export namespace dotnetUtils {
-    const projectPackageId: string = 'microsoft.azurefunctions.projecttemplates';
-    const functionsPackageId: string = 'azure.functions.templates';
-    const betaTemplateVersion: string = '2.0.0-beta-10167';
-    const v1TemplateVersion: string = '1.0.3.10168';
-
-    function getPackagesCsproj(version: string): string {
-        // tslint:disable:no-multiline-string
-        return `<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="${projectPackageId}" Version="${version}" />
-    <PackageReference Include="${functionsPackageId}" Version="${version}" />
-  </ItemGroup>
-</Project>
-`;
-    }
-
-    async function validateDotnetInstalled(): Promise<void> {
-        try {
-            await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--version');
-        } catch (error) {
-            throw new Error(localize('azFunc.dotnetNotInstalled', 'You must have the .NET CLI installed to perform this operation.'));
-        }
-    }
-
     export const funcProjectId: string = 'azureFunctionsProjectTemplates';
 
-    export async function validateTemplatesInstalled(outputChannel: OutputChannel, ui: IAzureUserInput): Promise<void> {
+    export async function validateTemplatesInstalled(actionContext: IActionContext): Promise<void> {
         await validateDotnetInstalled();
+
         const listOutput: string = await cpUtils.executeCommand(undefined, undefined, 'dotnet', 'new', '--list');
-        if (!listOutput.includes(funcProjectId) || !listOutput.includes('HttpTrigger')) {
-            const installTemplates: MessageItem = { title: localize('installTemplates', 'Install Templates') };
-            await ui.showWarningMessage(localize('noDotnetFuncTemplates', 'You must have the Azure Functions templates installed for the .NET CLI.'), { modal: true }, installTemplates, DialogResponses.cancel);
-            await installDotnetTemplates(ui, outputChannel);
-        }
-    }
+        const templatesInstalled: boolean = listOutput.includes(funcProjectId) && listOutput.includes('HttpTrigger');
 
-    export async function uninstallDotnetTemplates(outputChannel: OutputChannel): Promise<void> {
-        await validateDotnetInstalled();
-
-        const tempFolder: string = os.tmpdir();
-
-        outputChannel.show();
-        outputChannel.appendLine(localize('uninstallFuncProject', 'Uninstalling "{0}"', projectPackageId));
-        await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--uninstall', projectPackageId);
-        outputChannel.appendLine(localize('uninstallFuncs', 'Uninstalling "{0}"', functionsPackageId));
-        await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--uninstall', functionsPackageId);
-        outputChannel.appendLine(localize('finishedUninstallingTemplates', 'Finished uninstalling Azure Functions templates.'));
-    }
-
-    export async function installDotnetTemplates(ui: IAzureUserInput, outputChannel: OutputChannel): Promise<void> {
-        await validateDotnetInstalled();
-
-        let templateVersion: string = betaTemplateVersion;
-
-        if (isWindows) {
-            const picks: QuickPickItem[] = [
-                { label: ProjectRuntime.beta, description: '(.NET Core)' },
-                { label: ProjectRuntime.one, description: '(.NET Framework)' }
-            ];
-            const options: QuickPickOptions = { placeHolder: localize('pickTemplateVersion', 'Select the template version to install') };
-            const versionResult: QuickPickItem = await ui.showQuickPick(picks, options);
-            if (versionResult.label === ProjectRuntime.one) {
-                templateVersion = v1TemplateVersion;
+        const templatesVersion: string | undefined = templatesInstalled ? ext.context.globalState.get(templatesKey) : undefined;
+        const cliFeedJson: cliFeedJsonResponse | undefined = await tryGetCliFeedJson();
+        if (!cliFeedJson) {
+            if (templatesInstalled) {
+                return;
+            } else {
+                throw new Error(localize('retryInternet', 'There was an error in retrieving the templates.  Recheck your internet connection and try again.'));
             }
         }
 
-        const packagesCsproj: string = getPackagesCsproj(templateVersion);
-
-        const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());
-        await fse.ensureDir(tempFolder);
-        try {
-            await fse.writeFile(path.join(tempFolder, 'packages.csproj'), packagesCsproj);
-
-            // 'dotnet new --install' doesn't allow you to specify a source when installing templates
-            // Once these templates are published to Nuget.org, we can just call 'dotnet new --install' directly and skip all the tempFolder/restore stuff
-            outputChannel.show();
-            outputChannel.appendLine(localize('downloadingTemplates', 'Downloading .NET templates for Azure Functions...'));
-            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'restore', '--packages', '.', '--source', 'https://www.myget.org/F/azure-appservice/api/v3/index.json', '--source', 'https://api.nuget.org/v3/index.json');
-
-            const fullProjectPackageId: string = `${projectPackageId}.${templateVersion}`;
-            outputChannel.appendLine(localize('installFuncProject', 'Installing "{0}"', fullProjectPackageId));
-            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(projectPackageId, templateVersion, `${fullProjectPackageId}.nupkg`));
-
-            const fullFunctionsPackageId: string = `${functionsPackageId}.${templateVersion}`;
-            outputChannel.appendLine(localize('installFuncs', 'Installing "{0}"', fullFunctionsPackageId));
-            await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', path.join(functionsPackageId, templateVersion, `${fullFunctionsPackageId}.nupkg`));
-
-            outputChannel.appendLine(localize('finishedInstallingTemplates', 'Finished installing Azure Functions templates.'));
-            outputChannel.appendLine(localize('howToUninstall', 'NOTE: You may uninstall or reinstall the templates with the following steps:'));
-            outputChannel.appendLine(localize('howToUninstall1', '1. Open Command Palette (View -> Command Palette...)'));
-            outputChannel.appendLine(localize('howToUninstall2', '2. Search for "Azure Functions" and "install" or "uninstall"'));
-            outputChannel.appendLine(localize('howToUninstall3', '3. Run the corresponding command for .NET templates'));
-        } finally {
-            await fse.remove(tempFolder);
+        let runtime: ProjectRuntime | undefined = await functionRuntimeUtils.tryGetLocalRuntimeVersion();
+        if (runtime === undefined) {
+            const picks: IAzureQuickPickItem<ProjectRuntime>[] = [
+                { label: ProjectRuntime.beta, description: '(.NET Core)', data: ProjectRuntime.beta },
+                { label: ProjectRuntime.one, description: '(.NET Framework)', data: ProjectRuntime.one }
+            ];
+            const options: QuickPickOptions = { placeHolder: localize('pickTemplateVersion', 'Select the template version to install') };
+            runtime = (await ext.ui.showQuickPick(picks, options)).data;
         }
+
+        const latestRelease: string = await tryGetTemplateVersionSetting(actionContext, cliFeedJson, runtime) || cliFeedJson.tags[getFeedRuntime(runtime)].release;
+        if (templatesVersion !== latestRelease) {
+            ext.outputChannel.show();
+            ext.outputChannel.appendLine(localize('updatingTemplates', 'Updating .NET templates for Azure Functions...'));
+            if (templatesInstalled) {
+                await uninstallTemplates();
+            }
+
+            const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());
+            await fse.ensureDir(tempFolder);
+            try {
+                ext.outputChannel.appendLine(localize('installFuncProject', 'Installing "{0}"', projectPackageId));
+                const projectTemplatePath: string = await downloadDotnetTemplates(cliFeedJson.releases[latestRelease].projectTemplates, tempFolder, projectPackageId);
+                await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', projectTemplatePath);
+
+                ext.outputChannel.appendLine(localize('installFuncs', 'Installing "{0}"', functionsPackageId));
+                const functionsTemplatePath: string = await downloadDotnetTemplates(cliFeedJson.releases[latestRelease].itemTemplates, tempFolder, functionsPackageId);
+                await cpUtils.executeCommand(undefined, tempFolder, 'dotnet', 'new', '--install', functionsTemplatePath);
+
+                ext.context.globalState.update(templatesKey, latestRelease);
+            } finally {
+                await fse.remove(tempFolder);
+            }
+        }
+    }
+
+    export async function uninstallTemplates(): Promise<void> {
+        await validateDotnetInstalled();
+
+        ext.outputChannel.show();
+        ext.outputChannel.appendLine(localize('uninstallFuncProject', 'Uninstalling "{0}"', projectPackageId));
+        await cpUtils.executeCommand(undefined, undefined, 'dotnet', 'new', '--uninstall', projectPackageId);
+        ext.outputChannel.appendLine(localize('uninstallFuncs', 'Uninstalling "{0}"', functionsPackageId));
+        await cpUtils.executeCommand(undefined, undefined, 'dotnet', 'new', '--uninstall', functionsPackageId);
+        ext.outputChannel.appendLine(localize('finishedUninstallingTemplates', 'Finished uninstalling Azure Functions templates.'));
+        ext.context.globalState.update(templatesKey, undefined);
     }
 }

--- a/src/utils/getCliFeedJson.ts
+++ b/src/utils/getCliFeedJson.ts
@@ -6,6 +6,7 @@
 // tslint:disable-next-line:no-require-imports
 import request = require('request-promise');
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
+import { ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
 
 const funcCliFeedUrl: string = 'https://aka.ms/V00v5v';
@@ -20,7 +21,9 @@ export type cliFeedJsonResponse = {
     },
     releases: {
         [release: string]: {
-            templateApiZip: string
+            templateApiZip: string,
+            itemTemplates: string,
+            projectTemplates: string
         }
     }
 };
@@ -36,4 +39,15 @@ export async function tryGetCliFeedJson(): Promise<cliFeedJsonResponse | undefin
         };
         return <cliFeedJsonResponse>JSON.parse(await <Thenable<string>>request(funcJsonOptions).promise());
     });
+}
+
+export function getFeedRuntime(runtime: ProjectRuntime): string {
+    switch (runtime) {
+        case ProjectRuntime.beta:
+            return 'v2';
+        case ProjectRuntime.one:
+            return 'v1';
+        default:
+            throw new RangeError();
+    }
 }

--- a/test/TestExtensionContext.ts
+++ b/test/TestExtensionContext.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// disabling for unimportant test code
+// tslint:disable:no-reserved-keywords
+// tslint:disable:no-any
+// tslint:disable:typedef
+// tslint:disable:strict-boolean-expressions
+
+import { ExtensionContext, Memento } from 'vscode';
+
+class TestMemento implements Memento {
+    private _data: { [key: string]: any } = {};
+    public get<T>(key: string): T | undefined;
+    public get<T>(key: string, defaultValue: T): T;
+    public get(key: any, defaultValue?: any) {
+        return this._data[key] || defaultValue;
+    }
+    public async update(key: string, value: any): Promise<void> {
+        this._data[key] = value;
+    }
+}
+
+export class TestExtensionContext implements ExtensionContext {
+    public subscriptions: { dispose(): any; }[]; public workspaceState: Memento;
+    public globalState: Memento;
+    public extensionPath: string;
+    public storagePath: string | undefined;
+    constructor() {
+        this.globalState = new TestMemento();
+    }
+    public asAbsolutePath(_relativePath: string): string {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { TestUserInput } from 'vscode-azureextensionui';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ProjectLanguage, ProjectRuntime } from '../../src/constants';
 import { dotnetUtils } from '../../src/utils/dotnetUtils';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -32,7 +32,7 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
     suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
         this.timeout(120 * 1000);
         await csTester.initAsync();
-        await dotnetUtils.installDotnetTemplates(new TestUserInput([]), csTester.outputChannel);
+        await dotnetUtils.validateTemplatesInstalled(<IActionContext>{ properties: {} });
     });
 
     // tslint:disable-next-line:no-function-expression

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -30,7 +30,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
     suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
         this.timeout(120 * 1000);
         await fse.ensureDir(testFolderPath);
-        await dotnetUtils.installDotnetTemplates(new TestUserInput([]), outputChannel);
+        await dotnetUtils.validateTemplatesInstalled(<IActionContext>{ properties: {} });
     });
 
     suiteTeardown(async () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -12,6 +12,8 @@
 
 // tslint:disable-next-line:no-require-imports
 import testRunner = require('vscode/lib/testrunner');
+import { ext } from '../src/extensionVariables';
+import { TestExtensionContext } from './TestExtensionContext';
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
@@ -22,3 +24,5 @@ testRunner.configure({
 });
 
 module.exports = testRunner;
+
+ext.context = new TestExtensionContext();


### PR DESCRIPTION
Rather than hard-coding the version, always update to the version of dotnet templates listed in the cli feed. NOTE: @fiveisprime and I decided to no longer prompt when installing dotnet templates (unless we don't know what version to install).

Required as a part of #179