### PR TITLE
Dynamically retrieve appropriate dist-tag for npm

### DIFF
--- a/src/funcCoreTools/getNpmDistTag.ts
+++ b/src/funcCoreTools/getNpmDistTag.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// tslint:disable-next-line:no-require-imports
+import request = require('request-promise');
+import { ProjectRuntime } from '../constants';
+import { localize } from '../localize';
+
+const npmRegistryUri: string = 'https://aka.ms/W2mvv3';
+
+export interface INpmDistTag { tag: string; value: string; }
+
+export async function getNpmDistTag(runtime: ProjectRuntime): Promise<INpmDistTag> {
+    const tags: { [key: string]: string } = <{ [key: string]: string }>JSON.parse(await <Thenable<string>>request(npmRegistryUri));
+    for (const key of Object.keys(tags)) {
+        if ((runtime === ProjectRuntime.v1 && tags[key].startsWith('1')) ||
+            (runtime === ProjectRuntime.v2 && tags[key].startsWith('2'))) {
+            return { tag: key, value: tags[key] };
+        }
+    }
+
+    throw new Error(localize('noDistTag', 'Failed to retrieve NPM tag for runtime "{0}".', runtime));
+}

--- a/src/funcCoreTools/installFuncCoreTools.ts
+++ b/src/funcCoreTools/installFuncCoreTools.ts
@@ -8,6 +8,7 @@ import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { promptForProjectRuntime } from "../ProjectSettings";
 import { cpUtils } from '../utils/cpUtils';
+import { getNpmDistTag, INpmDistTag } from './getNpmDistTag';
 
 export async function installFuncCoreTools(packageManager: PackageManager): Promise<void> {
     let runtime: ProjectRuntime;
@@ -20,16 +21,8 @@ export async function installFuncCoreTools(packageManager: PackageManager): Prom
     ext.outputChannel.show();
     switch (packageManager) {
         case PackageManager.npm:
-            switch (runtime) {
-                case ProjectRuntime.v1:
-                    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', funcPackageName);
-                    break;
-                case ProjectRuntime.v2:
-                    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', `${funcPackageName}@core`, '--unsafe-perm', 'true');
-                    break;
-                default:
-                    throw new RangeError(localize('invalidRuntime', 'Invalid runtime "{0}".', runtime));
-            }
+            const distTag: INpmDistTag = await getNpmDistTag(runtime);
+            await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', `${funcPackageName}@${distTag.tag}`);
             break;
         case PackageManager.brew:
             await cpUtils.executeCommand(ext.outputChannel, undefined, 'brew', 'tap', 'azure/functions');

--- a/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
+++ b/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
@@ -15,8 +15,7 @@ import { funcToolsInstalled } from './validateFuncCoreToolsInstalled';
 export async function installOrUpdateFuncCoreTools(): Promise<void> {
     const isFuncInstalled: boolean = await funcToolsInstalled();
     const packageManager: PackageManager | undefined = await getFuncPackageManager(isFuncInstalled);
-    // tslint:disable-next-line:strict-boolean-expressions
-    if (!packageManager) {
+    if (packageManager === undefined) {
         throw new Error(localize('installNotSupported', 'Install or update is only supported for brew or npm.'));
     }
 

--- a/src/funcCoreTools/updateFuncCoreTools.ts
+++ b/src/funcCoreTools/updateFuncCoreTools.ts
@@ -7,21 +7,14 @@ import { funcPackageName, PackageManager, ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { cpUtils } from '../utils/cpUtils';
+import { getNpmDistTag, INpmDistTag } from './getNpmDistTag';
 
 export async function updateFuncCoreTools(packageManager: PackageManager, projectRuntime: ProjectRuntime): Promise<void> {
     ext.outputChannel.show();
     switch (packageManager) {
         case PackageManager.npm:
-            switch (projectRuntime) {
-                case ProjectRuntime.v1:
-                    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', funcPackageName);
-                    break;
-                case ProjectRuntime.v2:
-                    await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', `${funcPackageName}@core`, '--unsafe-perm', 'true');
-                    break;
-                default:
-                    throw new RangeError(localize('invalidRuntime', 'Invalid runtime "{0}".', projectRuntime));
-            }
+            const distTag: INpmDistTag = await getNpmDistTag(projectRuntime);
+            await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'install', '-g', `${funcPackageName}@${distTag.tag}`);
             break;
         case PackageManager.brew:
             await cpUtils.executeCommand(ext.outputChannel, undefined, 'brew', 'upgrade', funcPackageName);

--- a/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -16,6 +16,7 @@ import { localize } from '../localize';
 import { convertStringToRuntime, getFuncExtensionSetting, updateGlobalSetting } from '../ProjectSettings';
 import { getFuncPackageManager } from './getFuncPackageManager';
 import { getLocalFuncCoreToolsVersion } from './getLocalFuncCoreToolsVersion';
+import { getNpmDistTag } from "./getNpmDistTag";
 import { updateFuncCoreTools } from './updateFuncCoreTools';
 
 export async function validateFuncCoreToolsIsLatest(): Promise<void> {
@@ -80,16 +81,7 @@ async function getNewestFunctionRuntimeVersion(packageManager: PackageManager | 
                 return matches[1];
             }
         } else {
-            const npmRegistryUri: string = 'https://aka.ms/W2mvv3';
-            type distTags = { core: string, docker: string, latest: string };
-            const distTags: distTags = <distTags>JSON.parse(await <Thenable<string>>request(npmRegistryUri));
-            switch (projectRuntime) {
-                case ProjectRuntime.v1:
-                    return distTags.latest;
-                case ProjectRuntime.v2:
-                    return distTags.core;
-                default:
-            }
+            return (await getNpmDistTag(projectRuntime)).value;
         }
     } catch (error) {
         actionContext.properties.latestRuntimeError = parseError(error).message;


### PR DESCRIPTION
The tags are changing when v2 GA's soon. We could hard-code the new strings and try to time our release perfectly with the func cli, but I'd rather dynamically check the dist-tags.

Tested on mac/windows. I'm not worried about Linux since we don't support install in that scenario (Linux requires sudo so we ignore it).

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/563