### PR TITLE
Contribute func-watch problemMatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,6 +477,35 @@
                 "url": "http://json.schemastore.org/proxies"
             }
         ],
+        "problemPatterns": [
+            {
+                "name": "func",
+                "kind": "file",
+                "regexp": "^.*Missing.*AzureWebJobsStorage.*(local.settings.json).*$",
+                "file": 1,
+                "message": 0
+            }
+        ],
+        "problemMatchers": [
+            {
+                "name": "func-watch",
+                "label": "%azFunc.problemMatchers.funcWatch.label%",
+                "owner": "Azure Functions",
+                "source": "func",
+                "applyTo": "allDocuments",
+                "fileLocation": [
+                    "relative",
+                    "${workspaceFolder}"
+                ],
+                "pattern": "$func",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
+                    "endsPattern": "^.*(?:Application|Job host) started.*$"
+                },
+                "severity": "error"
+            }
+        ],
         "configuration": [
             {
                 "title": "Azure Functions",

--- a/package.nls.json
+++ b/package.nls.json
@@ -44,5 +44,6 @@
     "azFunc.templateVersion": "A runtime release version (any runtime) that species which templates will be used rather than the latest templates.  This version will be used for ALL runtimes. (Requires a restart of VS Code to take effect)",
     "azFunc.projectOpenBehaviorDescription": "The behavior to use after creating a new project. The options are \"AddToWorkspace\", \"OpenInNewWindow\", or \"OpenInCurrentWindow\".",
     "azFunc.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
-    "azFunc.preDeployTaskDescription": "The name of the task to run before zip deployments."
+    "azFunc.preDeployTaskDescription": "The name of the task to run before zip deployments.",
+    "azFunc.problemMatchers.funcWatch.label": "Azure Functions problems (watch mode)"
 }

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -17,7 +17,7 @@ import { getFuncExtensionSetting, promptForProjectRuntime, updateGlobalSetting }
 import { executeDotnetTemplateCommand } from '../../templates/executeDotnetTemplateCommand';
 import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
-import { funcHostTaskId, ProjectCreatorBase } from './IProjectCreator';
+import { funcHostTaskId, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
@@ -115,7 +115,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     presentation: {
                         reveal: 'always'
                     },
-                    problemMatcher: []
+                    problemMatcher: funcWatchProblemMatcher
                 }
             ]
         };

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -5,7 +5,7 @@
 
 import { TemplateFilter } from "../../constants";
 import { localize } from "../../localize";
-import { funcHostTaskId, funcHostTaskLabel } from "./IProjectCreator";
+import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
@@ -24,7 +24,7 @@ export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
                     presentation: {
                         reveal: 'always'
                     },
-                    problemMatcher: []
+                    problemMatcher: funcWatchProblemMatcher
                 }
             ]
         };

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -5,7 +5,7 @@
 
 import { OutputChannel } from "vscode";
 import { IAzureUserInput, TelemetryProperties } from "vscode-azureextensionui";
-import { extensionPrefix, ProjectRuntime, TemplateFilter } from "../../constants";
+import { ProjectRuntime, TemplateFilter } from "../../constants";
 import { tryGetLocalRuntimeVersion } from "../../funcCoreTools/tryGetLocalRuntimeVersion";
 import { promptForProjectRuntime } from "../../ProjectSettings";
 
