### PR TITLE
Make pickFuncProcess more robust to timing issues

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -114,7 +114,7 @@ async function getInnermostWindowsPid(pid: string, timeoutInSeconds: number, tim
         if (psTree.name.toLowerCase().includes('func')) {
             return psTree.pid.toString();
         } else {
-            await delay(1000);
+            await delay(500);
         }
     }
 

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -27,10 +27,19 @@ export async function pickFuncProcess(actionContext: IActionContext): Promise<st
         throw new Error(localize('noFuncTask', 'Failed to find task with label "{0}".', funcHostTaskLabel));
     }
 
-    const pid: string = await startFuncTask(funcTask, actionContext);
+    const settingKey: string = 'pickProcessTimeout';
+    const settingValue: number | undefined = getFuncExtensionSetting<number>(settingKey);
+    const timeoutInSeconds: number = Number(settingValue);
+    if (isNaN(timeoutInSeconds)) {
+        throw new Error(localize('invalidSettingValue', 'The setting "{0}" must be a number, but instead found "{1}".', settingKey, settingValue));
+    }
+    actionContext.properties.timeoutInSeconds = timeoutInSeconds.toString();
+    const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${extensionPrefix}.${settingKey}`));
+
+    const pid: string = await startFuncTask(funcTask, timeoutInSeconds, timeoutError);
     // On Mac/Linux we can leverage the pid of the task directly.
     // On Windows, the pid of the task corresponds to the parent PowerShell process and we have to drill down to get the actual func process
-    return isWindows ? await getInnermostWindowsPid(pid) : pid;
+    return isWindows ? await getInnermostWindowsPid(pid, timeoutInSeconds, timeoutError) : pid;
 }
 
 function isFuncTask(task: Task): boolean {
@@ -58,15 +67,7 @@ async function stopFuncTaskIfRunning(): Promise<void> {
     }
 }
 
-async function startFuncTask(funcTask: Task, actionContext: IActionContext): Promise<string> {
-    const settingKey: string = 'pickProcessTimeout';
-    const settingValue: number | undefined = getFuncExtensionSetting<number>(settingKey);
-    const timeoutInSeconds: number = Number(settingValue);
-    if (isNaN(timeoutInSeconds)) {
-        throw new Error(localize('invalidSettingValue', 'The setting "{0}" must be a number, but instead found "{1}".', settingKey, settingValue));
-    }
-    actionContext.properties.timeoutInSeconds = timeoutInSeconds.toString();
-
+async function startFuncTask(funcTask: Task, timeoutInSeconds: number, timeoutError: Error): Promise<string> {
     const waitForStartPromise: Promise<string> = new Promise((resolve: (pid: string) => void, reject: (e: Error) => void): void => {
         const listener: vscode.Disposable = vscode.tasks.onDidStartTaskProcess((e: vscode.TaskProcessStartEvent) => {
             if (isFuncTask(e.execution.task)) {
@@ -83,32 +84,41 @@ async function startFuncTask(funcTask: Task, actionContext: IActionContext): Pro
             }
         });
 
-        const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${extensionPrefix}.${settingKey}`));
         setTimeout(() => { reject(timeoutError); }, timeoutInSeconds * 1000);
     });
     await vscode.tasks.executeTask(funcTask);
     return await waitForStartPromise;
 }
 
-async function getInnermostWindowsPid(pid: string): Promise<string> {
+async function getInnermostWindowsPid(pid: string, timeoutInSeconds: number, timeoutError: Error): Promise<string> {
     const moduleName: string = 'windows-process-tree';
     const windowsProcessTree: IWindowsProcessTree | undefined = await tryFetchNodeModule<IWindowsProcessTree>(moduleName);
     if (!windowsProcessTree) {
         throw new Error(localize('noWindowsProcessTree', 'Failed to find dependency "{0}".', moduleName));
     }
 
-    let psTree: IProcessTreeNode | undefined = await new Promise<IProcessTreeNode | undefined>((resolve: (p: IProcessTreeNode | undefined) => void): void => {
-        windowsProcessTree.getProcessTree(Number(pid), resolve);
-    });
+    const maxTime: number = Date.now() + timeoutInSeconds * 1000;
+    while (Date.now() < maxTime) {
+        let psTree: IProcessTreeNode | undefined = await new Promise<IProcessTreeNode | undefined>((resolve: (p: IProcessTreeNode | undefined) => void): void => {
+            windowsProcessTree.getProcessTree(Number(pid), resolve);
+        });
 
-    if (!psTree) {
-        throw new Error(localize('funcTaskStopped', 'Functions host is no longer running.'));
+        if (!psTree) {
+            throw new Error(localize('funcTaskStopped', 'Functions host is no longer running.'));
+        }
+
+        while (psTree.children.length > 0) {
+            psTree = psTree.children[0];
+        }
+
+        if (psTree.name.toLowerCase().includes('func')) {
+            return psTree.pid.toString();
+        } else {
+            await delay(1000);
+        }
     }
 
-    while (psTree.children.length > 0) {
-        psTree = psTree.children[0];
-    }
-    return psTree.pid.toString();
+    throw timeoutError;
 }
 
 interface IProcessTreeNode {
@@ -121,4 +131,8 @@ interface IProcessTreeNode {
 
 interface IWindowsProcessTree {
     getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode | undefined) => void): void;
+}
+
+export async function delay(ms: number): Promise<void> {
+    await new Promise<void>((resolve: () => void): NodeJS.Timer => setTimeout(resolve, ms));
 }

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -133,6 +133,6 @@ interface IWindowsProcessTree {
     getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode | undefined) => void): void;
 }
 
-export async function delay(ms: number): Promise<void> {
+async function delay(ms: number): Promise<void> {
     await new Promise<void>((resolve: () => void): NodeJS.Timer => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
As described in this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/558, we have to get the inner 'func' process on Windows instead of attaching to the parent PowerShell process. Well it turns out there's a delay between when the PowerShell process is created and when it has the child process running the func cli. This change prevents us from attaching to the PowerShell process and getting "unverified" breakpoints.