### PR TITLE
Add service bus templates to verified category

### DIFF
--- a/package.json
+++ b/package.json
@@ -688,6 +688,7 @@
         "azure-arm-resource": "^3.0.0-preview",
         "azure-arm-storage": "^3.1.0",
         "azure-arm-website": "^4.0.0",
+        "azure-arm-sb": "^2.3.0-preview",
         "clipboardy": "^1.2.2",
         "extract-zip": "^1.6.6",
         "fs-extra": "^4.0.2",

--- a/src/LocalAppSettings.ts
+++ b/src/LocalAppSettings.ts
@@ -57,6 +57,9 @@ export async function promptForAppSetting(actionContext: IActionContext, localSe
                     }
                 );
                 break;
+            case ResourceType.ServiceBus:
+                resourceResult = await azUtil.promptForServiceBus();
+                break;
             default:
         }
     } catch (error) {

--- a/src/templates/DotnetTemplateRetriever.ts
+++ b/src/templates/DotnetTemplateRetriever.ts
@@ -72,7 +72,9 @@ export function getDotnetVerifiedTemplateIds(runtime: string): string[] {
         'HttpTrigger',
         'BlobTrigger',
         'QueueTrigger',
-        'TimerTrigger'
+        'TimerTrigger',
+        'ServiceBusTopicTrigger',
+        'ServiceBusQueueTrigger'
     ];
 
     if (runtime === ProjectRuntime.v1) {

--- a/src/templates/IFunctionSetting.ts
+++ b/src/templates/IFunctionSetting.ts
@@ -16,7 +16,8 @@ export enum ValueType {
 export enum ResourceType {
     DocumentDB = 'DocumentDB',
     Storage = 'Storage',
-    EventHub = 'EventHub'
+    EventHub = 'EventHub',
+    ServiceBus = 'ServiceBus'
 }
 
 export function getResourceTypeLabel(resourceType: ResourceType): string {
@@ -27,6 +28,8 @@ export function getResourceTypeLabel(resourceType: ResourceType): string {
             return localize('azFunc.Storage', 'Storage Account');
         case ResourceType.EventHub:
             return localize('azFunc.EventHub', 'Event Hub');
+        case ResourceType.ServiceBus:
+            return localize('azFunc.ServiceBus', 'Service Bus');
         default:
             return resourceType;
     }

--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -101,13 +101,19 @@ export function getScriptVerifiedTemplateIds(runtime: string): string[] {
             'ManualTrigger-JavaScript'
         ]);
     } else {
+        // Python is only supported in v2
+        // For JavaScript, only include triggers that require extensions in v2. v1 doesn't have the same support for 'func extensions install'
         verifiedTemplateIds = verifiedTemplateIds.concat([
-            'CosmosDBTrigger-JavaScript', // Only include in v2. v1 doesn't have the same support for 'func extensions install' that's required for Cosmos DB
+            'CosmosDBTrigger-JavaScript',
+            'ServiceBusQueueTrigger-JavaScript',
+            'ServiceBusTopicTrigger-JavaScript',
             'BlobTrigger-Python',
             'HttpTrigger-Python',
             'QueueTrigger-Python',
             'TimerTrigger-Python',
-            'CosmosDBTrigger-Python'
+            'CosmosDBTrigger-Python',
+            'ServiceBusQueueTrigger-Python',
+            'ServiceBusTopicTrigger-Python'
         ]);
     }
 

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -5,16 +5,19 @@
 
 import { CosmosDBManagementClient } from 'azure-arm-cosmosdb';
 import { DatabaseAccount, DatabaseAccountListKeysResult } from 'azure-arm-cosmosdb/lib/models';
+import { ServiceBusManagementClient } from 'azure-arm-sb';
+import { AccessKeys, SBAuthorizationRule, SBNamespace } from 'azure-arm-sb/lib/models';
 // tslint:disable-next-line:no-require-imports
 import StorageClient = require('azure-arm-storage');
 import { StorageAccount, StorageAccountListKeysResult } from 'azure-arm-storage/lib/models';
 import { BaseResource } from 'ms-rest-azure';
 import { QuickPickOptions } from 'vscode';
-import { addExtensionUserAgent, AzureTreeDataProvider, AzureWizard, IActionContext, IAzureNode, IAzureQuickPickItem, IAzureUserInput, IStorageAccountFilters, IStorageAccountWizardContext, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
+import { addExtensionUserAgent, AzureTreeDataProvider, AzureWizard, createAzureClient, IActionContext, IAzureNode, IAzureQuickPickItem, IAzureUserInput, IStorageAccountFilters, IStorageAccountWizardContext, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication } from 'vscode-azureextensionui';
 import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { getResourceTypeLabel, ResourceType } from '../templates/IFunctionSetting';
+import { nonNullProp } from './nonNull';
 
 function parseResourceId(id: string): RegExpMatchArray {
     const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(.*)\/resourceGroups\/(.*)\/providers\/(.*)\/(.*)/);
@@ -117,4 +120,26 @@ export async function promptForStorageAccount(actionContext: IActionContext, fil
             id: storageAccount.id
         };
     }
+}
+
+export async function promptForServiceBus(): Promise<IResourceResult> {
+    const resourceTypeLabel: string = getResourceTypeLabel(ResourceType.ServiceBus);
+    const node: IAzureNode = await ext.tree.showNodePicker(AzureTreeDataProvider.subscriptionContextValue);
+
+    const client: ServiceBusManagementClient = createAzureClient(node, ServiceBusManagementClient);
+    const resource: SBNamespace = await promptForResource<SBNamespace>(ext.ui, resourceTypeLabel, client.namespaces.list());
+    const id: string = nonNullProp(resource, 'id');
+    const name: string = nonNullProp(resource, 'name');
+
+    const resourceGroup: string = getResourceGroupFromId(id);
+    const authRules: SBAuthorizationRule[] = await client.namespaces.listAuthorizationRules(resourceGroup, name);
+    const authRule: SBAuthorizationRule | undefined = authRules.find((ar: SBAuthorizationRule) => ar.rights.some((r: string) => r.toLowerCase() === 'listen'));
+    if (!authRule) {
+        throw new Error(localize('noAuthRule', 'Failed to get connection string for Service Bus namespace "{0}".', name));
+    }
+    const keys: AccessKeys = await client.namespaces.listKeys(resourceGroup, name, nonNullProp(authRule, 'name'));
+    return {
+        name: name,
+        connectionString: nonNullProp(keys, 'primaryConnectionString')
+    };
 }

--- a/src/utils/nonNull.ts
+++ b/src/utils/nonNull.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isNullOrUndefined } from 'util';
+
+/**
+ * Retrieves a property by name from an object and checks that it's not null and not undefined.  It is strongly typed
+ * for the property and will give a compile error if the given name is not a property of the source.
+ */
+export function nonNullProp<TSource, TKey extends keyof TSource>(source: TSource, name: TKey): NonNullable<TSource[TKey]> {
+    const value: NonNullable<TSource[TKey]> = <NonNullable<TSource[TKey]>>source[name];
+    return nonNullValue(value, <string>name);
+}
+
+/**
+ * Validates that a given value is not null and not undefined.
+ */
+// tslint:disable-next-line:no-any
+export function nonNullValue<T>(value: T | undefined, propertyNameOrMessage?: string): T {
+    if (isNullOrUndefined(value)) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null nor undefined'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}

--- a/test/functionTemplates.test.ts
+++ b/test/functionTemplates.test.ts
@@ -38,17 +38,17 @@ async function validateTemplateCounts(templates: FunctionTemplates): Promise<voi
     assert.equal(jsTemplatesv1.length, 8, 'Unexpected JavaScript v1 templates count.');
 
     const jsTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.JavaScript, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(jsTemplatesv2.length, 5, 'Unexpected JavaScript v2 templates count.');
+    assert.equal(jsTemplatesv2.length, 7, 'Unexpected JavaScript v2 templates count.');
 
     const javaTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Java, JavaProjectCreator.defaultRuntime, TemplateFilter.Verified);
     assert.equal(javaTemplates.length, 4, 'Unexpected Java templates count.');
 
     const cSharpTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v1, TemplateFilter.Verified);
-    assert.equal(cSharpTemplates.length, 7, 'Unexpected CSharp (.NET Framework) templates count.');
+    assert.equal(cSharpTemplates.length, 9, 'Unexpected CSharp (.NET Framework) templates count.');
 
     const cSharpTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(cSharpTemplatesv2.length, 4, 'Unexpected CSharp (.NET Core) templates count.');
+    assert.equal(cSharpTemplatesv2.length, 6, 'Unexpected CSharp (.NET Core) templates count.');
 
     const pythonTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Python, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(pythonTemplates.length, 5, 'Unexpected Python templates count.');
+    assert.equal(pythonTemplates.length, 7, 'Unexpected Python templates count.');
 }


### PR DESCRIPTION
Now that we have support for installing func extensions, we can add a few more templates to the "verified" category.

nonNull stuff copied from here: https://github.com/Microsoft/vscode-docker/pull/475