### PR TITLE
Exclude obj and bin folders when creating a non C# project

### DIFF
--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -11,6 +11,7 @@ import { promptForProjectRuntime } from "../../ProjectSettings";
 export abstract class ProjectCreatorBase {
     public deploySubpath: string = '';
     public preDeployTask: string = '';
+    public excludedFiles: string | string[] = '';
     public abstract templateFilter: TemplateFilter;
 
     protected readonly functionAppPath: string;

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -16,6 +16,9 @@ export const funcNodeDebugEnvVar: string = 'languageWorkers:node:arguments';
 export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
     public readonly deploySubpath: string = '.';
+    // "func extensions install" task creates C# build artifacts that should be hidden
+    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
+    public readonly excludedFiles: string | string[] = ['obj', 'bin'];
 
     public readonly functionsWorkerRuntime: string | undefined = 'node';
 

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -34,6 +34,10 @@ const minPythonVersionLabel: string = '3.6.x'; // Use invalid semver as the labe
 export class PythonProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
     public preDeployTask: string = funcPackId;
+    // "func extensions install" task creates C# build artifacts that should be hidden
+    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
+    public readonly excludedFiles: string | string[] = ['obj', 'bin'];
+
     public getLaunchJson(): {} {
         return {
             version: '0.2.0',

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -5,7 +5,6 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { Uri, workspace, WorkspaceConfiguration } from 'vscode';
 import { IActionContext, TelemetryProperties } from 'vscode-azureextensionui';
 import { deploySubpathSetting, extensionPrefix, filesExcludeSetting, gitignoreFileName, preDeployTaskSetting, projectLanguageSetting, projectRuntimeSetting, templateFilterSetting } from '../../constants';
 import { ext } from '../../extensionVariables';
@@ -100,7 +99,7 @@ async function writeVSCodeSettings(projectCreator: ProjectCreatorBase, vscodePat
             }
 
             if (projectCreator.excludedFiles) {
-                data[filesExcludeSetting] = addToFilesExcludeSetting(projectCreator.excludedFiles, vscodePath);
+                data[filesExcludeSetting] = addToFilesExcludeSetting(projectCreator.excludedFiles, data);
             }
 
             // We want the terminal to be open after F5, not the debug console (Since http triggers are printed in the terminal)
@@ -129,12 +128,9 @@ async function writeExtensionRecommendations(projectCreator: ProjectCreatorBase,
     );
 }
 
-function addToFilesExcludeSetting(filesToExclude: string | string[], fsPath: string): { [key: string]: boolean } {
-    const exclude: string = 'exclude';
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration('files', Uri.file(fsPath));
-    const allExcludedFiles: { key: string; workspaceValue?: {} } | undefined = projectConfiguration.inspect(exclude);
-    const workspaceExcludedFiles: { [key: string]: boolean } = allExcludedFiles && allExcludedFiles.workspaceValue ? allExcludedFiles.workspaceValue : {};
-
+function addToFilesExcludeSetting(filesToExclude: string | string[], data: {}): { [key: string]: boolean } {
+    // tslint:disable-next-line:no-unsafe-any
+    const workspaceExcludedFiles: { [key: string]: boolean } = data[filesExcludeSetting] ? data[filesExcludeSetting] : {};
     // if multiple directories were passed in, iterate over and include to files.exclude
     if (Array.isArray(filesToExclude)) {
         for (const file of filesToExclude) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const templateFilterSetting: string = 'templateFilter';
 export const deploySubpathSetting: string = 'deploySubpath';
 export const templateVersionSetting: string = 'templateVersion';
 export const preDeployTaskSetting: string = 'preDeployTask';
+export const filesExcludeSetting: string = 'files.exclude';
 
 export enum ProjectLanguage {
     Bash = 'Bash',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,11 +68,3 @@ export enum ScmType {
 export const publishTaskId: string = 'publish';
 export const installExtensionsId: string = 'installExtensions';
 export const funcPackId: string = 'funcPack';
-
-export enum DefaultFilesExcluded {
-    DS_Store = '**/.DS_Store',
-    Git = '**/.git',
-    Hg = '**/.hg',
-    Svn = '**/.svn',
-    CVS = '**/CVS'
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,3 +68,11 @@ export enum ScmType {
 export const publishTaskId: string = 'publish';
 export const installExtensionsId: string = 'installExtensions';
 export const funcPackId: string = 'funcPack';
+
+export enum DefaultFilesExcluded {
+    DS_Store = '**/.DS_Store',
+    Git = '**/.git',
+    Hg = '**/.hg',
+    Svn = '**/.svn',
+    CVS = '**/CVS'
+}


### PR DESCRIPTION
Fixes #658 

This is a temporary solution since ultimatey the func cli shouldn't have a dependency on dotnet.

If somebody knows how to ONLY get the workspace settings, please let me know.  Every time I get the projectConfiguration settings, it pulls down the default settings along with them (which includes all the constants that I defined).  I don't think there is any "harm" in just writing them in the workspace settings, but it looks messy.  That being said, it is safer to do that because it definitely will not alter any of the user's settings (in case they enabled `**/.git` to be included in their workspace settings, though this is a new project so that technically shouldn't happen).