### PR TITLE
Refactor pickProcess to leverage tasks api

### DIFF
--- a/package.json
+++ b/package.json
@@ -641,7 +641,6 @@
         "ms-rest-azure": "^2.3.1",
         "opn": "^5.2.0",
         "portfinder": "^1.0.13",
-        "ps-node": "^0.1.6",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
         "vscode-azureappservice": "^0.21.0",

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -7,7 +7,6 @@ import { OutputChannel } from "vscode";
 import { IAzureUserInput, TelemetryProperties } from "vscode-azureextensionui";
 import { extensionPrefix, ProjectRuntime, TemplateFilter } from "../../constants";
 import { tryGetLocalRuntimeVersion } from "../../funcCoreTools/tryGetLocalRuntimeVersion";
-import { localize } from "../../localize";
 import { promptForProjectRuntime } from "../../ProjectSettings";
 
 export abstract class ProjectCreatorBase {
@@ -48,7 +47,8 @@ export abstract class ProjectCreatorBase {
 }
 
 export const funcHostTaskId: string = 'runFunctionsHost';
-export const funcHostTaskLabel: string = localize('azFunc.runFuncHost', 'Run Functions Host');
+// Don't localize this label until this is fixed: https://github.com/Microsoft/vscode/issues/57707
+export const funcHostTaskLabel: string = 'Run Functions Host';
 export const funcHostProblemMatcher: {} = {
     owner: extensionPrefix,
     pattern: [

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -3,32 +3,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-// tslint:disable-next-line:no-require-imports
-import ps = require('ps-node');
-import { isNullOrUndefined } from 'util';
 import * as vscode from 'vscode';
+import { Task, TaskExecution } from 'vscode';
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
 import { extensionPrefix, isWindows } from '../constants';
 import { validateFuncCoreToolsInstalled } from '../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../localize';
 import { getFuncExtensionSetting } from '../ProjectSettings';
-import { cpUtils } from '../utils/cpUtils';
-import { funcHostTaskId } from './createNewProject/IProjectCreator';
+import { tryFetchNodeModule } from '../utils/tryFetchNodeModule';
+import { funcHostTaskLabel } from './createNewProject/IProjectCreator';
 
 export async function pickFuncProcess(actionContext: IActionContext): Promise<string | undefined> {
     if (!await validateFuncCoreToolsInstalled(true /* forcePrompt */)) {
         throw new UserCancelledError();
     }
 
-    let funcHostPid: string | undefined = await getFuncHostPid();
-    if (funcHostPid !== undefined) {
-        // Stop the functions host to prevent build errors like "Cannot access the file '...' because it is being used by another process."
-        await killProcess(funcHostPid);
+    // Stop any running func task so that a build can access those dlls
+    await stopFuncTaskIfRunning();
+
+    const tasks: Task[] = await vscode.tasks.fetchTasks();
+    const funcTask: Task | undefined = tasks.find(isFuncTask);
+    if (!funcTask) {
+        throw new Error(localize('noFuncTask', 'Failed to find task with label "{0}".', funcHostTaskLabel));
     }
 
-    // Start (or restart) functions host (which will also trigger a build)
-    await vscode.commands.executeCommand('workbench.action.tasks.runTask', funcHostTaskId);
+    const pid: string = await startFuncTask(funcTask, actionContext);
+    // On Mac/Linux we can leverage the pid of the task directly.
+    // On Windows, the pid of the task corresponds to the parent PowerShell process and we have to drill down to get the actual func process
+    return isWindows ? await getInnermostWindowsPid(pid) : pid;
+}
 
+function isFuncTask(task: Task): boolean {
+    // Until this is fixed, we have to query the task's name instead of id: https://github.com/Microsoft/vscode/issues/57707
+    return task.name.toLowerCase() === funcHostTaskLabel.toLowerCase();
+}
+
+async function stopFuncTaskIfRunning(): Promise<void> {
+    const funcExecution: TaskExecution | undefined = vscode.tasks.taskExecutions.find((te: TaskExecution) => isFuncTask(te.task));
+    if (funcExecution) {
+        const waitForEndPromise: Promise<void> = new Promise((resolve: () => void): void => {
+            const listener: vscode.Disposable = vscode.tasks.onDidEndTask((e: vscode.TaskEndEvent) => {
+                if (isFuncTask(e.execution.task)) {
+                    resolve();
+                    listener.dispose();
+                }
+            });
+        });
+        funcExecution.terminate();
+        await waitForEndPromise;
+    }
+}
+
+async function startFuncTask(funcTask: Task, actionContext: IActionContext): Promise<string> {
     const settingKey: string = 'pickProcessTimeout';
     const settingValue: number | undefined = getFuncExtensionSetting<number>(settingKey);
     const timeoutInSeconds: number = Number(settingValue);
@@ -37,110 +63,53 @@ export async function pickFuncProcess(actionContext: IActionContext): Promise<st
     }
     actionContext.properties.timeoutInSeconds = timeoutInSeconds.toString();
 
-    const maxTime: number = Date.now() + timeoutInSeconds * 1000;
-    while (Date.now() < maxTime) {
-        // Wait one second between each attempt
-        // NOTE: Intentionally waiting at the beginning of the loop since we don't want to attach to the process we just stopped above
-        await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
-
-        funcHostPid = await getFuncHostPid();
-        if (funcHostPid !== undefined) {
-            return funcHostPid;
-        }
-    }
-
-    throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${extensionPrefix}.${settingKey}`));
-}
-
-async function getFuncHostPid(): Promise<string | undefined> {
-    let pids: string[] = [];
-    pids = pids.concat(...await Promise.all([
-        // If the cli is self-contained, the command will look like this: func host start
-        getMatchingPids(/.*func.*/, /.*host.*start.*/),
-        // If the cli is an old version that requires .NET Core to be installed, the command will look like this: dotnet Azure.Functions.Cli.dll host start
-        getMatchingPids(/.*dotnet.*/, /.*Azure\.Functions\.Cli\.dll.*host.*start.*/)
-    ]));
-
-    if (pids.length === 0) {
-        return undefined;
-    } else if (pids.length === 1) {
-        return pids[0];
-    } else {
-        throw new Error(localize('multipleFuncHost', 'Detected multiple processes running the Functions host. Stop all but one process in order to debug.'));
-    }
-}
-
-async function getMatchingPids(commandRegExp: RegExp, argumentsRegExp: RegExp): Promise<string[]> {
-    if (isWindows) {
-        // Ideally we could use 'ps.lookup' for all OS's, but unfortunately it's very slow on windows
-        // Instead, we will call 'wmic' manually and parse the results
-        const processList: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'get', 'CommandLine,Name,ProcessId', '/FORMAT:csv');
-        const regExp: RegExp = new RegExp(`^.*,${argumentsRegExp.source},${commandRegExp.source},(\\d+)$`, 'gmi');
-        const pids: string[] = [];
-        // tslint:disable-next-line:no-constant-condition
-        while (true) {
-            const result: RegExpExecArray | null = regExp.exec(processList);
-            if (!isNullOrUndefined(result) && result.length > 1) {
-                pids.push(result[1]);
-            } else {
-                break;
+    const waitForStartPromise: Promise<string> = new Promise((resolve: (pid: string) => void, reject: (e: Error) => void): void => {
+        const listener: vscode.Disposable = vscode.tasks.onDidStartTaskProcess((e: vscode.TaskProcessStartEvent) => {
+            if (isFuncTask(e.execution.task)) {
+                resolve(e.processId.toString());
+                listener.dispose();
             }
-        }
-
-        return pids;
-    } else {
-        const processList: IProcess[] = await new Promise((resolve: (processList: IProcess[]) => void, reject: (e: Error) => void): void => {
-            //tslint:disable-next-line:no-unsafe-any
-            ps.lookup(
-                {
-                    command: commandRegExp,
-                    arguments: argumentsRegExp
-                },
-                (error: Error | undefined, result: IProcess[]): void => {
-                    if (error) {
-                        reject(error);
-                    } else {
-                        resolve(result);
-                    }
-                });
         });
 
-        return processList.map((proc: IProcess) => proc.pid);
-    }
-}
-
-interface IProcess {
-    pid: string;
-}
-
-async function killProcess(pid: string, timeoutInSeconds: number = 60): Promise<void> {
-    if (isWindows) {
-        // Just like 'ps.lookup', 'ps.kill' is very slow on windows
-        // We can use it to kill the process, but we have to implement our own 'wait' logic to make sure the process actually stopped
-        //tslint:disable-next-line:no-unsafe-any
-        ps.kill(pid);
-        const maxTime: number = Date.now() + timeoutInSeconds * 1000;
-        while (Date.now() < maxTime) {
-            // Wait one second between each attempt
-            await new Promise((resolve: () => void): void => { setTimeout(resolve, 1000); });
-
-            const oldProcess: string = await cpUtils.executeCommand(undefined, undefined, 'wmic', 'process', 'where', `ProcessId="${pid}"`, 'get', 'ProcessId', '/FORMAT:csv');
-            if (oldProcess.indexOf(pid) === -1) {
-                return;
+        const errorListener: vscode.Disposable = vscode.tasks.onDidEndTaskProcess((e: vscode.TaskProcessEndEvent) => {
+            if (e.exitCode !== 0) {
+                // Throw if _any_ task fails, not just funcTask (since funcTask often depends on build/clean tasks)
+                reject(new Error(localize('taskFailed', 'Failed to start debugging. Task "{0}" failed with exit code "{1}".', e.execution.task.name, e.exitCode)));
+                errorListener.dispose();
             }
-        }
-
-        throw new Error(localize('failedToTerminateProcess', 'Failed to terminate process with pid "{0}" in "{1}" seconds.', pid, timeoutInSeconds));
-    } else {
-        await new Promise((resolve: () => void, reject: (e: Error) => void): void => {
-            //tslint:disable-next-line:no-unsafe-any
-            ps.kill(pid, (err: Error | undefined) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
         });
+
+        const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${extensionPrefix}.${settingKey}`));
+        setTimeout(() => { reject(timeoutError); }, timeoutInSeconds * 1000);
+    });
+    await vscode.tasks.executeTask(funcTask);
+    return await waitForStartPromise;
+}
+
+async function getInnermostWindowsPid(pid: string): Promise<string> {
+    const moduleName: string = 'windows-process-tree';
+    const windowsProcessTree: IWindowsProcessTree | undefined = await tryFetchNodeModule<IWindowsProcessTree>(moduleName);
+    if (!windowsProcessTree) {
+        throw new Error(localize('noWindowsProcessTree', 'Failed to find dependency "{0}".', moduleName));
     }
+
+    let psTree: IProcessTreeNode = await new Promise((resolve: (psTree: IProcessTreeNode) => void): void => {
+        windowsProcessTree.getProcessTree(Number(pid), resolve);
+    });
+    while (psTree.children.length > 0) {
+        psTree = psTree.children[0];
+    }
+    return psTree.pid.toString();
+}
+
+interface IProcessTreeNode {
+    pid: number;
+    name: string;
+    memory?: number;
+    commandLine?: string;
+    children: IProcessTreeNode[];
+}
+
+interface IWindowsProcessTree {
+    getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode) => void): void;
 }

