### PR TITLE
Change endsPattern for 'func-watch'

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,7 +507,7 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
-                    "endsPattern": "^.*(?:Application|Job host) started.*$"
+                    "endsPattern": "^.*Host lock lease acquired by instance ID.*$"
                 },
                 "severity": "error"
             }


### PR DESCRIPTION
Based on discussion here: https://github.com/Microsoft/vscode-azurefunctions/issues/660

This 'endsPattern' is a signal that debugging can start, but turns out we may have been doing it too soon on some people's computers.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/660