@@ -49,19 +49,4 @@ export abstract class ProjectCreatorBase {
 export const funcHostTaskId: string = 'runFunctionsHost';
 // Don't localize this label until this is fixed: https://github.com/Microsoft/vscode/issues/57707
 export const funcHostTaskLabel: string = 'Run Functions Host';
-export const funcHostProblemMatcher: {} = {
-    owner: extensionPrefix,
-    pattern: [
-        {
-            regexp: '\\b\\B',
-            file: 1,
-            location: 2,
-            message: 3
-        }
-    ],
-    background: {
-        activeOnStart: true,
-        beginsPattern: '^.*Stopping host.*',
-        endsPattern: '^.*Job host started.*'
-    }
-};
+export const funcWatchProblemMatcher: string = '$func-watch';

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -14,7 +14,7 @@ import { localize } from "../../localize";
 import * as fsUtil from '../../utils/fs';
 import { validateMavenIdentifier, validatePackageName } from '../../utils/javaNameUtils';
 import { mavenUtils } from '../../utils/mavenUtils';
-import { funcHostProblemMatcher, funcHostTaskId, funcHostTaskLabel, ProjectCreatorBase } from './IProjectCreator';
+import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 export class JavaProjectCreator extends ProjectCreatorBase {
     public static defaultRuntime: ProjectRuntime = ProjectRuntime.beta;
@@ -120,9 +120,7 @@ export class JavaProjectCreator extends ProjectCreatorBase {
                     presentation: {
                         reveal: 'always'
                     },
-                    problemMatcher: [
-                        funcHostProblemMatcher
-                    ]
+                    problemMatcher: funcWatchProblemMatcher
                 }
             ]
         };
@@ -143,8 +141,6 @@ export class JavaProjectCreator extends ProjectCreatorBase {
         tasksJsonString = tasksJsonString.replace(/%path%/g, this._javaTargetPath);
         // tslint:disable-next-line:no-string-literal no-unsafe-any
         tasksJson = JSON.parse(tasksJsonString);
-        // tslint:disable-next-line:no-string-literal no-unsafe-any
-        tasksJson['tasks'][0]['problemMatcher'][0]['background']['beginsPattern'] = '^.*Scanning for projects.*';
         return tasksJson;
     }
 

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -5,7 +5,7 @@
 
 import { installExtensionsId, ProjectRuntime, TemplateFilter } from "../../constants";
 import { localize } from "../../localize";
-import { funcHostProblemMatcher, funcHostTaskId, funcHostTaskLabel } from "./IProjectCreator";
+import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher } from "./IProjectCreator";
 import { ITaskOptions } from "./ITasksJson";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
@@ -44,9 +44,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
             presentation: {
                 reveal: 'always'
             },
-            problemMatcher: [
-                funcHostProblemMatcher
-            ]
+            problemMatcher: funcWatchProblemMatcher
         };
 
         const installExtensionsTask: {} = {

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -13,7 +13,7 @@ import { ext } from '../../extensionVariables';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from "../../localize";
 import { cpUtils } from "../../utils/cpUtils";
-import { funcHostProblemMatcher, funcHostTaskId } from "./IProjectCreator";
+import { funcHostTaskId, funcWatchProblemMatcher } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export enum PythonAlias {
@@ -83,11 +83,8 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                             'languageWorkers:python:arguments': '-m ptvsd --server --port 9091 --file'
                         }
                     },
-                    problemMatcher: [
-                        funcHostProblemMatcher
-                    ]
+                    problemMatcher: funcWatchProblemMatcher
                 },
-
                 {
                     label: funcPackId,
                     identifier: funcPackId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -9,7 +9,7 @@ import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime,
 import { ILocalAppSettings } from '../../LocalAppSettings';
 import { confirmOverwriteFile } from "../../utils/fs";
 import * as fsUtil from '../../utils/fs';
-import { funcHostProblemMatcher, funcHostTaskId, funcHostTaskLabel, ProjectCreatorBase } from './IProjectCreator';
+import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 // tslint:disable-next-line:no-multiline-string
 const gitignore: string = `bin
@@ -59,9 +59,7 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
                     presentation: {
                         reveal: 'always'
                     },
-                    problemMatcher: [
-                        funcHostProblemMatcher
-                    ]
+                    problemMatcher: funcWatchProblemMatcher
                 }
             ]
         };


### PR DESCRIPTION
I'm basically shifting the implementation of the problem matcher from each user's project to our extension. This means we can change/improve it in the future without having to modify the user's project.

Unfortunately, the func cli is very annoying to parse, so I only added support for one error (although it's somewhat common). Now users will see this in the problems view:
![screen shot 2018-09-12 at 8 38 30 am](https://user-images.githubusercontent.com/11282622/45438021-e0da6d80-b66a-11e8-91f7-8d861b8b46c8.png)
