### PR TITLE
Allow creation of python function apps on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -697,7 +697,7 @@
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "^0.21.3",
+        "vscode-azureappservice": "^0.22.0",
         "vscode-azureextensionui": "^0.17.4",
         "vscode-azurekudu": "^0.1.8",
         "vscode-extension-telemetry": "^0.0.18",

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -83,12 +83,13 @@ export class FunctionAppProvider implements IChildProvider {
         const createOptions: IAppCreateOptions = { functionAppSettings, resourceGroup };
 
         if (language === ProjectLanguage.Python) {
+            // Python only works on Linux
             createOptions.os = 'linux';
             createOptions.runtime = 'python';
         } else {
             // If the language isn't set, just assume it's not Python. Python is still in preview and it's not worth an extra prompt yet
 
-            // Default to windows because linux is still in preview
+            // Use windows because linux is still in preview
             createOptions.os = 'windows';
             // WEBSITE_RUN_FROM_PACKAGE has several benefits, so make that the default
             // https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package


### PR DESCRIPTION
Based on this PR in shared package: https://github.com/Microsoft/vscode-azuretools/pull/263

Also default to 'WEBSITE_RUN_FROM_PACKAGE' for non-python apps since that just GA-ed. Last part that fixes https://github.com/Microsoft/vscode-azurefunctions/issues/284

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/587
