### PR TITLE
Prompt for python path

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -203,7 +203,7 @@ async function validatePythonAlias(pyAlias: PythonAlias): Promise<string | undef
     try {
         const result: cpUtils.ICommandResult = await cpUtils.tryExecuteCommand(undefined /*don't display output*/, undefined /*default to cwd*/, `${pyAlias} --version`);
         if (result.code !== 0) {
-            return localize('failValidate', 'Failed to validate version:{1}{2}', pyAlias, os.EOL, result.cmdOutputIncludingStderr);
+            return localize('failValidate', 'Failed to validate version: {0}', result.cmdOutputIncludingStderr);
         }
 
         const pyVersion: string | undefined = result.cmdOutputIncludingStderr.substring('Python '.length).trim();

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
 import { MessageItem, window } from 'vscode';
-import { DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
+import { DialogResponses, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { funcPackId, gitignoreFileName, Platform, TemplateFilter } from "../../constants";
 import { ext } from '../../extensionVariables';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
@@ -22,6 +22,8 @@ export enum PythonAlias {
     python3 = 'python3',
     py = 'py'
 }
+
+const minPythonVersion: string = '3.6.0';
 
 export class PythonProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
@@ -111,31 +113,25 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
     }
 
     private async validatePythonVersion(): Promise<void> {
-        const minReqVersion: string = '3.6.0';
-        await this.tryGetPythonAlias(PythonAlias.py, minReqVersion);
-        await this.tryGetPythonAlias(PythonAlias.python, minReqVersion);
-        await this.tryGetPythonAlias(PythonAlias.python3, minReqVersion);
+        for (const key of Object.keys(PythonAlias)) {
+            const alias: PythonAlias = <PythonAlias>PythonAlias[key];
+            const errorMessage: string | undefined = await validatePythonAlias(alias);
+            if (!errorMessage) {
+                this.pythonAlias = alias;
+                break;
+            }
+        }
+
         if (!this.pythonAlias) {
             const enterPython: MessageItem = { title: localize('enterPython', 'Enter Python Path') };
-            const pythonMsg: string = localize('pythonVersionRequired', 'Python {0} or higher is required to create a Python Function project and was not found.', minReqVersion);
+            const pythonMsg: string = localize('pythonVersionRequired', 'Python {0} or higher is required to create a Python Function project and was not found.', minPythonVersion);
             const result: MessageItem | undefined = await window.showErrorMessage(pythonMsg, { modal: true }, enterPython);
             if (!result) {
                 throw new UserCancelledError();
             } else {
                 const placeHolder: string = localize('pyAliasPlaceholder', 'Enter the Python alias (if its in your PATH) or the full path to your Python executable.');
-                this.pythonAlias = await ext.ui.showInputBox({ placeHolder });
+                this.pythonAlias = await ext.ui.showInputBox({ placeHolder, validateInput: validatePythonAlias });
             }
-        }
-    }
-
-    private async tryGetPythonAlias(pyAlias: PythonAlias, minReqVersion: string): Promise<void> {
-        try {
-            const pyVersion: string = (await cpUtils.executeCommand(undefined /*don't display output*/, undefined /*default to cwd*/, `${pyAlias} --version`)).substring('Python '.length);
-            if (semver.gte(pyVersion, minReqVersion)) {
-                this.pythonAlias = pyAlias;
-            }
-        } catch {
-            // ignore error, not installed under this alias
         }
     }
 
@@ -197,5 +193,26 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                 await fse.writeFile(gitignorePath, gitignoreContents);
             }
         }
+    }
+}
+
+/**
+ * Returns undefined if valid or an error message if not
+ */
+async function validatePythonAlias(pyAlias: PythonAlias): Promise<string | undefined> {
+    try {
+        const result: cpUtils.ICommandResult = await cpUtils.tryExecuteCommand(undefined /*don't display output*/, undefined /*default to cwd*/, `${pyAlias} --version`);
+        if (result.code !== 0) {
+            return localize('failValidate', 'Failed to validate version:{1}{2}', pyAlias, os.EOL, result.cmdOutputIncludingStderr);
+        }
+
+        const pyVersion: string | undefined = result.cmdOutputIncludingStderr.substring('Python '.length).trim();
+        if (semver.gte(pyVersion, minPythonVersion)) {
+            return undefined;
+        } else {
+            return localize('tooLowVersion', 'Python version "{0}" is below minimum version of "{1}".', pyVersion, minPythonVersion);
+        }
+    } catch (error) {
+        return parseError(error).message;
     }
 }

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
-import { MessageItem } from 'vscode';
+import { MessageItem, window } from 'vscode';
 import { DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
 import { funcPackId, gitignoreFileName, Platform, TemplateFilter } from "../../constants";
 import { ext } from '../../extensionVariables';
@@ -116,7 +116,15 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         await this.tryGetPythonAlias(PythonAlias.python, minReqVersion);
         await this.tryGetPythonAlias(PythonAlias.python3, minReqVersion);
         if (!this.pythonAlias) {
-            throw new Error(localize('pythonVersionRequired', 'Python {0} is required to create a Python Function project with Azure Functions Core Tools.', minReqVersion));
+            const enterPython: MessageItem = { title: localize('enterPython', 'Enter Python Path') };
+            const pythonMsg: string = localize('pythonVersionRequired', 'Python {0} or higher is required to create a Python Function project and was not found.', minReqVersion);
+            const result: MessageItem | undefined = await window.showErrorMessage(pythonMsg, { modal: true }, enterPython);
+            if (!result) {
+                throw new UserCancelledError();
+            } else {
+                const placeHolder: string = localize('pyAliasPlaceholder', 'Enter the Python alias (if its in your PATH) or the full path to your Python executable.');
+                this.pythonAlias = await ext.ui.showInputBox({ placeHolder });
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/594
![screen shot 2018-09-13 at 10 57 40 am](https://user-images.githubusercontent.com/11282622/45506443-0f784700-b744-11e8-9190-ab180b5b6828.png)
![screen shot 2018-09-13 at 10 57 48 am](https://user-images.githubusercontent.com/11282622/45506444-10a97400-b744-11e8-9660-c5990ece9fab.png)

I decided not to validate _after_ the user enters a custom path. I figure we let them use what they want to use and they will get error message down the line if it doesn't work.