### PR TITLE
Fix refreshLabel due to new tree

### DIFF
--- a/src/tree/FunctionAppTreeItem.ts
+++ b/src/tree/FunctionAppTreeItem.ts
@@ -69,7 +69,7 @@ export class FunctionAppTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         return false;
     }
 
-    public async refreshLabel(): Promise<void> {
+    public async refreshLabelImpl(): Promise<void> {
         try {
             this._state = await this.root.client.getState();
         } catch {


### PR DESCRIPTION
Realized I forgot to change this when working on Cosmos DB.

As a reminder: the new tree suffixes methods with "Impl" if that method should be implemented, but not called directly (other than by the base class).