### PR TITLE
Check for C#Script && v1 runtime to enable WEBSITE_RUN_FROM_PACKAGE

### DIFF
--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -86,6 +86,8 @@ export class FunctionAppProvider implements IChildProvider {
             createOptions.runtime = 'python';
         } else {
             createOptions.os = 'windows';
+            // need to check if a project is both a C# Script and running v1
+            // https://github.com/Microsoft/vscode-azurefunctions/issues/684
             if (language !== ProjectLanguage.CSharpScript || runtime !== ProjectRuntime.v1) {
                 // WEBSITE_RUN_FROM_PACKAGE has several benefits, so make that the default
                 // https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -86,9 +86,11 @@ export class FunctionAppProvider implements IChildProvider {
             createOptions.runtime = 'python';
         } else {
             createOptions.os = 'windows';
-            // WEBSITE_RUN_FROM_PACKAGE has several benefits, so make that the default
-            // https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
-            functionAppSettings.WEBSITE_RUN_FROM_PACKAGE = '1';
+            if (language !== ProjectLanguage.CSharpScript || runtime !== ProjectRuntime.v1) {
+                // WEBSITE_RUN_FROM_PACKAGE has several benefits, so make that the default
+                // https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
+                functionAppSettings.WEBSITE_RUN_FROM_PACKAGE = '1';
+            }
         }
 
         const site: Site = await createFunctionApp(actionContext, parent, createOptions, showCreatingNode);


### PR DESCRIPTION
Fixes #684 

Just check if the project is NOT and the runtime is NOT v1.  If it is, then we set `WEBSITE_RUN_FROM_PACKAGE`.  Otherwise, don't.