### PR TITLE
Use double underscore instead of colon for languageWorkers env var

### DIFF
--- a/docs/debugConfig.md
+++ b/docs/debugConfig.md
@@ -2,7 +2,7 @@
 
 The debug configuration for v2 of the Azure Functions runtime [has changed](https://github.com/Azure/azure-functions-core-tools/issues/521) and old configurations will likely fail with the error "Cannot connect to runtime process, timeout after 10000 ms". You will automatically be prompted to update your configuration when you open a project. However, you can manually update your project with one of the following options:
 
-The first option is to add `languageWorkers:node:arguments` to your `runFunctionsHost` task in `.vscode\tasks.json` as seen below:
+The first option is to add `languageWorkers__node__arguments` to your `runFunctionsHost` task in `.vscode\tasks.json` as seen below:
 
 ```json
 {
@@ -15,7 +15,7 @@ The first option is to add `languageWorkers:node:arguments` to your `runFunction
       "command": "func host start",
       "options": {
         "env": {
-          "languageWorkers:node:arguments": "--inspect=5858"
+          "languageWorkers__node__arguments": "--inspect=5858"
         }
       },
       "isBackground": true,

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -11,7 +11,7 @@ import { ITaskOptions } from "./ITasksJson";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export const funcNodeDebugArgs: string = '--inspect=5858';
-export const funcNodeDebugEnvVar: string = 'languageWorkers:node:arguments';
+export const funcNodeDebugEnvVar: string = 'languageWorkers__node__arguments';
 
 export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -113,8 +113,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                     },
                     options: {
                         env: {
-                            // tslint:disable-next-line:no-invalid-template-strings
-                            'languageWorkers:python:arguments': '-m ptvsd --server --port 9091 --file'
+                            languageWorkers__python__arguments: '-m ptvsd --server --port 9091 --file'
                         }
                     },
                     problemMatcher: funcWatchProblemMatcher

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -97,7 +97,8 @@ async function verifyDebugConfigIsValid(projectLanguage: string | undefined, fol
             const tasksJsonPath: string = path.join(folderPath, vscodeFolderName, tasksFileName);
             const rawTasksData: string = (await fse.readFile(tasksJsonPath)).toString();
 
-            if (!rawTasksData.includes(funcNodeDebugEnvVar)) {
+            const oldFuncNodeDebugEnvVar: string = funcNodeDebugEnvVar.replace(/__/g, ':'); // Also check against an old version of the env var that works in most (but not all) cases
+            if (!rawTasksData.includes(funcNodeDebugEnvVar) && !rawTasksData.includes(oldFuncNodeDebugEnvVar)) {
                 const tasksContent: ITasksJson = <ITasksJson>JSON.parse(rawTasksData);
 
                 const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => funcHostNameRegEx.test(t.label));


### PR DESCRIPTION
A colon has worked on all OS's for me, but I must've just gotten lucky. According to [these docs](https://docs.microsoft.com/aspnet/core/fundamentals/configuration/?view=aspnetcore-2.1#conventions):
> In environment variables, a colon separator may not work on all platforms. A double underscore (__) is supported by all platforms and is converted to a colon.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/704