### PR TITLE
Actually use createTelemetryReporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -726,7 +726,6 @@
         "vscode-azureappservice": "^0.23.0",
         "vscode-azureextensionui": "^0.18.1",
         "vscode-azurekudu": "^0.1.8",
-        "vscode-extension-telemetry": "^0.0.22",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25",
         "xml2js": "^0.4.19",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,7 @@
 import * as vscode from 'vscode';
 import { WorkspaceFoldersChangeEvent } from 'vscode';
 import { AppSettingsTreeItem, AppSettingTreeItem, registerAppServiceExtensionVariables } from 'vscode-azureappservice';
-import { AzureParentTreeItem, AzureTreeDataProvider, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables } from 'vscode-azureextensionui';
-import TelemetryReporter from 'vscode-extension-telemetry';
+import { AzureParentTreeItem, AzureTreeDataProvider, AzureTreeItem, AzureUserInput, callWithTelemetryAndErrorHandling, createTelemetryReporter, IActionContext, registerCommand, registerEvent, registerUIExtensionVariables } from 'vscode-azureextensionui';
 import { decryptLocalSettings } from './commands/appSettings/decryptLocalSettings';
 import { downloadAppSettings } from './commands/appSettings/downloadAppSettings';
 import { encryptLocalSettings } from './commands/appSettings/encryptLocalSettings';
@@ -49,14 +48,7 @@ export function activate(context: vscode.ExtensionContext): void {
     registerUIExtensionVariables(ext);
     registerAppServiceExtensionVariables(ext);
     ext.context = context;
-
-    try {
-        const packageInfo: IPackageInfo = (<(id: string) => IPackageInfo>require)(context.asAbsolutePath('./package.json'));
-        ext.reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
-    } catch (error) {
-        // swallow exceptions so that telemetry doesn't affect user
-    }
-
+    ext.reporter = createTelemetryReporter(context);
     ext.outputChannel = vscode.window.createOutputChannel('Azure Functions');
     context.subscriptions.push(ext.outputChannel);
 
@@ -128,10 +120,4 @@ export function activate(context: vscode.ExtensionContext): void {
 
 // tslint:disable-next-line:no-empty
 export function deactivate(): void {
-}
-
-interface IPackageInfo {
-    name: string;
-    version: string;
-    aiKey: string;
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, OutputChannel } from "vscode";
-import { AzureTreeDataProvider, IAzureUserInput } from "vscode-azureextensionui";
-import TelemetryReporter from "vscode-extension-telemetry";
+import { AzureTreeDataProvider, IAzureUserInput, ITelemetryReporter } from "vscode-azureextensionui";
 import { FunctionTemplates } from "./templates/FunctionTemplates";
 
 /**
@@ -17,5 +16,5 @@ export namespace ext {
     export let outputChannel: OutputChannel;
     export let ui: IAzureUserInput;
     export let functionTemplates: FunctionTemplates;
-    export let reporter: TelemetryReporter;
+    export let reporter: ITelemetryReporter;
 }


### PR DESCRIPTION
I already did some of the DEBUGTELEMETRY stuff in this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/663, but missed calling createTelemetryReporter, which actually sets up the DebugReporter. Also by using createTelemetryReporter that means I don't have to reference the `vscode-extension-telemetry` directly and can just rely on whatever version the UI package uses.