### PR TITLE
Pass along runtime from createNewProject api

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -31,7 +31,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
 
     private _hasDetectedRuntime: boolean = false;
 
-    public async addNonVSCodeFiles(): Promise<void> {
+    public async addNonVSCodeFiles(runtime: ProjectRuntime | undefined): Promise<void> {
         await dotnetUtils.validateDotnetInstalled();
 
         const projectName: string = path.basename(this.functionAppPath);
@@ -39,7 +39,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
         await this.confirmOverwriteExisting(this.functionAppPath, csProjName);
 
         // tslint:disable-next-line:strict-boolean-expressions
-        this._runtime = await tryGetLocalRuntimeVersion() || await promptForProjectRuntime();
+        this._runtime = runtime || await tryGetLocalRuntimeVersion() || await promptForProjectRuntime();
         const identity: string = `Microsoft.AzureFunctions.ProjectTemplate.CSharp.${this._runtime === ProjectRuntime.v1 ? '1' : '2'}.x`;
         const functionsVersion: string = this._runtime === ProjectRuntime.v1 ? 'v1' : 'v2';
         await executeDotnetTemplateCommand(this._runtime, this.functionAppPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -35,7 +35,7 @@ export abstract class ProjectCreatorBase {
     /**
      * Add all project files not included in the '.vscode' folder
      */
-    public abstract addNonVSCodeFiles(): Promise<void>;
+    public abstract addNonVSCodeFiles(runtime: ProjectRuntime | undefined): Promise<void>;
     public abstract getTasksJson(runtime: string): {} | Promise<{}>;
     public getRecommendedExtensions(): string[] {
         return ['ms-azuretools.vscode-azurefunctions'];

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -10,7 +10,7 @@ import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../c
 import { ext } from '../../extensionVariables';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
-import { getFuncExtensionSetting, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
+import { convertStringToRuntime, getFuncExtensionSetting, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
 import { gitUtils } from '../../utils/gitUtils';
 import * as workspaceUtil from '../../utils/workspace';
 import { createFunction } from '../createFunction/createFunction';
@@ -66,7 +66,7 @@ export async function createNewProject(
         language = language!;
 
         const projectCreator: ProjectCreatorBase = getProjectCreator(language, functionAppPath, actionContext);
-        await projectCreator.addNonVSCodeFiles();
+        await projectCreator.addNonVSCodeFiles(convertStringToRuntime(runtime));
 
         await initProjectForVSCode(actionContext, functionAppPath, language, runtime, projectCreator);
         if (await gitUtils.isGitInstalled(functionAppPath) && !await gitUtils.isInsideRepo(functionAppPath)) {


### PR DESCRIPTION
Fixes #665 (reported by IoT team where we weren't respecting the runtime they passed in)

I already have a test to cover this scenario [here](https://github.com/Microsoft/vscode-azurefunctions/blob/master/test/createNewProject.test.ts#L137), but unfortunately the bug only repros on Windows and Travis CI only runs on Linux. Not sure I care enough at the moment to set up windows on Travis CI.