### PR TITLE
Fix C# project creation logic to handle 'netcoreapp'

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -160,7 +160,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
         } else {
             const targetFramework: string = matches[1];
             this.telemetryProperties.cSharpTargetFramework = targetFramework;
-            if (targetFramework.startsWith('netstandard')) {
+            if (/net(standard|coreapp)/i.test(targetFramework)) {
                 this._runtime = ProjectRuntime.v2;
             } else {
                 this._runtime = ProjectRuntime.v1;

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -160,7 +160,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
         } else {
             const targetFramework: string = matches[1];
             this.telemetryProperties.cSharpTargetFramework = targetFramework;
-            if (/net(standard|coreapp)/i.test(targetFramework)) {
+            if (/net(standard|core)/i.test(targetFramework)) {
                 this._runtime = ProjectRuntime.v2;
             } else {
                 this._runtime = ProjectRuntime.v1;

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -66,7 +66,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         await validateVSCodeProjectFiles(projectPath);
         const projectName: string = path.basename(projectPath);
         assert.equal(await fse.pathExists(path.join(projectPath, `${projectName}.csproj`)), true, 'csproj does not exist');
-        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netstandard2.0/publish');
+        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netcoreapp2.1/publish');
     });
 
     const bashProject: string = 'BashProject';
@@ -150,7 +150,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         const projectPath: string = path.join(testFolderPath, 'createNewProjectApiCSharp');
         ext.ui = new TestUserInput([DialogResponses.skipForNow.title]);
         await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'C#', '~2', false /* openFolder */, templateId, functionName, { namespace: namespace, Path: iotPath, Connection: connection });
-        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netstandard2.0/publish');
+        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netcoreapp2.1/publish');
     });
 
     async function testCreateNewProject(projectPath: string, language: string, previewLanguage: boolean, ...inputs: (string | undefined)[]): Promise<void> {


### PR DESCRIPTION
Builds started failing over the weekend: https://travis-ci.org/Microsoft/vscode-azurefunctions/builds/444489354

Looks like C# projects used to default to 'netstandard2.0' and now they default to 'netcoreapp2.1'. I took a look at the list of possibilities: https://docs.microsoft.com/en-us/nuget/reference/target-frameworks and my new regex should handle the old value (netstandard) the new value (netcoreapp) and 'netcore' (not sure if that's actually possible, but it's fair to assume it would be ProjectRuntime.v2)

