### PR TITLE
 Better error message when failing to list functions on linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to the "azurefunctions" extension will be documented in this
 ### [Fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.11.0%22+label%3Abug+is%3Aclosed)
 - "Copy Function Url" for v2 non-anonymous functions will copy an invalid url [#567](https://github.com/Microsoft/vscode-azurefunctions/issues/567)
 
+### Known Issues
+- Functions cannot be listed for Linux Consumption apps [azure-functions-host#3502](https://github.com/Azure/azure-functions-host/issues/3502)
+
 ## 0.10.2 - 2018-09-10
 
 ### Fixed

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FunctionEnvelope, FunctionEnvelopeCollection } from 'azure-arm-website/lib/models';
+import { isArray } from 'util';
 import { SiteClient } from 'vscode-azureappservice';
 import { createTreeItemsWithErrorHandling, IAzureNode, IAzureParentTreeItem, IAzureTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
@@ -41,6 +42,11 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
         }
 
         const funcs: FunctionEnvelopeCollection = this._nextLink ? await this._client.listFunctionsNext(this._nextLink) : await this._client.listFunctions();
+
+        if (!isArray(funcs)) {
+            throw new Error(localize('failedToList', 'Failed to list functions.'));
+        }
+
         this._nextLink = funcs.nextLink;
 
         return await createTreeItemsWithErrorHandling(

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -43,6 +43,7 @@ export class FunctionsTreeItem implements IAzureParentTreeItem {
 
         const funcs: FunctionEnvelopeCollection = this._nextLink ? await this._client.listFunctionsNext(this._nextLink) : await this._client.listFunctions();
 
+        // https://github.com/Azure/azure-functions-host/issues/3502
         if (!isArray(funcs)) {
             throw new Error(localize('failedToList', 'Failed to list functions.'));
         }


### PR DESCRIPTION
There's a bug in the ARM api. Hopefully they fix it soon, but I think it's worth it to show a slightly better error message since we try to list functions after every deploy.

From this:
![screen shot 2018-09-21 at 10 48 29 am](https://user-images.githubusercontent.com/11282622/45897410-e41cda00-bd8b-11e8-85bf-56e0812b8579.png)

To this:
![screen shot 2018-09-21 at 10 45 04 am](https://user-images.githubusercontent.com/11282622/45897314-a455f280-bd8b-11e8-8cb5-f5977f30b567.png)
