### PR TITLE
Nat/storage from setting

### DIFF
--- a/src/LocalAppSettings.ts
+++ b/src/LocalAppSettings.ts
@@ -21,7 +21,7 @@ export interface ILocalAppSettings {
     ConnectionStrings?: { [key: string]: string };
 }
 
-const azureWebJobsStorageKey: string = 'AzureWebJobsStorage';
+export const azureWebJobsStorageKey: string = 'AzureWebJobsStorage';
 
 export async function promptForAppSetting(actionContext: IActionContext, localSettingsPath: string, resourceType: ResourceType): Promise<string> {
     const settings: ILocalAppSettings = await getLocalSettings(localSettingsPath);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -113,7 +113,7 @@ export async function deploy(ui: IAzureUserInput, actionContext: IActionContext,
                     await client.stop();
                 }
                 if (node && isLinuxConsumptionPlan) {
-                    await runFromPackageDeploy(actionContext, node, deployFsPath, language);
+                    await runFromPackageDeploy(node, deployFsPath, language);
                 } else {
                     await appservice.deploy(client, deployFsPath, extensionPrefix, telemetryProperties);
                 }

--- a/src/commands/runFromPackageDeploy.ts
+++ b/src/commands/runFromPackageDeploy.ts
@@ -81,7 +81,7 @@ async function createBlobService(node: IAzureParentNode<FunctionAppTreeItem>): P
             return azureStorage.createBlobService(name, key);
         }
     }
-    throw new Error(localize('"{0}" app setting must be set to proceed with deploy.', azureWebJobsStorageKey));
+    throw new Error(localize('"{0}" app setting is required for Run From Package deployment.', azureWebJobsStorageKey));
 }
 
 async function createBlobFromZip(blobService: azureStorage.BlobService, zipFilePath: string, blobName: string): Promise<string> {


### PR DESCRIPTION
Uses the `AzureWebJobsStorage` app setting to select the Storage Account rather than prompting the user for an account.