### PR TITLE
Add host.json version

### DIFF
--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -70,7 +70,9 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
     public async addNonVSCodeFiles(): Promise<void> {
         const hostJsonPath: string = path.join(this.functionAppPath, hostFileName);
         if (await confirmOverwriteFile(hostJsonPath, this.ui)) {
-            const hostJson: {} = {};
+            const hostJson: {} = {
+                version: '2.0'
+            };
             await fsUtil.writeFormattedJson(hostJsonPath, hostJson);
         }
 


### PR DESCRIPTION
See breaking changes announced here: https://github.com/Azure/app-service-announcements/issues/129#issuecomment-416296046

The version property is now a required part of the 'host.json' file