### PR TITLE
Fix duplicate identifiers when linking npm packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,14 @@
         "noImplicitThis": true,
         "noImplicitReturns": true,
         "strictNullChecks": true,
-        "noUnusedParameters": true
+        "noUnusedParameters": true,
+        "baseUrl": "./",
+        "paths": {
+            "*": [
+                "node_modules/vscode/*",
+                "*"
+            ]
+        }
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
When running `npm link` with the [shared packages](https://github.com/microsoft/vscode-azuretools), we get a bunch of build errors like this:
![screen shot 2018-08-28 at 11 02 03 am](https://user-images.githubusercontent.com/11282622/44741433-e30ccb80-aab1-11e8-9902-b814ada2cc31.png)

The solution was based off of this comment: https://github.com/Microsoft/TypeScript/issues/11916#issuecomment-257130001

My understanding is that by having multiple "paths" defined, it will only use the typings in the first path and ignore any duplicates found in the second path.