### PR TITLE
Run publish task before every csharp deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.23.0"
+        "vscode": "^1.24.0"
     },
     "repository": {
         "type": "git",

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -21,6 +21,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
 
+    private _debugSubpath: string;
     private _runtime: ProjectRuntime;
 
     public async addNonVSCodeFiles(): Promise<void> {
@@ -77,7 +78,8 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     }
                 }
             }
-            this.deploySubpath = `bin/Debug/${targetFramework}`;
+            this.deploySubpath = `bin/Release/${targetFramework}/publish`;
+            this._debugSubpath = `bin/Debug/${targetFramework}`;
         }
 
         return this._runtime;
@@ -111,12 +113,31 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
+                    label: 'clean release',
+                    command: 'dotnet clean --configuration Release',
+                    type: 'shell',
+                    presentation: {
+                        reveal: 'always'
+                    },
+                    problemMatcher: '$msCompile'
+                },
+                {
+                    label: 'publish',
+                    command: 'dotnet publish --configuration Release',
+                    type: 'shell',
+                    dependsOn: 'clean release',
+                    presentation: {
+                        reveal: 'always'
+                    },
+                    problemMatcher: '$msCompile'
+                },
+                {
                     label: localize('azFunc.runFuncHost', 'Run Functions Host'),
                     identifier: funcHostTaskId,
                     type: 'shell',
                     dependsOn: 'build',
                     options: {
-                        cwd: `\${workspaceFolder}/${this.deploySubpath}`
+                        cwd: `\${workspaceFolder}/${this._debugSubpath}`
                     },
                     command: 'func host start',
                     isBackground: true,


### PR DESCRIPTION
This ensures the latest code is always deployed. It's also just better to deploy the publish output rather than the build output.

This depends on the tasks api released in v1.24 of VS Code

Fixes #223