### PR TITLE
Fix separator for executeCommand on windows

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -201,12 +201,14 @@ async function validatePythonAlias(pyAlias: PythonAlias): Promise<string | undef
     }
 }
 
-function convertToVenvCommand(command: string, platform: NodeJS.Platform = process.platform): string {
+function convertToVenvCommand(command: string, platform: NodeJS.Platform, separator?: string): string {
     switch (platform) {
         case Platform.Windows:
-            return `${path.join('.', funcEnvName, 'Scripts', 'activate')} | ${command}`;
+            // tslint:disable-next-line:strict-boolean-expressions
+            return `${path.join('.', funcEnvName, 'Scripts', 'activate')} ${separator || '|'} ${command}`;
         default:
-            return `. ${path.join('.', funcEnvName, 'bin', 'activate')} && ${command}`;
+            // tslint:disable-next-line:strict-boolean-expressions
+            return `. ${path.join('.', funcEnvName, 'bin', 'activate')} ${separator || '&&'} ${command}`;
     }
 }
 
@@ -241,5 +243,6 @@ export async function makeVenvDebuggable(functionAppPath: string): Promise<void>
 }
 
 export async function runPythonCommandInVenv(folderPath: string, command: string): Promise<void> {
-    await cpUtils.executeCommand(ext.outputChannel, folderPath, convertToVenvCommand(command));
+    // executeCommand always uses '&&' separator even on Windows
+    await cpUtils.executeCommand(ext.outputChannel, folderPath, convertToVenvCommand(command, process.platform, '&&'));
 }

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -94,7 +94,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                         command: `${funcExtensionsCommand} && ${convertToVenvCommand(funcHostStartCommand, Platform.MacOS)}`
                     },
                     windows: {
-                        command: `${funcExtensionsCommand} | ${convertToVenvCommand(funcHostStartCommand, Platform.Windows)}`
+                        command: `${funcExtensionsCommand} ; ${convertToVenvCommand(funcHostStartCommand, Platform.Windows)}`
                     },
                     linux: {
                         command: `${funcExtensionsCommand} && ${convertToVenvCommand(funcHostStartCommand, Platform.Linux)}`
@@ -205,7 +205,7 @@ function convertToVenvCommand(command: string, platform: NodeJS.Platform, separa
     switch (platform) {
         case Platform.Windows:
             // tslint:disable-next-line:strict-boolean-expressions
-            return `${path.join('.', funcEnvName, 'Scripts', 'activate')} ${separator || '|'} ${command}`;
+            return `${path.join('.', funcEnvName, 'Scripts', 'activate')} ${separator || ';'} ${command}`;
         default:
             // tslint:disable-next-line:strict-boolean-expressions
             return `. ${path.join('.', funcEnvName, 'bin', 'activate')} ${separator || '&&'} ${command}`;


### PR DESCRIPTION
Accidentally introduced this bug here: https://github.com/Microsoft/vscode-azurefunctions/pull/623

the node child_process stuff always needs '&&' as a separator, even on windows