### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Microsoft/vscodeazuretools

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,3 +10,4 @@ package-lock.json
 tsconfig.json
 tslint.json
 tools/**
+.github/**


### PR DESCRIPTION
Theoretically vscodeazuretools will be added automatically to every PR going forward and we won't have to add it manually. Tried with a PR in a test Repo and Andrii seemed to be added automatically: https://github.com/EricJizbaMSFT/functest/pull/5

https://help.github.com/articles/about-codeowners/
> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin or owner permissions has enabled required reviews, they also can optionally require approval from a code owner before the author can merge a pull request in the repository.