### PR TITLE
Add setting validation and Azure prompts back to C# templates

### DIFF
--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -59,7 +59,7 @@ async function promptForBooleanSetting(setting: IFunctionSetting): Promise<strin
 async function promptForStringSetting(setting: IFunctionSetting): Promise<string> {
     const options: vscode.InputBoxOptions = {
         placeHolder: setting.label,
-        prompt: localize('azFunc.stringSettingPrompt', 'Provide a \'{0}\'', setting.label),
+        prompt: setting.description || localize('azFunc.stringSettingPrompt', 'Provide a \'{0}\'', setting.label),
         validateInput: (s: string): string | undefined => setting.validateSetting(s),
         value: setting.defaultValue
     };

--- a/src/templates/IFunctionSetting.ts
+++ b/src/templates/IFunctionSetting.ts
@@ -46,6 +46,7 @@ export interface IFunctionSetting {
     defaultValue: string | undefined;
     enums: IEnumValue[];
     label: string;
+    description?: string;
     name: string;
     validateSetting(value: string | undefined): string | undefined;
 }

--- a/src/templates/parseDotnetTemplates.ts
+++ b/src/templates/parseDotnetTemplates.ts
@@ -37,6 +37,7 @@ function parseDotnetSetting(rawSetting: IRawSetting): IFunctionSetting {
         valueType: rawSetting.DataType === 'choice' ? ValueType.enum : ValueType.string,
         defaultValue: rawSetting.DefaultValue,
         label: rawSetting.Name,
+        description: rawSetting.Documentation,
         enums: rawSetting.Choices ? Object.keys(rawSetting.Choices).map((key: string) => { return { value: key, displayName: key }; }) : [],
         validateSetting: (): undefined => { return undefined; } // Dotnet templates do not give us validation information
     };


### PR DESCRIPTION
We lost setting validation and some Azure-specific prompts when we switched to dynamic retrieval of .NET templates. Fortunately, we can pretty easily copy this information from JavaScript templates. We only do this if the template name _and_ setting name match exactly, so it will default to the plain-old .NET experience when applicable.

I also leveraged the 'Documenation' information that is supplied with the .NET templates. This is the one case where these templates actually provide more information than the JavaScript templates. Rather than just `Provide a 'schedule'`, the user might see something like this:
![screen shot 2018-07-17 at 4 19 09 pm](https://user-images.githubusercontent.com/11282622/42851721-89d67c7c-89e2-11e8-8559-8a0b10e9ee8b.png)
