### PR TITLE
Fix initProjectForVSCode for python projects

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -70,6 +70,8 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
     }
 
     public async getTasksJson(): Promise<{}> {
+        // func host task requires this
+        await makeVenvDebuggable(this.functionAppPath);
         return {
             version: '2.0.0',
             tasks: [
@@ -225,6 +227,9 @@ async function getPythonAlias(): Promise<string> {
 export async function createVirtualEnviornment(functionAppPath: string): Promise<void> {
     const pythonAlias: string = await getPythonAlias();
     await cpUtils.executeCommand(ext.outputChannel, functionAppPath, pythonAlias, '-m', 'venv', funcEnvName);
+}
+
+export async function makeVenvDebuggable(functionAppPath: string): Promise<void> {
     // install ptvsd - required for debugging in VS Code
     await runPythonCommandInVenv(functionAppPath, 'pip install ptvsd');
 }

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -19,7 +19,7 @@ import { initProjectForVSCode } from './initProjectForVSCode';
 import { funcHostTaskId } from './IProjectCreator';
 import { ITask, ITasksJson } from './ITasksJson';
 import { funcNodeDebugArgs, funcNodeDebugEnvVar } from './JavaScriptProjectCreator';
-import { createVirtualEnviornment, funcEnvName, runPythonCommandInVenv } from './PythonProjectCreator';
+import { createVirtualEnviornment, funcEnvName, makeVenvDebuggable, runPythonCommandInVenv } from './PythonProjectCreator';
 
 export async function validateFunctionProjects(actionContext: IActionContext, ui: IAzureUserInput, outputChannel: vscode.OutputChannel, folders: vscode.WorkspaceFolder[] | undefined): Promise<void> {
     actionContext.suppressTelemetry = true;
@@ -163,6 +163,7 @@ async function verifyPythonVenv(projectLanguage: string | undefined, folderPath:
                     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('creatingVenv', 'Creating virtual environment...') }, async () => {
                         // create venv
                         await createVirtualEnviornment(folderPath);
+                        await makeVenvDebuggable(folderPath);
                         // install venv requirements
                         const requirementsFileName: string = 'requirements.txt';
                         if (await fse.pathExists(path.join(folderPath, requirementsFileName))) {


### PR DESCRIPTION
We have this dialog that detects projects created outside our extension (aka through the func cli):
![screen shot 2018-09-20 at 10 47 16 am](https://user-images.githubusercontent.com/11282622/45836783-9ab48800-bcc2-11e8-8bdd-99b315110142.png)

I tested that scenario for Python and everything works except it doesn't install ptvsd, required for debugging. Moved that logic into 'getTasks' since that method is called during initProjectForVSCode

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/616