### PR TITLE
Make preDeployTask have scope 'resource'

### DIFF
--- a/package.json
+++ b/package.json
@@ -657,6 +657,7 @@
                         "description": "%azFunc.projectOpenBehaviorDescription%"
                     },
                     "azureFunctions.preDeployTask": {
+                        "scope": "resource",
                         "type": "string",
                         "description": "%azFunc.preDeployTaskDescription%"
                     },


### PR DESCRIPTION
So that users can set this at the workspace _folder_ level if they want.