### PR TITLE
Fix getNpmDistTag for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,27 +59,13 @@ Both v1 and v2 of the runtime can be installed on Windows. [See here](https://do
 To install v1:
 
 ```bash
-npm i -g azure-functions-core-tools
+npm i -g azure-functions-core-tools@1
 ```
 
 To install v2:
 
 ```bash
-npm i -g azure-functions-core-tools@core
-```
-
-**IMPORTANT**: v2 is becoming generally available (GA) soon (as of 9/19/2018). After GA, the commands will change to the following:
-
-To install v1:
-
-```bash
-npm i -g azure-functions-core-tools@v1
-```
-
-To install v2:
-
-```bash
-npm i -g azure-functions-core-tools
+npm i -g azure-functions-core-tools@2
 ```
 
 ### Mac

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -5,7 +5,7 @@ The local project runtime is controlled by the "azureFunctions.projectRuntime" s
 |VS Code Setting|Version|Status|Platform|Supported OS's|
 |---|---|---|---|---|
 |~1|1.x|Generally Available (GA)|.NET Framework|Windows|
-|~2|2.x|Preview (as of 9/19/2018) but Generally Available (GA) soon|.NET Standard|Windows, Mac, and Linux|
+|~2|2.x|Generally Available (GA)|.NET Standard|Windows, Mac, and Linux|
 
 It's recommended to use the same version of the runtime installed on your machine as the VS Code setting, but not required. For example, if you are developing on a Mac, you are required to install the "~2" runtime because "~1" only works on Windows. However, you might set your runtime to "~1" if your coworkers are developing on Windows or if you haven't migrated to "~2" in Azure yet. WARNING: This may lead to differences when running the Function App locally vs. remotely.
 

--- a/src/funcCoreTools/getNpmDistTag.ts
+++ b/src/funcCoreTools/getNpmDistTag.ts
@@ -31,10 +31,10 @@ export async function getNpmDistTag(runtime: ProjectRuntime): Promise<INpmDistTa
             throw new RangeError(localize('invalidRuntime', 'Invalid runtime "{0}".', runtime));
     }
 
-    const filteredVersions: string[] = Object.keys(packageMetadata.versions).filter((v: string) => v.startsWith(majorVersion));
-    if (filteredVersions.length < 1) {
+    const validVersions: string[] = Object.keys(packageMetadata.versions).filter((v: string) => !!semver.valid(v));
+    const maxVersion: string | null = semver.maxSatisfying(validVersions, majorVersion);
+    if (!maxVersion) {
         throw new Error(localize('noDistTag', 'Failed to retrieve NPM tag for runtime "{0}".', runtime));
     }
-    const maxVersion: string = filteredVersions.reduce((v1: string, v2: string) => semver.gt(v1, v2) ? v1 : v2);
     return { tag: majorVersion, value: maxVersion };
 }

--- a/src/funcCoreTools/getNpmDistTag.ts
+++ b/src/funcCoreTools/getNpmDistTag.ts
@@ -5,21 +5,36 @@
 
 // tslint:disable-next-line:no-require-imports
 import request = require('request-promise');
+import * as semver from 'semver';
 import { ProjectRuntime } from '../constants';
 import { localize } from '../localize';
 
-const npmRegistryUri: string = 'https://aka.ms/W2mvv3';
+const npmRegistryUri: string = 'https://aka.ms/AA2qmnu';
 
 export interface INpmDistTag { tag: string; value: string; }
 
+interface IPackageMetadata {
+    versions: { [version: string]: {} };
+}
+
 export async function getNpmDistTag(runtime: ProjectRuntime): Promise<INpmDistTag> {
-    const tags: { [key: string]: string } = <{ [key: string]: string }>JSON.parse(await <Thenable<string>>request(npmRegistryUri));
-    for (const key of Object.keys(tags)) {
-        if ((runtime === ProjectRuntime.v1 && tags[key].startsWith('1')) ||
-            (runtime === ProjectRuntime.v2 && tags[key].startsWith('2'))) {
-            return { tag: key, value: tags[key] };
-        }
+    const packageMetadata: IPackageMetadata = <IPackageMetadata>JSON.parse(await <Thenable<string>>request(npmRegistryUri));
+    let majorVersion: string;
+    switch (runtime) {
+        case ProjectRuntime.v1:
+            majorVersion = '1';
+            break;
+        case ProjectRuntime.v2:
+            majorVersion = '2';
+            break;
+        default:
+            throw new RangeError(localize('invalidRuntime', 'Invalid runtime "{0}".', runtime));
     }
 
-    throw new Error(localize('noDistTag', 'Failed to retrieve NPM tag for runtime "{0}".', runtime));
+    const filteredVersions: string[] = Object.keys(packageMetadata.versions).filter((v: string) => v.startsWith(majorVersion));
+    if (filteredVersions.length < 1) {
+        throw new Error(localize('noDistTag', 'Failed to retrieve NPM tag for runtime "{0}".', runtime));
+    }
+    const maxVersion: string = filteredVersions.reduce((v1: string, v2: string) => semver.gt(v1, v2) ? v1 : v2);
+    return { tag: majorVersion, value: maxVersion };
 }


### PR DESCRIPTION
We thought the func team was going to add a 'v1' tag [here](http://registry.npmjs.org/-/package/azure-functions-core-tools/dist-tags), but instead this is what the api is returning:
```json
{
  "latest": "2.0.3",
  "core": "2.0.3"
}
```

The only consequence for users right now is that they're not getting this warning:
![screen shot 2018-10-01 at 3 48 51 pm](https://user-images.githubusercontent.com/11282622/46320169-ed7b2300-c591-11e8-8657-3fad7588bce3.png)

The [install instructions](https://github.com/Azure/azure-functions-core-tools#windows) say to just use `npm i -g azure-functions-core-tools@1` which is easy enough for us to do (and won't ever change in the future since it's not really a 'tag', just the major version).