--- a/src/utils/tryFetchNodeModule.ts
+++ b/src/utils/tryFetchNodeModule.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/**
+ * Used to fetch node modules shipped with VS Code that we don't want to ship with our extension (for example if they are OS-specific)
+ */
+export async function tryFetchNodeModule<T>(moduleName: string): Promise<T | undefined> {
+    try {
+        return <T>await import(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
+    } catch (err) {
+        // ignore
+    }
+    try {
+        return <T>await import(`${vscode.env.appRoot}/node_modules/${moduleName}`);
+    } catch (err) {
+        // ignore
+    }
+    return undefined;
+}

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -9,13 +9,12 @@ are grateful to these developers for their contribution to open source.
 2. request-promise (https://github.com/request/request-promise)
 3. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
 4. clipboardy (https://github.com/sindresorhus/clipboardy)
-5. ps-node (https://github.com/neekey/ps)
-6. xregexp (https://github.com/slevithan/xregexp)
-7. opn (https://github.com/sindresorhus/opn)
-8. semver (https://github.com/npm/node-semver)
-9. portfinder (https://github.com/indexzero/node-portfinder)
-10. websocket (https://github.com/theturtle32/WebSocket-Node)
-11. extract-zip (https://github.com/maxogden/extract-zip)
+5. xregexp (https://github.com/slevithan/xregexp)
+6. opn (https://github.com/sindresorhus/opn)
+7. semver (https://github.com/npm/node-semver)
+8. portfinder (https://github.com/indexzero/node-portfinder)
+9. websocket (https://github.com/theturtle32/WebSocket-Node)
+10. extract-zip (https://github.com/maxogden/extract-zip)
 
 fs-extra NOTICES BEGIN HERE
 =============================
@@ -101,34 +100,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 END OF clipboardy NOTICES AND INFORMATION
-==================================
-
-ps-node NOTICES BEGIN HERE
-=============================
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Neekey
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-END OF ps-node NOTICES AND INFORMATION
 ==================================
 
 xregexp NOTICES BEGIN HERE


### PR DESCRIPTION
We've had a whole host of issues related to pickProcess for C# debugging. I was able to simplify this logic by leveraging VS Code's tasks api that was released a few months ago rather than searching the entire list of processes myself. The VS Code tasks api actually gives me the pid of the task, which is great.

Unfortunately it's never that simple, though 😅 On Windows, it gives me the pid of the parent PowerShell process, not the actual func process. In order to find the child process, I decided to leverage the [windows-process-tree](https://github.com/Microsoft/vscode-windows-process-tree) module that's created for and shipped with VS Code, which is a native windows module and avoids a lot of the problems we originally ran into with wmic (which most other modules like 'ps-node' use).

Fixes #436
Fixes #518 
Fixes #534 
Fixes #437