### PR TITLE
Install ptvsd and other local debug fixes

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -176,12 +176,24 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         // .gitignore is created by `func init`
         const gitignorePath: string = path.join(this.functionAppPath, gitignoreFileName);
         if (await fse.pathExists(gitignorePath)) {
-            ext.outputChannel.appendLine(localize('gitAddFunc_Env', 'Adding "{0}" to .gitignore...', this.funcEnv));
+            const pythonPackages: string = 'python_packages';
+            let writeFile: boolean = false;
             let gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
             // the func_env and ._python_packages are recreated and should not be checked in
-            gitignoreContents = gitignoreContents.concat(`${os.EOL}${this.funcEnv}`);
-            gitignoreContents = gitignoreContents.concat(`${os.EOL}.python_packages`);
-            await fse.writeFile(gitignorePath, gitignoreContents);
+            if (!gitignoreContents.includes(this.funcEnv)) {
+                ext.outputChannel.appendLine(localize('gitAddFunc_Env', 'Adding "{0}" to .gitignore...', this.funcEnv));
+                gitignoreContents = gitignoreContents.concat(`${os.EOL}${this.funcEnv}`);
+                writeFile = true;
+            }
+            if (!gitignoreContents.includes(pythonPackages)) {
+                ext.outputChannel.appendLine(localize('gitAddFunc_Env', 'Adding "{0}" to .gitignore...', pythonPackages));
+                gitignoreContents = gitignoreContents.concat(`${os.EOL}${pythonPackages}`);
+                writeFile = true;
+            }
+
+            if (writeFile) {
+                await fse.writeFile(gitignorePath, gitignoreContents);
+            }
         }
     }
 }

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -176,7 +176,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         // .gitignore is created by `func init`
         const gitignorePath: string = path.join(this.functionAppPath, gitignoreFileName);
         if (await fse.pathExists(gitignorePath)) {
-            const pythonPackages: string = 'python_packages';
+            const pythonPackages: string = '.python_packages';
             let writeFile: boolean = false;
             let gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
             // the func_env and ._python_packages are recreated and should not be checked in
@@ -186,7 +186,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                 writeFile = true;
             }
             if (!gitignoreContents.includes(pythonPackages)) {
-                ext.outputChannel.appendLine(localize('gitAddFunc_Env', 'Adding "{0}" to .gitignore...', pythonPackages));
+                ext.outputChannel.appendLine(localize('gitAddPythonPackages', 'Adding "{0}" to .gitignore...', pythonPackages));
                 gitignoreContents = gitignoreContents.concat(`${os.EOL}${pythonPackages}`);
                 writeFile = true;
             }

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -159,11 +159,11 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         const funcInitPython: string = 'func init ./ --worker-runtime python';
         switch (process.platform) {
             case Platform.Windows:
-                await cpUtils.executeCommand(ext.outputChannel, this.functionAppPath, `${await this.getVenvActivatePath(Platform.Windows)} && ${funcInitPython} && ${this.pythonAlias} -m pip install ptvsd`);
+                await cpUtils.executeCommand(ext.outputChannel, this.functionAppPath, `${await this.getVenvActivatePath(Platform.Windows)} && ${funcInitPython} && pip install ptvsd`);
                 break;
             case Platform.MacOS:
             default:
-                await cpUtils.executeCommand(ext.outputChannel, this.functionAppPath, `source ${await this.getVenvActivatePath(Platform.MacOS)} && ${funcInitPython} && ${this.pythonAlias} -m pip install ptvsd`);
+                await cpUtils.executeCommand(ext.outputChannel, this.functionAppPath, `source ${await this.getVenvActivatePath(Platform.MacOS)} && ${funcInitPython} && pip install ptvsd`);
                 break;
         }
         // .gitignore is created by `func init`
@@ -171,7 +171,9 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         if (await fse.pathExists(gitignorePath)) {
             ext.outputChannel.appendLine(localize('gitAddFunc_Env', 'Adding "{0}" to .gitignore...', this.funcEnv));
             let gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
+            // the func_env and ._python_packages are recreated and should not be checked in
             gitignoreContents = gitignoreContents.concat(`\n${this.funcEnv}`);
+            gitignoreContents = gitignoreContents.concat('\n.python_packages');
             await fse.writeFile(gitignorePath, gitignoreContents);
         }
     }


### PR DESCRIPTION
Installs ptvsd (no longer need pre)
Ignores output when looking for python alias
Adds "func_env" & ."python_packages" to .gitignore (as this should not be checked in)

I don't think there are dev dependencies for python unless you make a different requirement.txt.  func_env is packed in with the .zip file created by `func pack` so it's probably necessary to run on the remote.