### PR TITLE
Add test for createFunctionApp API

### DIFF
--- a/package.json
+++ b/package.json
@@ -724,7 +724,7 @@
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
         "vscode-azureappservice": "^0.23.0",
-        "vscode-azureextensionui": "^0.18.1",
+        "vscode-azureextensionui": "^0.18.3",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^2.0.2",
         "websocket": "^1.0.25",

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -76,6 +76,7 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
         );
     });
 
+    // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-local-function
     test('createFunction API', async () => {
         // Intentionally testing IoTHub trigger since a partner team plans to use that
         const templateId: string = 'Azure.Function.CSharp.IotHubTrigger.2.x';

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -51,6 +51,7 @@ suite('Create C# Script Function Tests', async () => {
     const iotFunctionName: string = 'createFunctionApi';
     const iotFunctionSettings: {} = { connection: 'test_EVENTHUB', path: 'sample-workitems', consumerGroup: '$Default' };
 
+    // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-local-function
     test('createFunction API', async () => {
         // Intentionally testing IoTHub trigger since a partner team plans to use that
 

--- a/test/createFunction/createFunction.JavaScript.test.ts
+++ b/test/createFunction/createFunction.JavaScript.test.ts
@@ -139,6 +139,7 @@ suite('Create JavaScript Function Tests', async function (this: ISuiteCallbackCo
         );
     });
 
+    // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-local-function
     test('createFunction API', async () => {
         const templateId: string = 'HttpTrigger-JavaScript';
         const functionName: string = 'createFunctionApi';

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -128,12 +128,14 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         await validateVSCodeProjectFiles(projectPath, false);
     });
 
+    // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-new-project
     test('createNewProject API', async () => {
         const projectPath: string = path.join(testFolderPath, 'createNewProjectApi');
         await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', '~1', false /* openFolder */);
         await validateVSCodeProjectFiles(projectPath);
     });
 
+    // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-new-project
     test('createNewProject API C#', async function (this: IHookCallbackContext): Promise<void> {
         if (!longRunningTestsEnabled) {
             this.skip();

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tslint.json",
+    "rules": {
+        "no-console": false
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,292 +1,48 @@
 {
+    "extends": "tslint-microsoft-contrib",
     "rules": {
-        "insecure-random": true,
-        "no-banned-terms": true,
-        "no-cookies": true,
-        "no-delete-expression": true,
-        "no-disable-auto-sanitization": true,
-        "no-document-domain": true,
-        "no-document-write": true,
-        "no-eval": true,
-        "no-exec-script": true,
-        "no-function-constructor-with-string-args": true,
-        "no-http-string": [
-            true,
-            "http://www.example.com/?.*",
-            "http://www.examples.com/?.*"
-        ],
-        "no-inner-html": true,
-        "no-octal-literal": true,
-        "no-reserved-keywords": true,
-        "no-string-based-set-immediate": true,
-        "no-string-based-set-interval": true,
-        "no-string-based-set-timeout": true,
-        "non-literal-require": true,
-        "possible-timing-attack": true,
-        "react-anchor-blank-noopener": true,
-        "react-iframe-missing-sandbox": true,
-        "react-no-dangerous-html": true,
         "await-promise": [
             true,
-            "Thenable" // changed
+            "Thenable"
         ],
-        "forin": true,
-        "jquery-deferred-must-complete": true,
-        "label-position": true,
-        "match-default-export-name": true,
-        "mocha-avoid-only": true,
-        "mocha-no-side-effect-code": true,
-        "no-any": true,
-        "no-arg": true,
-        "no-backbone-get-set-outside-model": false, // changed
-        "no-bitwise": true,
-        "no-conditional-assignment": true,
-        "no-console": [
-            true,
-            "debug",
-            "info",
-            "log",
-            "time",
-            "timeEnd",
-            "trace"
-        ],
-        "no-constant-condition": true,
-        "no-control-regex": true,
-        "no-debugger": true,
-        "no-duplicate-case": true,
-        "no-duplicate-super": true,
-        "no-duplicate-variable": true,
-        "no-empty": true,
-        "no-floating-promises": true,
-        "no-for-in-array": true,
-        "no-import-side-effect": true,
-        "no-increment-decrement": true,
-        "no-invalid-regexp": true,
-        "no-invalid-template-strings": true,
-        "no-invalid-this": true,
-        "no-jquery-raw-elements": true,
-        "no-misused-new": true,
-        "no-non-null-assertion": true,
-        "no-reference-import": true,
-        "no-regex-spaces": true,
-        "no-sparse-arrays": true,
-        "no-stateless-class": true,
-        "no-string-literal": true,
-        "no-string-throw": true,
-        "no-unnecessary-bind": true,
-        "no-unnecessary-callback-wrapper": true,
-        "no-unnecessary-initializer": true,
-        "no-unnecessary-override": true,
-        "no-unsafe-any": true,
-        "no-unsafe-finally": true,
-        "no-unused-expression": true,
-        "no-use-before-declare": true,
-        "no-with-statement": true,
-        "promise-function-async": true,
-        "promise-must-complete": true,
-        "radix": false, // changed
-        "react-this-binding-issue": true,
-        "react-unused-props-and-state": true,
-        "restrict-plus-operands": true,
+        "no-backbone-get-set-outside-model": false,
+        "radix": false,
         "strict-boolean-expressions": [
             true,
-            "allow-string", // changed
-            "allow-undefined-union", // changed
-            "allow-mix", // changed,
-            "allow-null-union" // changed
+            "allow-string",
+            "allow-undefined-union",
+            "allow-mix",
+            "allow-null-union"
         ],
-        "switch-default": true,
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "use-isnan": true,
-        "use-named-parameter": true,
-        "valid-typeof": true,
-        "adjacent-overload-signatures": true,
-        "array-type": [
-            true,
-            "array"
-        ],
-        "arrow-parens": false,
-        "callable-types": true,
-        "chai-prefer-contains-to-index-of": true,
-        "chai-vague-errors": true,
-        "class-name": true,
-        "comment-format": true,
         "completed-docs": [
-            false, // changed
+            false,
             "classes"
         ],
-        "export-name": true,
-        "function-name": true,
-        "import-name": false, // changed
-        "interface-name": true,
-        "jsdoc-format": true,
-        "max-classes-per-file": [
-            true,
-            3
-        ],
-        "max-file-line-count": true,
-        "max-func-body-length": [
-            true,
-            100,
-            {
-                "ignore-parameters-to-function-regex": "describe"
-            }
-        ],
+        "import-name": false,
         "max-line-length": [
-            false, // changed
+            false,
             140
         ],
-        "member-access": true,
-        "member-ordering": [
-            true,
-            {
-                "order": "fields-first"
-            }
-        ],
-        "missing-jsdoc": false, // changed
-        "mocha-unneeded-done": true,
-        "new-parens": true,
-        "no-construct": true,
-        "no-default-export": true,
-        "no-empty-interface": true,
-        "no-for-in": true,
-        "no-function-expression": true,
-        "no-inferrable-types": false,
-        "no-multiline-string": true,
-        "no-null-keyword": false,
-        "no-parameter-properties": true,
-        "no-relative-imports": false, // changed
-        "no-require-imports": true,
-        "no-shadowed-variable": true,
-        "no-suspicious-comment": true,
-        "no-typeof-undefined": true,
-        "no-unnecessary-field-initialization": true,
-        "no-unnecessary-local-variable": true,
-        "no-unnecessary-qualifier": true,
-        "no-unsupported-browser-code": true,
-        "no-useless-files": true,
-        "no-var-keyword": true,
-        "no-var-requires": true,
-        "no-var-self": true,
+        "missing-jsdoc": false,
+        "no-relative-imports": false,
         "no-void-expression": [
             true,
-            "ignore-arrow-function-shorthand" // changed
+            "ignore-arrow-function-shorthand"
         ],
-        "object-literal-sort-keys": false,
-        "one-variable-per-declaration": true,
-        "only-arrow-functions": false,
-        "ordered-imports": true,
-        "prefer-array-literal": true,
-        "prefer-const": true,
-        "prefer-for-of": true,
-        "prefer-method-signature": true,
-        "prefer-template": true,
-        "return-undefined": false,
-        "typedef": [
-            true,
-            "call-signature",
-            "arrow-call-signature",
-            "parameter",
-            "arrow-parameter",
-            "property-declaration",
-            "variable-declaration",
-            "member-variable-declaration"
-        ],
-        "underscore-consistent-invocation": true,
-        "unified-signatures": true,
-        "variable-name": [ // changed
+        "variable-name": [
             true,
             "ban-keywords",
             "check-format",
             "allow-leading-underscore"
         ],
-        "react-a11y-anchors": true,
-        "react-a11y-aria-unsupported-elements": true,
-        "react-a11y-event-has-role": true,
-        "react-a11y-image-button-has-alt": true,
-        "react-a11y-img-has-alt": true,
-        "react-a11y-lang": true,
-        "react-a11y-meta": true,
-        "react-a11y-props": true,
-        "react-a11y-proptypes": true,
-        "react-a11y-role": true,
-        "react-a11y-role-has-required-aria-props": true,
-        "react-a11y-role-supports-aria-props": true,
-        "react-a11y-tabindex-no-positive": true,
-        "react-a11y-titles": true,
-        "align": [
-            true,
-            "parameters",
-            "arguments",
-            "statements"
-        ],
-        "curly": true,
-        "eofline": true,
-        "import-spacing": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "linebreak-style": false, // changed
-        "newline-before-return": false, // changed
-        "no-consecutive-blank-lines": true,
-        "no-empty-line-after-opening-brace": false,
-        "no-single-line-block-comment": false, // changed
-        "no-trailing-whitespace": true,
-        "no-unnecessary-semicolons": true,
-        "object-literal-key-quotes": [
-            true,
-            "as-needed"
-        ],
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-catch",
-            "check-else",
-            "check-whitespace"
-        ],
+        "linebreak-style": false,
+        "newline-before-return": false,
+        "no-single-line-block-comment": false,
         "quotemark": [
-            false, // changed
+            false,
             "single"
         ],
-        "react-tsx-curly-spacing": true,
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "trailing-comma": [
-            true,
-            {
-                "singleline": "never",
-                "multiline": "never"
-            }
-        ],
-        "typedef-whitespace": false,
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ],
-        "ban": false,
-        "ban-types": true,
-        "cyclomatic-complexity": true,
-        "file-header": false,
-        "import-blacklist": false,
-        "interface-over-type-literal": false,
-        "no-angle-bracket-type-assertion": false,
-        "no-inferred-empty-object-type": false,
-        "no-internal-module": false,
-        "no-magic-numbers": false,
-        "no-mergeable-namespace": false,
-        "no-namespace": false,
-        "no-reference": true,
-        "no-unexternalized-strings": [ // changed
+        "no-unexternalized-strings": [
             true,
             {
                 "signatures": [
@@ -296,17 +52,6 @@
                 "keyIndex": 0,
                 "messageIndex": 1
             }
-        ],
-        "object-literal-shorthand": false,
-        "prefer-type-cast": true,
-        "space-before-function-paren": false,
-        "missing-optional-annotation": false,
-        "no-duplicate-parameter-names": false,
-        "no-empty-interfaces": false,
-        "no-missing-visibility-modifiers": false,
-        "no-multiple-var-decl": false,
-        "no-switch-case-fall-through": false,
-        "typeof-compare": false
-    },
-    "rulesDirectory": "node_modules/tslint-microsoft-contrib/"
+        ]
+    }
 }


### PR DESCRIPTION
The IoT team is calling this api, so we need a test. And Nathan's TestAzureAccount makes it so easy!

Also I wanted to disable the "no-console" rule for the entire test folder (but not other folders) so I explored the "extends" attribute in tslint.json. It actually cleans stuff up quite a bit since we only have to specify rules we changed.

Depends on https://github.com/Microsoft/vscode-azuretools/pull/285