### PR TITLE
Force users to have workspace open when deploying

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -47,6 +47,10 @@ export async function deploy(ui: IAzureUserInput, actionContext: IActionContext,
         deployFsPath = await workspaceUtil.selectWorkspaceFolder(ext.ui, workspaceMessage, (f: vscode.WorkspaceFolder) => getFuncExtensionSetting(deploySubpathSetting, f.uri.fsPath));
         node = target;
     }
+
+    const folderOpenWarning: string = localize('folderOpenWarning', 'Failed to deploy because the folder is not open in a workspace. Open in a workspace and try again.');
+    await workspaceUtil.ensureFolderIsOpen(deployFsPath, actionContext, folderOpenWarning, true /* allowSubFolder */);
+
     const onNodeCreatedFromQuickPickDisposable: vscode.Disposable = tree.onNodeCreate((newNode: IAzureNode<FunctionAppTreeItem>) => {
         // event is fired from azure-extensionui if node was created during deployment
         newNodes.push(newNode);
@@ -134,6 +138,10 @@ export async function deploy(ui: IAzureUserInput, actionContext: IActionContext,
         }
     });
 
+    await listHttpTriggerUrls(node);
+}
+
+async function listHttpTriggerUrls(node: IAzureParentNode): Promise<void> {
     const children: IAzureNode[] = await node.getCachedChildren();
     const functionsNode: IAzureParentNode<FunctionsTreeItem> = <IAzureParentNode<FunctionsTreeItem>>children.find((n: IAzureNode) => n.treeItem instanceof FunctionsTreeItem);
     await node.treeDataProvider.refresh(functionsNode);

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -92,6 +92,7 @@ export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionC
     } else {
         if (message) {
             const open: vscode.MessageItem = { title: localize('open', 'Open Folder') };
+            // No need to check result. Open/Cancel are the only possibilities and Cancel will throw a UserCancelledError
             await ext.ui.showWarningMessage(message, { modal: true }, open);
         }
 


### PR DESCRIPTION
We check several settings when deploying and we can't read/write those if the folder isn't open in the workspace

Here's the new message:
![screen shot 2018-09-17 at 2 28 58 pm](https://user-images.githubusercontent.com/11282622/45651428-5a68c600-ba86-11e8-8096-36b3a7ca4686.png)

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/502