### PR TITLE
Run 'func extensions install' before debug/deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -591,6 +591,10 @@
                             "OpenInCurrentWindow"
                         ],
                         "description": "%azFunc.projectOpenBehaviorDescription%"
+                    },
+                    "azureFunctions.preDeployTask": {
+                        "type": "string",
+                        "description": "%azFunc.preDeployTaskDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,5 +42,6 @@
     "azFunc.showFuncInstallationDescription": "Show a warning to install Azure Functions Core Tools CLI when you create a new project if the CLI is not installed.",
     "azFunc.templateVersion": "A runtime release version (any runtime) that species which templates will be used rather than the latest templates.  This version will be used for ALL runtimes. (Requires a restart of VS Code to take effect)",
     "azFunc.projectOpenBehaviorDescription": "The behavior to use after creating a new project. The options are \"AddToWorkspace\", \"OpenInNewWindow\", or \"OpenInCurrentWindow\".",
-    "azFunc.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools"
+    "azFunc.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
+    "azFunc.preDeployTaskDescription": "The name of the task to run before zip deployments."
 }

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { DialogResponses, parseError } from 'vscode-azureextensionui';
-import { gitignoreFileName, hostFileName, isWindows, localSettingsFileName, ProjectRuntime, TemplateFilter } from '../../constants';
+import { gitignoreFileName, hostFileName, isWindows, localSettingsFileName, ProjectRuntime, publishTaskId, TemplateFilter } from '../../constants';
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from "../../localize";
 import { getFuncExtensionSetting, promptForProjectRuntime, updateGlobalSetting } from '../../ProjectSettings';
@@ -22,6 +22,7 @@ import { funcHostTaskId, ProjectCreatorBase } from './IProjectCreator';
 export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
+    public preDeployTask: string = publishTaskId;
 
     private _debugSubpath: string;
     private _runtime: ProjectRuntime;
@@ -91,7 +92,8 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
-                    label: 'publish',
+                    label: publishTaskId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
+                    identifier: publishTaskId,
                     command: 'dotnet publish --configuration Release',
                     type: 'shell',
                     dependsOn: 'clean release',

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -12,6 +12,7 @@ import { promptForProjectRuntime } from "../../ProjectSettings";
 
 export abstract class ProjectCreatorBase {
     public deploySubpath: string = '';
+    public preDeployTask: string = '';
     public abstract templateFilter: TemplateFilter;
 
     protected readonly functionAppPath: string;

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ProjectRuntime, TemplateFilter } from "../../constants";
+import { installExtensionsId, ProjectRuntime, TemplateFilter } from "../../constants";
 import { localize } from "../../localize";
 import { funcHostProblemMatcher, funcHostTaskId, funcHostTaskLabel } from "./IProjectCreator";
 import { ITaskOptions } from "./ITasksJson";
@@ -16,6 +16,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
 
     public readonly functionsWorkerRuntime: string | undefined = 'node';
+    public preDeployTask: string = installExtensionsId;
 
     public getLaunchJson(): {} {
         return {
@@ -56,7 +57,17 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
                     },
                     problemMatcher: [
                         funcHostProblemMatcher
-                    ]
+                    ],
+                    dependsOn: installExtensionsId
+                },
+                {
+                    label: installExtensionsId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
+                    identifier: installExtensionsId,
+                    command: 'func extensions install',
+                    type: 'shell',
+                    presentation: {
+                        reveal: 'always'
+                    }
                 }
             ]
         };

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { OutputChannel } from 'vscode';
 import { IAzureUserInput, TelemetryProperties } from 'vscode-azureextensionui';
