### PR TITLE
Add a few more verified templates to C# v1

### DIFF
--- a/src/templates/DotnetTemplateRetriever.ts
+++ b/src/templates/DotnetTemplateRetriever.ts
@@ -50,14 +50,23 @@ export class DotnetTemplateRetriever extends TemplateRetriever {
 }
 
 export function getDotnetVerifiedTemplateIds(runtime: string): string[] {
-    const verifiedTemplateIds: string[] = [
-        'Azure.Function.CSharp.HttpTrigger',
-        'Azure.Function.CSharp.BlobTrigger',
-        'Azure.Function.CSharp.QueueTrigger',
-        'Azure.Function.CSharp.TimerTrigger'
+    let verifiedTemplateIds: string[] = [
+        'HttpTrigger',
+        'BlobTrigger',
+        'QueueTrigger',
+        'TimerTrigger'
     ];
 
+    if (runtime === ProjectRuntime.one) {
+        verifiedTemplateIds = verifiedTemplateIds.concat([
+            'GenericWebHook',
+            'GitHubWebHook',
+            'HttpTriggerWithParameters'
+        ]);
+    }
+
     return verifiedTemplateIds.map((id: string) => {
+        id = `Azure.Function.CSharp.${id}`;
         switch (runtime) {
             case ProjectRuntime.one:
                 return `${id}.1.x`;

--- a/test/functionTemplates.test.ts
+++ b/test/functionTemplates.test.ts
@@ -44,7 +44,7 @@ async function validateTemplateCounts(templates: FunctionTemplates): Promise<voi
     assert.equal(javaTemplates.length, 4, 'Unexpected Java templates count.');
 
     const cSharpTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.one, TemplateFilter.Verified);
-    assert.equal(cSharpTemplates.length, 4, 'Unexpected CSharp (.NET Framework) templates count.');
+    assert.equal(cSharpTemplates.length, 7, 'Unexpected CSharp (.NET Framework) templates count.');
 
     const cSharpTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.beta, TemplateFilter.Verified);
     assert.equal(cSharpTemplatesv2.length, 4, 'Unexpected CSharp (.NET Core) templates count.');


### PR DESCRIPTION
Since we now have more templates available, I tried to make this list match the verified templates for JavaScript. v2 is exactly the same for both (just 4 templates). JavaScript has 8 for v1 while C# only has 7 (it's missing the ManualTrigger for some reason).

I tested the new templates and they worked for me.