### PR TITLE
Ensure spaces and special chars are preserved

### DIFF
--- a/src/commands/createFunction/CSharpFunctionCreator.ts
+++ b/src/commands/createFunction/CSharpFunctionCreator.ts
@@ -12,6 +12,7 @@ import { ProjectRuntime } from '../../constants';
 import { localize } from "../../localize";
 import { executeDotnetTemplateCommand } from '../../templates/executeDotnetTemplateCommand';
 import { IFunctionTemplate } from "../../templates/IFunctionTemplate";
+import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
 import * as fsUtil from '../../utils/fs';
 import { FunctionCreatorBase } from './FunctionCreatorBase';
@@ -54,14 +55,14 @@ export class CSharpFunctionCreator extends FunctionCreatorBase {
 
         const args: string[] = [];
         args.push('--arg:name');
-        args.push(this._functionName);
+        args.push(cpUtils.wrapArgInQuotes(this._functionName));
 
         args.push('--arg:namespace');
-        args.push(this._namespace);
+        args.push(cpUtils.wrapArgInQuotes(this._namespace));
 
         for (const key of Object.keys(userSettings)) {
             args.push(`--arg:${key}`);
-            args.push(`"${userSettings[key]}"`);
+            args.push(cpUtils.wrapArgInQuotes(userSettings[key]));
         }
 
         await executeDotnetTemplateCommand(runtime, this._functionAppPath, 'create', '--identity', this._template.id, ...args);

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -15,6 +15,7 @@ import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntim
 import { localize } from "../../localize";
 import { getFuncExtensionSetting, promptForProjectRuntime, updateGlobalSetting } from '../../ProjectSettings';
 import { executeDotnetTemplateCommand } from '../../templates/executeDotnetTemplateCommand';
+import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
 import { funcHostTaskId, ProjectCreatorBase } from './IProjectCreator';
 
@@ -38,7 +39,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
         this._runtime = await tryGetLocalRuntimeVersion() || await promptForProjectRuntime(this.ui);
         const identity: string = `Microsoft.AzureFunctions.ProjectTemplate.CSharp.${this._runtime === ProjectRuntime.one ? '1' : '2'}.x`;
         const functionsVersion: string = this._runtime === ProjectRuntime.one ? 'v1' : 'v2';
-        await executeDotnetTemplateCommand(this._runtime, this.functionAppPath, 'create', '--identity', identity, '--arg:name', projectName, '--arg:AzureFunctionsVersion', functionsVersion);
+        await executeDotnetTemplateCommand(this._runtime, this.functionAppPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);
 
         if (!this._hasDetectedRuntime) {
             await this.detectRuntime();

--- a/src/templates/executeDotnetTemplateCommand.ts
+++ b/src/templates/executeDotnetTemplateCommand.ts
@@ -10,7 +10,18 @@ import { cpUtils } from "../utils/cpUtils";
 
 export async function executeDotnetTemplateCommand(runtime: ProjectRuntime, workingDirectory: string | undefined, operation: 'list' | 'create', ...args: string[]): Promise<string> {
     const jsonDllPath: string = ext.context.asAbsolutePath(path.join('resources', 'dotnetJsonCli', 'Microsoft.TemplateEngine.JsonCli.dll'));
-    return await cpUtils.executeCommand(undefined, workingDirectory, 'dotnet', jsonDllPath, '--require', getDotnetItemTemplatePath(runtime), '--require', getDotnetProjectTemplatePath(runtime), '--operation', operation, ...args);
+    return await cpUtils.executeCommand(
+        undefined,
+        workingDirectory,
+        'dotnet',
+        cpUtils.wrapArgInQuotes(jsonDllPath),
+        '--require',
+        cpUtils.wrapArgInQuotes(getDotnetItemTemplatePath(runtime)),
+        '--require',
+        cpUtils.wrapArgInQuotes(getDotnetProjectTemplatePath(runtime)),
+        '--operation',
+        operation,
+        ...args);
 }
 
 export function getDotnetTemplatesPath(): string {

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -6,6 +6,7 @@
 import * as cp from 'child_process';
 import * as os from 'os';
 import * as vscode from 'vscode';
+import { isWindows } from '../constants';
 import { localize } from '../localize';
 
 export namespace cpUtils {
@@ -80,5 +81,13 @@ export namespace cpUtils {
         cmdOutput: string;
         cmdOutputIncludingStderr: string;
         formattedArgs: string;
+    }
+
+    const quotationMark: string = isWindows ? '"' : '\'';
+    /**
+     * Ensures spaces and special characters (most notably $) are preserved
+     */
+    export function wrapArgInQuotes(arg: string): string {
+        return quotationMark + arg + quotationMark;
     }
 }

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -7,13 +7,11 @@ import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
 import { TelemetryProperties } from "vscode-azureextensionui";
 import * as xml2js from 'xml2js';
-import { Platform } from '../constants';
 import { localize } from '../localize';
 import { cpUtils } from './cpUtils';
 
 export namespace mavenUtils {
     const mvnCommand: string = 'mvn';
-    const quotationMark: string = process.platform === Platform.Windows ? '"' : '\'';
     export async function validateMavenInstalled(workingDirectory: string | undefined): Promise<void> {
         try {
             await cpUtils.executeCommand(undefined, workingDirectory, mvnCommand, '--version');
@@ -68,6 +66,6 @@ export namespace mavenUtils {
     }
 
     export function formatMavenArg(key: string, value: string): string {
-        return `-${key}=${quotationMark}${value}${quotationMark}`;
+        return `-${key}=${cpUtils.wrapArgInQuotes(value)}`;
     }
 }


### PR DESCRIPTION
We have the same problem for C# functions that was reported for Java functions: https://github.com/Microsoft/vscode-azurefunctions/issues/516. Specifically, some parameters have `$` in the name, which gets evaluated on mac/linux unless we use single quotes

Fixes #519 - This one is just to fix C# templates when a user has a space in the path to their extension repo