### PR TITLE
Bump appservice package to fix linux deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -713,7 +713,7 @@
         "portfinder": "^1.0.13",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "^0.22.0",
+        "vscode-azureappservice": "^0.22.2",
         "vscode-azureextensionui": "^0.17.6",
         "vscode-azurekudu": "^0.1.8",
         "vscode-extension-telemetry": "^0.0.18",


### PR DESCRIPTION
Thought this fix was important enough to bump the version requirement in the package.json.

Based on this PR in shared package: https://github.com/Microsoft/vscode-azuretools/pull/268

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/630
Leaving https://github.com/Microsoft/vscode-azurefunctions/issues/625 open to fix all the edge cases in a future release