### PR TITLE
Change pythonExperimental to python for non-windows

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -28,14 +28,12 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
     private pythonAlias: string;
     private funcEnv: string = 'func_env';
     public getLaunchJson(): {} {
-        // https://github.com/Microsoft/vscode-azurefunctions/issues/543
-        const launchType: string = process.platform === Platform.Windows ? 'python' : 'pythonExperimental';
         return {
             version: '0.2.0',
             configurations: [
                 {
                     name: localize('azFunc.attachToJavaScriptFunc', 'Attach to Python Functions'),
-                    type: launchType,
+                    type: 'python',
                     request: 'attach',
                     port: 9091,
                     host: 'localhost',


### PR DESCRIPTION
Thought it would be easier for me to test on a mac than @nturinski. "python" is working for me with the latest version of the python extension

Fixes #543 