### PR TITLE
Fix error in logic when checking for publish task

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -20,7 +20,7 @@ import { convertStringToRuntime, getFuncExtensionSetting, getProjectLanguage, ge
 import { FunctionAppTreeItem } from '../tree/FunctionAppTreeItem';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
-import { isSubpath } from '../utils/fs';
+import { isPathEqual, isSubpath } from '../utils/fs';
 import { getCliFeedAppSettings } from '../utils/getCliFeedJson';
 import { mavenUtils } from '../utils/mavenUtils';
 import * as workspaceUtil from '../utils/workspace';
@@ -189,7 +189,7 @@ async function tryPublishCSharpProject(deployFsPath: string, outputChannel: vsco
     for (const task of tasks) {
         if (task.name.toLowerCase() === 'publish' && task.scope !== undefined) {
             const workspaceFolder: vscode.WorkspaceFolder = <vscode.WorkspaceFolder>task.scope;
-            if (<vscode.Uri | undefined>workspaceFolder.uri && isSubpath(workspaceFolder.uri.fsPath, deployFsPath)) {
+            if (<vscode.Uri | undefined>workspaceFolder.uri && (isPathEqual(workspaceFolder.uri.fsPath, deployFsPath) || isSubpath(workspaceFolder.uri.fsPath, deployFsPath))) {
                 publishTask = task;
                 break;
             }


### PR DESCRIPTION
When I'm checking for the existence of the publish task, I was only using the workspace folder if the deployFsPath was a _sub_ folder of the workspace. However, I should also use the workspace folder if it's equal.

In practice, this should not be that much of a problem because you should usually deploy a sub folder for C# projects. However, I ran into this because of a bug where I was accidently deploying the root folder (See https://github.com/Microsoft/vscode-azurefunctions/pull/464 for more info)