### PR TITLE
Clarify preview support for Python

### DIFF
--- a/package.json
+++ b/package.json
@@ -649,6 +649,11 @@
                     "azureFunctions.preDeployTask": {
                         "type": "string",
                         "description": "%azFunc.preDeployTaskDescription%"
+                    },
+                    "azureFunctions.enablePython": {
+                        "type": "boolean",
+                        "description": "%azFunc.enablePythonDescription%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -49,5 +49,6 @@
     "azFunc.projectRuntime.v1Description": "Azure Functions v1 (.NET Framework)",
     "azFunc.projectRuntime.v2Description": "Azure Functions v2 (.NET Standard)",
     "azFunc.projectRuntime.betaDescription": "DEPRECATED Use \"~2\" instead.",
-    "azFunc.projectLanguage.previewDescription": "(Preview)"
+    "azFunc.projectLanguage.previewDescription": "(Preview)",
+    "azFunc.enablePythonDescription": "Enable Python support when creating new projects. Local support is in preview and deploying to Azure is in private preview."
 }

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -10,7 +10,7 @@ import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../c
 import { ext } from '../../extensionVariables';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
-import { getGlobalFuncExtensionSetting } from '../../ProjectSettings';
+import { getFuncExtensionSetting, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
 import { gitUtils } from '../../utils/gitUtils';
 import * as workspaceUtil from '../../utils/workspace';
 import { createFunction } from '../createFunction/createFunction';
@@ -46,9 +46,13 @@ export async function createNewProject(
             const languagePicks: QuickPickItem[] = [
                 { label: ProjectLanguage.JavaScript, description: '' },
                 { label: ProjectLanguage.CSharp, description: '' },
-                { label: ProjectLanguage.Java, description: '' },
-                { label: ProjectLanguage.Python, description: '(Preview)' }
+                { label: ProjectLanguage.Java, description: '' }
             ];
+
+            if (getFuncExtensionSetting('enablePython')) {
+                languagePicks.push({ label: ProjectLanguage.Python, description: '(Preview)' });
+            }
+
             const options: QuickPickOptions = { placeHolder: localize('azFunc.selectFuncTemplate', 'Select a language for your function project') };
             language = (await ext.ui.showQuickPick(languagePicks, options)).label;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export function activate(context: vscode.ExtensionContext): void {
         // tslint:disable-next-line:no-floating-promises
         validateFuncCoreToolsIsLatest();
 
-        const tree: AzureTreeDataProvider = new AzureTreeDataProvider(new FunctionAppProvider(outputChannel), 'azureFunctions.loadMore');
+        const tree: AzureTreeDataProvider = new AzureTreeDataProvider(new FunctionAppProvider(), 'azureFunctions.loadMore');
         ext.tree = tree;
         context.subscriptions.push(tree);
         context.subscriptions.push(vscode.window.registerTreeDataProvider('azureFunctionsExplorer', tree));

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -78,15 +78,14 @@ export class FunctionAppProvider implements IChildProvider {
         const language: string | undefined = getFuncExtensionSetting(projectLanguageSetting);
         const createOptions: IAppCreateOptions = { functionAppSettings, resourceGroup };
 
-        const isPython: boolean = language === ProjectLanguage.Python;
-        if (isPython) {
-            // Python only works on Linux
+        // There are two things in preview right now:
+        // 1. Python support
+        // 2. Linux support
+        // Python only works on Linux, so we have to use Linux when creating a function app. For other languages, we will stick with Windows until Linux GA's
+        if (language === ProjectLanguage.Python) {
             createOptions.os = 'linux';
             createOptions.runtime = 'python';
         } else {
-            // If the language isn't set, just assume it's not Python. Python is still in preview and it's not worth an extra prompt yet
-
-            // Use windows because linux is still in preview
             createOptions.os = 'windows';
             // WEBSITE_RUN_FROM_PACKAGE has several benefits, so make that the default
             // https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
@@ -94,7 +93,7 @@ export class FunctionAppProvider implements IChildProvider {
         }
 
         const site: Site = await createFunctionApp(actionContext, parent, createOptions, showCreatingNode);
-        return new FunctionAppTreeItem(new SiteClient(site, parent), isPython);
+        return new FunctionAppTreeItem(new SiteClient(site, parent), createOptions.os === 'linux' /* isLinuxPreview */);
     }
 }
 

--- a/src/tree/FunctionAppTreeItem.ts
+++ b/src/tree/FunctionAppTreeItem.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { OutputChannel } from 'vscode';
 import { AppSettingsTreeItem, AppSettingTreeItem, deleteSite, SiteClient } from 'vscode-azureappservice';
 import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
 import { ILogStreamTreeItem } from '../commands/logstream/ILogStreamTreeItem';
+import { localize } from '../localize';
 import { nodeUtils } from '../utils/nodeUtils';
 import { FunctionsTreeItem } from './FunctionsTreeItem';
 import { FunctionTreeItem } from './FunctionTreeItem';
@@ -23,15 +23,15 @@ export class FunctionAppTreeItem implements ILogStreamTreeItem, IAzureParentTree
     private readonly _functionsTreeItem: FunctionsTreeItem;
     private readonly _appSettingsTreeItem: AppSettingsTreeItem;
     private readonly _proxiesTreeItem: ProxiesTreeItem;
-    private readonly _outputChannel: OutputChannel;
+    private readonly _isLinuxPreview: boolean;
 
-    public constructor(client: SiteClient, outputChannel: OutputChannel) {
+    public constructor(client: SiteClient, isLinuxPreview: boolean) {
         this.client = client;
         this._state = client.initialState;
-        this._outputChannel = outputChannel;
-        this._functionsTreeItem = new FunctionsTreeItem(client, this._outputChannel);
+        this._functionsTreeItem = new FunctionsTreeItem(client);
         this._appSettingsTreeItem = new AppSettingsTreeItem(client);
-        this._proxiesTreeItem = new ProxiesTreeItem(client, this._outputChannel);
+        this._proxiesTreeItem = new ProxiesTreeItem(client);
+        this._isLinuxPreview = isLinuxPreview;
     }
 
     public get logStreamLabel(): string {
@@ -47,7 +47,13 @@ export class FunctionAppTreeItem implements ILogStreamTreeItem, IAzureParentTree
     }
 
     public get description(): string | undefined {
-        return this._state && this._state.toLowerCase() !== 'running' ? this._state : undefined;
+        const stateDescription: string | undefined = this._state && this._state.toLowerCase() !== 'running' ? this._state : undefined;
+        const previewDescription: string | undefined = this._isLinuxPreview ? localize('linuxPreview', 'Linux Preview') : undefined;
+        if (stateDescription && previewDescription) {
+            return `${previewDescription} - ${stateDescription}`;
+        } else {
+            return stateDescription || previewDescription;
+        }
     }
 
     public get iconPath(): string {

--- a/src/tree/FunctionTreeItem.ts
+++ b/src/tree/FunctionTreeItem.ts
@@ -5,7 +5,6 @@
 
 import { FunctionEnvelope } from 'azure-arm-website/lib/models';
 import { URL } from 'url';
-import { OutputChannel } from 'vscode';
 import { functionsAdminRequest, SiteClient } from 'vscode-azureappservice';
 import { DialogResponses, IAzureNode } from 'vscode-azureextensionui';
 import { ILogStreamTreeItem } from '../commands/logstream/ILogStreamTreeItem';
@@ -22,17 +21,15 @@ export class FunctionTreeItem implements ILogStreamTreeItem {
     public readonly client: SiteClient;
 
     private readonly _name: string;
-    private readonly _outputChannel: OutputChannel;
     private _triggerUrl: string;
 
-    public constructor(client: SiteClient, func: FunctionEnvelope, outputChannel: OutputChannel) {
+    public constructor(client: SiteClient, func: FunctionEnvelope) {
         if (!func.id) {
             throw new ArgumentError(func);
         }
 
         this.client = client;
         this._name = getFunctionNameFromId(func.id);
-        this._outputChannel = outputChannel;
 
         this.config = new FunctionConfig(func.config);
     }
@@ -64,10 +61,10 @@ export class FunctionTreeItem implements ILogStreamTreeItem {
     public async deleteTreeItem(_node: IAzureNode): Promise<void> {
         const message: string = localize('ConfirmDeleteFunction', 'Are you sure you want to delete function "{0}"?', this._name);
         await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.deleteResponse, DialogResponses.cancel);
-        this._outputChannel.show(true);
-        this._outputChannel.appendLine(localize('DeletingFunction', 'Deleting function "{0}"...', this._name));
+        ext.outputChannel.show(true);
+        ext.outputChannel.appendLine(localize('DeletingFunction', 'Deleting function "{0}"...', this._name));
         await this.client.deleteFunction(this._name);
-        this._outputChannel.appendLine(localize('DeleteFunctionSucceeded', 'Successfully deleted function "{0}".', this._name));
+        ext.outputChannel.appendLine(localize('DeleteFunctionSucceeded', 'Successfully deleted function "{0}".', this._name));
     }
 
     public async initializeTriggerUrl(): Promise<void> {

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FunctionEnvelope, FunctionEnvelopeCollection } from 'azure-arm-website/lib/models';
-import { OutputChannel } from 'vscode';
 import { SiteClient } from 'vscode-azureappservice';
 import { IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
@@ -19,12 +18,10 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
     public readonly childTypeLabel: string = localize('azFunc.Function', 'Function');
 
     private readonly _client: SiteClient;
-    private readonly _outputChannel: OutputChannel;
     private _nextLink: string | undefined;
 
-    public constructor(client: SiteClient, outputChannel: OutputChannel) {
+    public constructor(client: SiteClient) {
         this._client = client;
-        this._outputChannel = outputChannel;
     }
 
     public get id(): string {
@@ -50,7 +47,7 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
         const treeItems: IAzureTreeItem[] = [];
         await Promise.all(funcs.map(async (fe: FunctionEnvelope) => {
             try {
-                const treeItem: FunctionTreeItem = new FunctionTreeItem(this._client, fe, this._outputChannel);
+                const treeItem: FunctionTreeItem = new FunctionTreeItem(this._client, fe);
                 if (treeItem.config.isHttpTrigger) {
                     // We want to cache the trigger url so that it is instantaneously copied when the user performs the copy action
                     // (Otherwise there might be a second or two delay which could lead to confusion)

--- a/src/tree/ProxiesTreeItem.ts
+++ b/src/tree/ProxiesTreeItem.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
 import { getFile, IFileResult, putFile, SiteClient } from 'vscode-azureappservice';
 import { DialogResponses, IAzureParentTreeItem, IAzureTreeItem, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
@@ -23,11 +22,9 @@ export class ProxiesTreeItem implements IAzureParentTreeItem {
     private _deletingProxy: boolean = false;
 
     private readonly _client: SiteClient;
-    private readonly _outputChannel: vscode.OutputChannel;
 
-    public constructor(client: SiteClient, outputChannel: vscode.OutputChannel) {
+    public constructor(client: SiteClient) {
         this._client = client;
-        this._outputChannel = outputChannel;
     }
 
     public get id(): string {
@@ -73,12 +70,12 @@ export class ProxiesTreeItem implements IAzureParentTreeItem {
         } else {
             this._deletingProxy = true;
             try {
-                this._outputChannel.show(true);
-                this._outputChannel.appendLine(localize('DeletingProxy', 'Deleting proxy "{0}"...', name));
+                ext.outputChannel.show(true);
+                ext.outputChannel.appendLine(localize('DeletingProxy', 'Deleting proxy "{0}"...', name));
                 delete this._proxyConfig.proxies[name];
                 const data: string = JSON.stringify(this._proxyConfig);
                 this._etag = await putFile(this._client, data, this._proxiesJsonPath, this._etag);
-                this._outputChannel.appendLine(localize('DeleteProxySucceeded', 'Successfully deleted proxy "{0}".', name));
+                ext.outputChannel.appendLine(localize('DeleteProxySucceeded', 'Successfully deleted proxy "{0}".', name));
             } finally {
                 this._deletingProxy = false;
             }


### PR DESCRIPTION
Per the Functions team, they're not doing a "full" preview of Python in Azure quite yet, so they want our support under a feature flag for the ignite release.

I also added "Linux Preview" in the explorer like so (Approved by Mr Matt):
![screen shot 2018-09-18 at 9 42 28 am](https://user-images.githubusercontent.com/11282622/45703132-4c6b8180-bb28-11e8-9604-00787cd5504a.png)
![screen shot 2018-09-18 at 9 42 13 am](https://user-images.githubusercontent.com/11282622/45703127-4aa1be00-bb28-11e8-8c35-5a99e7a05320.png)