### PR TITLE
Leverage 'func --version' with newer versions of the cli

### DIFF
--- a/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
+++ b/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
@@ -7,16 +7,21 @@ import * as semver from 'semver';
 import { cpUtils } from '../utils/cpUtils';
 
 export async function getLocalFuncCoreToolsVersion(): Promise<string | null> {
-    // https://github.com/Microsoft/vscode-azurefunctions/issues/343
-    const versionInfo: string = await cpUtils.executeCommand(undefined, undefined, 'func');
-    const matchResult: RegExpMatchArray | null = versionInfo.match(/(?:.*)Azure Functions Core Tools (.*)/);
-    if (matchResult !== null) {
-        let localVersion: string = matchResult[1].replace(/[()]/g, '').trim(); // remove () and whitespace
-        // this is a fix for a bug currently in the Function CLI
-        if (localVersion === '220.0.0-beta.0') {
-            localVersion = '2.0.1-beta.25';
+    const output: string = await cpUtils.executeCommand(undefined, undefined, 'func', '--version');
+    const version: string | null = semver.clean(output);
+    if (version) {
+        return version;
+    } else {
+        // Old versions of the func cli do not support '--version', so we have to parse the command usage to get the version
+        const matchResult: RegExpMatchArray | null = output.match(/(?:.*)Azure Functions Core Tools (.*)/);
+        if (matchResult !== null) {
+            let localVersion: string = matchResult[1].replace(/[()]/g, '').trim(); // remove () and whitespace
+            // this is a fix for a bug currently in the Function CLI
+            if (localVersion === '220.0.0-beta.0') {
+                localVersion = '2.0.1-beta.25';
+            }
+            return semver.valid(localVersion);
         }
-        return semver.valid(localVersion);
+        return null;
     }
-    return null;
 }


### PR DESCRIPTION
'func --version' didn't used to be supported, but now it is.

Fixes #343 