-import { deploySubpathSetting, extensionPrefix, gitignoreFileName, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../constants';
+import { deploySubpathSetting, extensionPrefix, gitignoreFileName, preDeployTaskSetting, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../constants';
 import { localize } from '../../localize';
 import { getGlobalFuncExtensionSetting, promptForProjectLanguage } from '../../ProjectSettings';
 import { confirmOverwriteFile } from '../../utils/fs';
@@ -93,6 +93,9 @@ async function writeVSCodeSettings(projectCreator: ProjectCreatorBase, vscodePat
             data[`${extensionPrefix}.${templateFilterSetting}`] = templateFilter;
             if (projectCreator.deploySubpath) {
                 data[`${extensionPrefix}.${deploySubpathSetting}`] = projectCreator.deploySubpath;
+            }
+            if (projectCreator.preDeployTask) {
+                data[`${extensionPrefix}.${preDeployTaskSetting}`] = projectCreator.preDeployTask;
             }
             return data;
         },

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -214,8 +214,15 @@ async function verifyRuntimeIsCompatible(localRuntime: ProjectRuntime, ui: IAzur
 
 async function runPreDeployTask(deployFsPath: string, telemetryProperties: TelemetryProperties, language: ProjectLanguage, isZipDeploy: boolean): Promise<void> {
     let taskName: string | undefined = getFuncExtensionSetting(preDeployTaskSetting, deployFsPath);
-    if (!isZipDeploy && taskName) {
-        ext.outputChannel.appendLine(localize('ignoringPreDeployTask', 'WARNING: Ignoring preDeployTask "{0}" for non-zip deploy.', taskName));
+    if (!isZipDeploy) {
+        // We don't run pre deploy tasks for non-zipdeploy since that stuff should be handled by kudu
+
+        if (taskName) {
+            // We only need to warn if they have the setting defined
+            ext.outputChannel.appendLine(localize('ignoringPreDeployTask', 'WARNING: Ignoring preDeployTask "{0}" for non-zip deploy.', taskName));
+        }
+
+        return;
     }
 
     let isTaskNameDefined: boolean = true;

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -225,9 +225,8 @@ async function runPreDeployTask(deployFsPath: string, telemetryProperties: Telem
         return;
     }
 
-    let isTaskNameDefined: boolean = true;
+    const isTaskNameDefinedInSettings: boolean = !!taskName;
     if (!taskName) {
-        isTaskNameDefined = false;
         switch (language) {
             case ProjectLanguage.CSharp:
                 taskName = publishTaskId;
@@ -271,7 +270,7 @@ async function runPreDeployTask(deployFsPath: string, telemetryProperties: Telem
         const messageLines: string[] = [];
         // If the task name was specified in the user's settings, we will throw an error and block the user's deploy if we can't find that task
         // If the task name was _not_ specified, we will display a warning and let the deployment continue. (The preDeployTask isn't _always_ necessary and we don't want to block old projects that never had this setting)
-        if (isTaskNameDefined) {
+        if (isTaskNameDefinedInSettings) {
             messageLines.push(localize('noPreDeployTaskError', 'Did not find preDeploy task "{0}". Change the "{1}.{2}" setting, manually edit your task.json, or re-initialize your VS Code config with the following steps:', taskName, extensionPrefix, preDeployTaskSetting));
         } else {
             messageLines.push(localize('noPreDeployTaskWarning', 'WARNING: Did not find preDeploy task "{0}". The deployment will continue, but the selected folder may not reflect your latest changes.', taskName));
@@ -283,7 +282,7 @@ async function runPreDeployTask(deployFsPath: string, telemetryProperties: Telem
         messageLines.push(localize('howToAddPreDeploy3', '3. Select "Yes" to overwrite your tasks.json file when prompted'));
 
         const fullMessage: string = messageLines.join(os.EOL);
-        if (isTaskNameDefined) {
+        if (isTaskNameDefinedInSettings) {
             throw new Error(fullMessage);
         } else {
             ext.outputChannel.show(true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const projectRuntimeSetting: string = 'projectRuntime';
 export const templateFilterSetting: string = 'templateFilter';
 export const deploySubpathSetting: string = 'deploySubpath';
 export const templateVersionSetting: string = 'templateVersion';
+export const preDeployTaskSetting: string = 'preDeployTask';
 export const v1ReleaseVersion: string = '1.0.12'; // known stable version
 export const betaReleaseVersion: string = '2.0.1-beta.25'; // known stable version
 
@@ -65,3 +66,6 @@ export enum ScmType {
     LocalGit = 'LocalGit',
     GitHub = 'GitHub'
 }
+
+export const publishTaskId: string = 'publish';
+export const installExtensionsId: string = 'installExtensions';


### PR DESCRIPTION
Users need to run `func extensions install` before debugging or deploying on JavaScript projects. This was always the case for some triggers (that we didn't "officially" support in VS Code), but it wasn't required on blob/queue triggers until the most recent functions release. Hence why we're adding this now.

As part of this change, I made the C# 'preDeploy' logic more generic so that it would also cover the JavaScript `func extensions install` case. I also changed the C# logic so that it won't run for local git deployments, since that should be covered by kudu.

Fixes #382 