### PR TITLE
Temporarily remove proxies.json

### DIFF
--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -5,7 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime, proxiesFileName, TemplateFilter } from '../../constants';
+import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime, TemplateFilter } from '../../constants';
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { ILocalAppSettings } from '../../LocalAppSettings';
 import { confirmOverwriteFile } from "../../utils/fs";
@@ -97,6 +97,8 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
             await fsUtil.writeFormattedJson(localSettingsJsonPath, localSettingsJson);
         }
 
+        // Temporarily disabling due to https://github.com/Azure/azure-functions-core-tools/issues/562
+        /*
         const proxiesJsonPath: string = path.join(this.functionAppPath, proxiesFileName);
         if (await confirmOverwriteFile(proxiesJsonPath, this.ui)) {
             const proxiesJson: {} = {
@@ -106,6 +108,7 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
             };
             await fsUtil.writeFormattedJson(proxiesJsonPath, proxiesJson);
         }
+        */
 
         const gitignorePath: string = path.join(this.functionAppPath, gitignoreFileName);
         if (await confirmOverwriteFile(gitignorePath, this.ui)) {


### PR DESCRIPTION
I ran into this issue: https://github.com/Azure/azure-functions-core-tools/issues/562

It only reproduces on a Mac, but it breaks debugging. It sounds like the issue has already been fixed in the functions cli - just not released yet. @nturinski can you see if this reproduces for you as well? If so, we just won't include 'proxies.json' in projects by default for this release and add it back in the next.

Repro steps:
1. Create a JavaScript project on a Mac
1. Add an HttpTrigger
1. F5