### PR TITLE
Handle existing python virtual environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -672,6 +672,11 @@
                         "type": "boolean",
                         "description": "%azFunc.enablePythonDescription%",
                         "default": false
+                    },
+                    "azureFunctions.pythonVenv": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%azFunc.pythonVenvDescription%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,5 +52,6 @@
     "azFunc.projectRuntime.v2Description": "Azure Functions v2 (.NET Standard)",
     "azFunc.projectRuntime.betaDescription": "DEPRECATED Use \"~2\" instead.",
     "azFunc.projectLanguage.previewDescription": "(Preview)",
-    "azFunc.enablePythonDescription": "Enable Python support when creating new projects. Local support is in preview and deploying to Azure is in private preview."
+    "azFunc.enablePythonDescription": "Enable Python support when creating new projects. Local support is in preview and deploying to Azure is in private preview.",
+    "azFunc.pythonVenvDescription": "The name of the Python virtual environment used for your project. A virtual environment is required to debug and deploy Python functions."
 }

--- a/src/commands/createNewProject/IProjectCreator.ts
+++ b/src/commands/createNewProject/IProjectCreator.ts
@@ -12,6 +12,7 @@ export abstract class ProjectCreatorBase {
     public deploySubpath: string = '';
     public preDeployTask: string = '';
     public excludedFiles: string | string[] = '';
+    public otherSettings: { [key: string]: string } = {};
     public abstract templateFilter: TemplateFilter;
 
     protected readonly functionAppPath: string;

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -149,7 +149,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
             let writeFile: boolean = false;
             let gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
 
-            function esnureInGitIgnore(newLine: string): void {
+            function ensureInGitIgnore(newLine: string): void {
                 if (!gitignoreContents.includes(newLine)) {
                     ext.outputChannel.appendLine(localize('gitAddNewLine', 'Adding "{0}" to .gitignore...', newLine));
                     gitignoreContents = gitignoreContents.concat(`${os.EOL}${newLine}`);
@@ -157,10 +157,10 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                 }
             }
 
-            esnureInGitIgnore(venvName);
-            esnureInGitIgnore('.python_packages');
-            esnureInGitIgnore('__pycache__');
-            esnureInGitIgnore(`${path.basename(this.functionAppPath)}.zip`);
+            ensureInGitIgnore(venvName);
+            ensureInGitIgnore('.python_packages');
+            ensureInGitIgnore('__pycache__');
+            ensureInGitIgnore(`${path.basename(this.functionAppPath)}.zip`);
 
             if (writeFile) {
                 await fse.writeFile(gitignorePath, gitignoreContents);

--- a/src/commands/createNewProject/initProjectForVSCode.ts
+++ b/src/commands/createNewProject/initProjectForVSCode.ts
@@ -102,6 +102,10 @@ async function writeVSCodeSettings(projectCreator: ProjectCreatorBase, vscodePat
                 data[filesExcludeSetting] = addToFilesExcludeSetting(projectCreator.excludedFiles, data);
             }
 
+            for (const key of Object.keys(projectCreator.otherSettings)) {
+                data[key] = projectCreator.otherSettings[key];
+            }
+
             // We want the terminal to be open after F5, not the debug console (Since http triggers are printed in the terminal)
             data['debug.internalConsoleOptions'] = 'neverOpen';
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/740

We still default to 'func_env' for new projects - but this improves the logic when detecting projects created from the func cli as described in the above issue. I introduced a `azureFunctions.pythonVenv` setting that is referenced directly from the "tasks.json" file.