### PR TITLE
Fix "func extensions install" on v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ All notable changes to the "azurefunctions" extension will be documented in this
 
 - [Bugs fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.10.0%22+label%3Abug+is%3Aclosed)
 
+### Known Issues
+
+- Configuring deployment source to "GitHub" fails with error "The resource type 'sourceControls' could not be found...". As a workaround, you can make this change directly in the Portal. [vscode-azureappservice#594](https://github.com/Microsoft/vscode-azureappservice/issues/594)
+- "Copy Function Url" for v2 non-anonymous functions will copy an invalid url (that returns a 401 Unauthorized error) due to recent breaking changes in the runtime [#567](https://github.com/Microsoft/vscode-azurefunctions/issues/567)
+
 ## 0.9.1 - 2018-05-23
 
 ### [Fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.9.1%22+label%3Abug+is%3Aclosed)

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -26,7 +26,6 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
                     type: 'node',
                     request: 'attach',
                     port: 5858,
-                    protocol: 'inspector',
                     preLaunchTask: funcHostTaskId
                 }
             ]

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -16,7 +16,6 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
 
     public readonly functionsWorkerRuntime: string | undefined = 'node';
-    public preDeployTask: string = installExtensionsId;
 
     public getLaunchJson(): {} {
         return {
@@ -36,40 +35,50 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
 
     public getTasksJson(runtime: string): {} {
         let options: ITaskOptions | undefined;
+        // tslint:disable-next-line:no-any
+        const funcTask: any = {
+            label: funcHostTaskLabel,
+            identifier: funcHostTaskId,
+            type: 'shell',
+            command: 'func host start',
+            isBackground: true,
+            presentation: {
+                reveal: 'always'
+            },
+            problemMatcher: [
+                funcHostProblemMatcher
+            ]
+        };
+
+        const installExtensionsTask: {} = {
+            label: installExtensionsId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
+            identifier: installExtensionsId,
+            command: 'func extensions install',
+            type: 'shell',
+            presentation: {
+                reveal: 'always'
+            }
+        };
+
+        // tslint:disable-next-line:no-unsafe-any
+        const tasks: {}[] = [funcTask];
+
         if (runtime !== ProjectRuntime.one) {
             options = {};
             options.env = {};
             options.env[funcNodeDebugEnvVar] = funcNodeDebugArgs;
+            // tslint:disable-next-line:no-unsafe-any
+            funcTask.options = options;
+
+            // tslint:disable-next-line:no-unsafe-any
+            funcTask.dependsOn = installExtensionsId;
+            this.preDeployTask = installExtensionsId;
+            tasks.push(installExtensionsTask);
         }
 
         return {
             version: '2.0.0',
-            tasks: [
-                {
-                    label: funcHostTaskLabel,
-                    identifier: funcHostTaskId,
-                    type: 'shell',
-                    command: 'func host start',
-                    options: options,
-                    isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
-                    problemMatcher: [
-                        funcHostProblemMatcher
-                    ],
-                    dependsOn: installExtensionsId
-                },
-                {
-                    label: installExtensionsId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
-                    identifier: installExtensionsId,
-                    command: 'func extensions install',
-                    type: 'shell',
-                    presentation: {
-                        reveal: 'always'
-                    }
-                }
-            ]
+            tasks: tasks
         };
     }
 }


### PR DESCRIPTION
We recently added support to run "func extensions install" before debug/deploy, but that only applies for v2. You get this error if you try to run it on v1:

![screen shot 2018-09-06 at 2 55 36 pm](https://user-images.githubusercontent.com/11282622/45187268-f5d77c80-b1e4-11e8-9682-9d25aecd02c3.png)
