### PR TITLE
Stop func host task after debug session ends

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -11,13 +11,14 @@ import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { DialogResponses, parseError } from 'vscode-azureextensionui';
 import { gitignoreFileName, hostFileName, isWindows, localSettingsFileName, ProjectRuntime, publishTaskId, TemplateFilter } from '../../constants';
+import { funcHostCommand, funcHostTaskLabel } from '../../funcCoreTools/funcHostTask';
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from "../../localize";
 import { getFuncExtensionSetting, promptForProjectRuntime, updateGlobalSetting } from '../../ProjectSettings';
 import { executeDotnetTemplateCommand } from '../../templates/executeDotnetTemplateCommand';
 import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
-import { funcHostTaskId, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
+import { funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
@@ -92,8 +93,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
-                    label: publishTaskId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
-                    identifier: publishTaskId,
+                    label: publishTaskId,
                     command: 'dotnet publish --configuration Release',
                     type: 'shell',
                     dependsOn: 'clean release',
@@ -103,14 +103,13 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
-                    label: localize('azFunc.runFuncHost', 'Run Functions Host'),
-                    identifier: funcHostTaskId,
+                    label: funcHostTaskLabel,
                     type: 'shell',
                     dependsOn: 'build',
                     options: {
                         cwd: `\${workspaceFolder}/${this._debugSubpath}`
                     },
-                    command: 'func host start',
+                    command: funcHostCommand,
                     isBackground: true,
                     presentation: {
                         reveal: 'always'

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TemplateFilter } from "../../constants";
+import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
-import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher } from "./IProjectCreator";
+import { funcWatchProblemMatcher } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
@@ -17,9 +18,8 @@ export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
             tasks: [
                 {
                     label: funcHostTaskLabel,
-                    identifier: funcHostTaskId,
                     type: 'shell',
-                    command: 'func host start',
+                    command: funcHostCommand,
                     isBackground: true,
                     presentation: {
                         reveal: 'always'

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -46,7 +46,4 @@ export abstract class ProjectCreatorBase {
     }
 }
 
-export const funcHostTaskId: string = 'runFunctionsHost';
-// Don't localize this label until this is fixed: https://github.com/Microsoft/vscode/issues/57707
-export const funcHostTaskLabel: string = 'Run Functions Host';
 export const funcWatchProblemMatcher: string = '$func-watch';

--- a/src/commands/createNewProject/ITasksJson.ts
+++ b/src/commands/createNewProject/ITasksJson.ts
@@ -8,7 +8,7 @@ export interface ITasksJson {
 }
 
 export interface ITask {
-    identifier: string;
+    label: string;
     options?: ITaskOptions;
 }
 

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -10,11 +10,12 @@ import * as vscode from 'vscode';
 import { InputBoxOptions } from 'vscode';
 import { IActionContext, IAzureUserInput } from "vscode-azureextensionui";
 import { ProjectRuntime, TemplateFilter } from '../../constants';
+import { funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
 import * as fsUtil from '../../utils/fs';
 import { validateMavenIdentifier, validatePackageName } from '../../utils/javaNameUtils';
 import { mavenUtils } from '../../utils/mavenUtils';
-import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
+import { funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 export class JavaProjectCreator extends ProjectCreatorBase {
     public static defaultRuntime: ProjectRuntime = ProjectRuntime.v2;
@@ -105,7 +106,6 @@ export class JavaProjectCreator extends ProjectCreatorBase {
             tasks: [
                 {
                     label: funcHostTaskLabel,
-                    identifier: funcHostTaskId,
                     linux: {
                         command: 'sh -c "mvn clean package -B && func host start --language-worker -- \\\"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\\\" --script-root \\\"%path%\\\""'
                     },
@@ -154,7 +154,7 @@ export class JavaProjectCreator extends ProjectCreatorBase {
                     request: 'attach',
                     hostName: 'localhost',
                     port: 5005,
-                    preLaunchTask: funcHostTaskId
+                    preLaunchTask: funcHostTaskLabel
                 }
             ]
         };

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -4,8 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { installExtensionsId, ProjectRuntime, TemplateFilter } from "../../constants";
+import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
-import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher } from "./IProjectCreator";
+import { funcWatchProblemMatcher } from "./IProjectCreator";
 import { ITaskOptions } from "./ITasksJson";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
@@ -27,7 +28,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
                     type: 'node',
                     request: 'attach',
                     port: 5858,
-                    preLaunchTask: funcHostTaskId
+                    preLaunchTask: funcHostTaskLabel
                 }
             ]
         };
@@ -38,9 +39,8 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
         // tslint:disable-next-line:no-any
         const funcTask: any = {
             label: funcHostTaskLabel,
-            identifier: funcHostTaskId,
             type: 'shell',
-            command: 'func host start',
+            command: funcHostCommand,
             isBackground: true,
             presentation: {
                 reveal: 'always'
@@ -49,8 +49,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
         };
 
         const installExtensionsTask: {} = {
-            label: installExtensionsId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
-            identifier: installExtensionsId,
+            label: installExtensionsId,
             command: 'func extensions install',
             type: 'shell',
             presentation: {

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -11,12 +11,13 @@ import { MessageItem, window } from 'vscode';
 import { DialogResponses, parseError, UserCancelledError } from 'vscode-azureextensionui';
 import { funcPackId, gitignoreFileName, isWindows, localSettingsFileName, Platform, ProjectRuntime, TemplateFilter } from "../../constants";
 import { ext } from '../../extensionVariables';
+import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { azureWebJobsStorageKey, getLocalSettings, ILocalAppSettings } from '../../LocalAppSettings';
 import { localize } from "../../localize";
 import { cpUtils } from "../../utils/cpUtils";
 import * as fsUtil from '../../utils/fs';
-import { funcHostTaskId, funcWatchProblemMatcher } from "./IProjectCreator";
+import { funcWatchProblemMatcher } from "./IProjectCreator";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export const funcEnvName: string = 'func_env';
@@ -43,7 +44,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                     request: 'attach',
                     port: 9091,
                     host: 'localhost',
-                    preLaunchTask: funcHostTaskId
+                    preLaunchTask: funcHostTaskLabel
                 }
             ]
         };
@@ -85,24 +86,22 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         await this.ensureAzureWebJobsStorage();
 
         const funcPackCommand: string = 'func pack';
-        const funcHostStartCommand: string = 'func host start';
         const funcExtensionsCommand: string = 'func extensions install';
         const pipInstallCommand: string = 'pip install -r requirements.txt';
         return {
             version: '2.0.0',
             tasks: [
                 {
-                    label: localize('azFunc.runFuncHost', 'Run Functions Host'),
-                    identifier: funcHostTaskId,
+                    label: funcHostTaskLabel,
                     type: 'shell',
                     osx: {
-                        command: convertToVenvCommand(Platform.MacOS, funcExtensionsCommand, pipInstallCommand, funcHostStartCommand)
+                        command: convertToVenvCommand(Platform.MacOS, funcExtensionsCommand, pipInstallCommand, funcHostCommand)
                     },
                     windows: {
-                        command: convertToVenvCommand(Platform.Windows, funcExtensionsCommand, pipInstallCommand, funcHostStartCommand)
+                        command: convertToVenvCommand(Platform.Windows, funcExtensionsCommand, pipInstallCommand, funcHostCommand)
                     },
                     linux: {
-                        command: convertToVenvCommand(Platform.Linux, funcExtensionsCommand, pipInstallCommand, funcHostStartCommand)
+                        command: convertToVenvCommand(Platform.Linux, funcExtensionsCommand, pipInstallCommand, funcHostCommand)
                     },
                     isBackground: true,
                     presentation: {
@@ -118,7 +117,6 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                 },
                 {
                     label: funcPackId,
-                    identifier: funcPackId, // Until this is fixed, the label must be the same as the id: https://github.com/Microsoft/vscode/issues/57707
                     type: 'shell',
                     osx: {
                         command: convertToVenvCommand(Platform.MacOS, funcPackCommand)

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -6,10 +6,11 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime, proxiesFileName, TemplateFilter } from '../../constants';
+import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { ILocalAppSettings } from '../../LocalAppSettings';
 import { confirmOverwriteFile } from "../../utils/fs";
 import * as fsUtil from '../../utils/fs';
-import { funcHostTaskId, funcHostTaskLabel, funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
+import { funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
 
 // tslint:disable-next-line:no-multiline-string
 const gitignore: string = `bin
@@ -52,9 +53,8 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
             tasks: [
                 {
                     label: funcHostTaskLabel,
-                    identifier: funcHostTaskId,
                     type: 'shell',
-                    command: 'func host start',
+                    command: funcHostCommand,
                     isBackground: true,
                     presentation: {
                         reveal: 'always'

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -11,12 +11,12 @@ import * as vscode from 'vscode';
 import { DialogResponses, IActionContext, IAzureUserInput } from 'vscode-azureextensionui';
 import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, tasksFileName, vscodeFolderName } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { funcHostNameRegEx } from "../../funcCoreTools/funcHostTask";
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from '../../localize';
 import { getFuncExtensionSetting, updateGlobalSetting, updateWorkspaceSetting } from '../../ProjectSettings';
 import * as fsUtil from '../../utils/fs';
 import { initProjectForVSCode } from './initProjectForVSCode';
-import { funcHostTaskId } from './IProjectCreator';
 import { ITask, ITasksJson } from './ITasksJson';
 import { funcNodeDebugArgs, funcNodeDebugEnvVar } from './JavaScriptProjectCreator';
 import { createVirtualEnviornment, funcEnvName, makeVenvDebuggable } from './PythonProjectCreator';
@@ -100,7 +100,7 @@ async function verifyDebugConfigIsValid(projectLanguage: string | undefined, fol
             if (!rawTasksData.includes(funcNodeDebugEnvVar)) {
                 const tasksContent: ITasksJson = <ITasksJson>JSON.parse(rawTasksData);
 
-                const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => t.identifier === funcHostTaskId);
+                const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => funcHostNameRegEx.test(t.label));
                 if (funcTask) {
                     actionContext.properties.debugConfigValid = 'false';
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -301,7 +301,6 @@ async function runPreDeployTask(deployFsPath: string, telemetryProperties: Telem
     const tasks: vscode.Task[] = await vscode.tasks.fetchTasks();
     let preDeployTask: vscode.Task | undefined;
     for (const task of tasks) {
-        // Until this is fixed, we have to query the task's name instead of id: https://github.com/Microsoft/vscode/issues/57707
         if (task.name.toLowerCase() === taskName.toLowerCase() && task.scope !== undefined) {
             const workspaceFolder: vscode.WorkspaceFolder = <vscode.WorkspaceFolder>task.scope;
             if (<vscode.Uri | undefined>workspaceFolder.uri && (isPathEqual(workspaceFolder.uri.fsPath, deployFsPath) || isSubpath(workspaceFolder.uri.fsPath, deployFsPath))) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,13 +29,14 @@ import { ILogStreamTreeItem } from './commands/logstream/ILogStreamTreeItem';
 import { startStreamingLogs } from './commands/logstream/startStreamingLogs';
 import { stopStreamingLogs } from './commands/logstream/stopStreamingLogs';
 import { openInPortal } from './commands/openInPortal';
-import { initPickFuncProcess, pickFuncProcess } from './commands/pickFuncProcess';
+import { pickFuncProcess } from './commands/pickFuncProcess';
 import { remoteDebugFunctionApp } from './commands/remoteDebugFunctionApp';
 import { renameAppSetting } from './commands/renameAppSetting';
 import { restartFunctionApp } from './commands/restartFunctionApp';
 import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
 import { ext } from './extensionVariables';
+import { registerFuncHostTaskEvents } from './funcCoreTools/funcHostTask';
 import { installOrUpdateFuncCoreTools } from './funcCoreTools/installOrUpdateFuncCoreTools';
 import { uninstallFuncCoreTools } from './funcCoreTools/uninstallFuncCoreTools';
 import { validateFuncCoreToolsIsLatest } from './funcCoreTools/validateFuncCoreToolsIsLatest';
@@ -127,7 +128,7 @@ export function activate(context: vscode.ExtensionContext): void {
         registerCommand('azureFunctions.installOrUpdateFuncCoreTools', async () => await installOrUpdateFuncCoreTools());
         registerCommand('azureFunctions.uninstallFuncCoreTools', async () => await uninstallFuncCoreTools());
 
-        initPickFuncProcess();
+        registerFuncHostTaskEvents();
     });
 }
 

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Task, TaskExecution } from 'vscode';
+import { IActionContext, registerEvent } from 'vscode-azureextensionui';
+import { localize } from '../localize';
+
+let isFuncHostRunning: boolean = false;
+
+export const funcHostTaskLabel: string = 'runFunctionsHost';
+export const funcHostCommand: string = 'func host start';
+export const funcHostNameRegEx: RegExp = /run\s*functions\s*host/i;
+
+export let stopFuncHostPromise: Promise<void> = Promise.resolve();
+
+export function isFuncHostTask(task: Task): boolean {
+    // task.name resolves to the task's id (deprecated https://github.com/Microsoft/vscode/issues/57707), then label
+    return funcHostNameRegEx.test(task.name);
+}
+
+export function registerFuncHostTaskEvents(): void {
+    registerEvent('azureFunctions.onDidStartTask', vscode.tasks.onDidStartTask, async function (this: IActionContext, e: vscode.TaskStartEvent): Promise<void> {
+        this.suppressErrorDisplay = true;
+        this.suppressTelemetry = true;
+        if (isFuncHostTask(e.execution.task)) {
+            isFuncHostRunning = true;
+        }
+    });
+
+    registerEvent('azureFunctions.onDidEndTask', vscode.tasks.onDidEndTask, async function (this: IActionContext, e: vscode.TaskEndEvent): Promise<void> {
+        this.suppressErrorDisplay = true;
+        this.suppressTelemetry = true;
+        if (isFuncHostTask(e.execution.task)) {
+            isFuncHostRunning = false;
+        }
+    });
+
+    registerEvent('azureFunctions.onDidTerminateDebugSession', vscode.debug.onDidTerminateDebugSession, stopFuncTaskIfRunning);
+}
+
+async function stopFuncTaskIfRunning(this: IActionContext): Promise<void> {
+    this.suppressErrorDisplay = true;
+    this.suppressTelemetry = true;
+
+    const funcExecution: TaskExecution | undefined = vscode.tasks.taskExecutions.find((te: TaskExecution) => isFuncHostTask(te.task));
+    if (funcExecution && isFuncHostRunning) {
+        this.suppressTelemetry = false; // only track telemetry if it's actually the func task
+        stopFuncHostPromise = new Promise((resolve: () => void, reject: (e: Error) => void): void => {
+            const listener: vscode.Disposable = vscode.tasks.onDidEndTask((e: vscode.TaskEndEvent) => {
+                if (isFuncHostTask(e.execution.task)) {
+                    resolve();
+                    listener.dispose();
+                }
+            });
+
+            const timeoutInSeconds: number = 30;
+            const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to stop previous running Functions host within "{0}" seconds. Make sure the task has stopped before you debug again.', timeoutInSeconds));
+            setTimeout(() => { reject(timeoutError); }, timeoutInSeconds * 1000);
+        });
+        funcExecution.terminate();
+        await stopFuncHostPromise;
+    }
+}


### PR DESCRIPTION
The bug was originally filed for Python, but this helps all languages.

Also removed 'identifier' from tasks.json since it's now deprecated.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/638
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/639