### PR TITLE
Retrieve the function version and node version from the cli feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -641,7 +641,7 @@
         "ps-node": "^0.1.6",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "~0.17.0",
+        "vscode-azureappservice": "~0.18.0",
         "vscode-azureextensionui": "~0.16.0",
         "vscode-azurekudu": "~0.1.8",
         "vscode-extension-telemetry": "^0.0.15",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -22,6 +22,7 @@ import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
 import { cpUtils } from '../utils/cpUtils';
 import { isSubpath } from '../utils/fs';
+import { getCliFeedAppSettings } from '../utils/getCliFeedJson';
 import { mavenUtils } from '../utils/mavenUtils';
 import * as workspaceUtil from '../utils/workspace';
 
@@ -165,8 +166,12 @@ async function verifyRuntimeIsCompatible(localRuntime: ProjectRuntime, ui: IAzur
                 telemetryProperties.cancelStep = 'learnMoreRuntime';
                 throw new UserCancelledError();
             } else {
-                outputChannel.appendLine(localize('azFunc.updateFunctionRuntime', 'Updating FUNCTIONS_EXTENSION_VERSION to "{0}"...', localRuntime));
-                appSettings.properties.FUNCTIONS_EXTENSION_VERSION = localRuntime;
+                const newAppSettings: { [key: string]: string } = await getCliFeedAppSettings(localRuntime);
+                for (const key of Object.keys(newAppSettings)) {
+                    const value: string = newAppSettings[key];
+                    outputChannel.appendLine(localize('updateFunctionRuntime', 'Updating "{0}" to "{1}"...', key, value));
+                    appSettings.properties[key] = value;
+                }
                 await client.updateApplicationSettings(appSettings);
             }
         }

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -9,7 +9,11 @@ import { Site, WebAppCollection } from "azure-arm-website/lib/models";
 import { OutputChannel } from "vscode";
 import { createFunctionApp, SiteClient } from 'vscode-azureappservice';
 import { IActionContext, IAzureNode, IAzureTreeItem, IChildProvider } from 'vscode-azureextensionui';
+import { ProjectRuntime, projectRuntimeSetting } from '../constants';
+import { tryGetLocalRuntimeVersion } from '../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from "../localize";
+import { getFuncExtensionSetting } from '../ProjectSettings';
+import { getCliFeedAppSettings } from '../utils/getCliFeedJson';
 import { FunctionAppTreeItem } from "./FunctionAppTreeItem";
 
 export class FunctionAppProvider implements IChildProvider {
@@ -49,7 +53,26 @@ export class FunctionAppProvider implements IChildProvider {
     }
 
     public async createChild(parent: IAzureNode, showCreatingNode: (label: string) => void, actionContext: IActionContext): Promise<IAzureTreeItem> {
-        const site: Site = await createFunctionApp(actionContext, parent.credentials, parent.subscriptionId, parent.subscriptionDisplayName, showCreatingNode);
+        const runtime: ProjectRuntime = await getDefaultRuntime();
+        const appSettings: { [key: string]: string } = await getCliFeedAppSettings(runtime);
+        const site: Site = await createFunctionApp(actionContext, parent.credentials, parent.subscriptionId, parent.subscriptionDisplayName, showCreatingNode, appSettings);
         return new FunctionAppTreeItem(new SiteClient(site, parent), this._outputChannel);
     }
+}
+
+async function getDefaultRuntime(): Promise<ProjectRuntime> {
+    // Try to get VS Code setting for runtime (aka if they have a project open)
+    let runtime: ProjectRuntime | undefined = getFuncExtensionSetting(projectRuntimeSetting);
+
+    if (runtime === undefined) {
+        // Try to get the runtime that matches their local func cli version
+        runtime = await tryGetLocalRuntimeVersion();
+    }
+
+    if (runtime === undefined) {
+        // Default to v1 if all else fails
+        runtime = ProjectRuntime.one;
+    }
+
+    return runtime;
 }

--- a/src/utils/getCliFeedJson.ts
+++ b/src/utils/getCliFeedJson.ts
@@ -9,6 +9,8 @@ import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azuree
 import { ProjectRuntime } from '../constants';
 
 const funcCliFeedUrl: string = 'https://aka.ms/V00v5v';
+const v1DefaultNodeVersion: string = '6.5.0';
+const v2DefaultNodeVersion: string = '8.11.1';
 
 export type cliFeedJsonResponse = {
     tags: {
@@ -59,7 +61,7 @@ export function getFeedRuntime(runtime: ProjectRuntime): string {
 export async function getCliFeedAppSettings(projectRuntime: ProjectRuntime): Promise<{ [key: string]: string }> {
     // Use these defaults in case we can't get the cli-feed
     let funcVersion: string = projectRuntime;
-    let nodeVersion: string = projectRuntime === ProjectRuntime.one ? '6.5.0' : '8.11.1';
+    let nodeVersion: string = projectRuntime === ProjectRuntime.one ? v1DefaultNodeVersion : v2DefaultNodeVersion;
 
     const cliFeed: cliFeedJsonResponse | undefined = await tryGetCliFeedJson();
     if (cliFeed) {


### PR DESCRIPTION
The old behavior always creates function apps for v1 and prompted users if they tried to deploy and their versions didn't match.

The new behavior detects their runtime and creates a function app that matches (although the warning on deploy still exists just in case).

As a part of this, we want to make sure the node version matches the runtime version as well. This information is contained in the cli-feed, although I've hard-coded backup versions just in case. This fixes #419 

Based on https://github.com/Microsoft/vscode-azuretools/pull/218