### PR TITLE
Add python verified templates

### DIFF
--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -100,6 +100,15 @@ export function getScriptVerifiedTemplateIds(runtime: string): string[] {
             'HttpTriggerWithParameters-JavaScript',
             'ManualTrigger-JavaScript'
         ]);
+    } else {
+        verifiedTemplateIds = verifiedTemplateIds.concat([
+            'CosmosDBTrigger-JavaScript', // Only include in v2. v1 doesn't have the same support for 'func extensions install' that's required for Cosmos DB
+            'BlobTrigger-Python',
+            'HttpTrigger-Python',
+            'QueueTrigger-Python',
+            'TimerTrigger-Python',
+            'CosmosDBTrigger-Python'
+        ]);
     }
 
     return verifiedTemplateIds;

--- a/test/functionTemplates.test.ts
+++ b/test/functionTemplates.test.ts
@@ -38,7 +38,7 @@ async function validateTemplateCounts(templates: FunctionTemplates): Promise<voi
     assert.equal(jsTemplatesv1.length, 8, 'Unexpected JavaScript v1 templates count.');
 
     const jsTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.JavaScript, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(jsTemplatesv2.length, 4, 'Unexpected JavaScript v2 templates count.');
+    assert.equal(jsTemplatesv2.length, 5, 'Unexpected JavaScript v2 templates count.');
 
     const javaTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Java, JavaProjectCreator.defaultRuntime, TemplateFilter.Verified);
     assert.equal(javaTemplates.length, 4, 'Unexpected Java templates count.');
@@ -48,4 +48,7 @@ async function validateTemplateCounts(templates: FunctionTemplates): Promise<voi
 
     const cSharpTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v2, TemplateFilter.Verified);
     assert.equal(cSharpTemplatesv2.length, 4, 'Unexpected CSharp (.NET Core) templates count.');
+
+    const pythonTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Python, ProjectRuntime.v2, TemplateFilter.Verified);
+    assert.equal(pythonTemplates.length, 5, 'Unexpected Python templates count.');
 }


### PR DESCRIPTION
And Cosmos DB trigger to v2 JavaScript

HttpTriggers are the only ones that actually work out of the box (at least on mac), but I filed the relevant bugs, so I feel comfortable putting these in verified:
https://github.com/Microsoft/vscode-azurefunctions/issues/584
https://github.com/Microsoft/vscode-azurefunctions/issues/583

Otherwise they're working for me.