### PR TITLE
"Add to workspace" with no folders opens in current window

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -143,12 +143,13 @@ export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionC
         }
 
         const uri: vscode.Uri = vscode.Uri.file(fsPath);
+
+        if (!openFolders.length && openBehavior === OpenBehavior.AddToWorkspace) {
+            openBehavior = OpenBehavior.OpenInCurrentWindow;
+        }
+
         if (openBehavior === OpenBehavior.AddToWorkspace) {
-            if (openFolders.length) {
-                vscode.workspace.updateWorkspaceFolders(openFolders.length, 0, { uri: uri });
-            } else {
-                await vscode.commands.executeCommand('vscode.openFolder', uri);
-            }
+            vscode.workspace.updateWorkspaceFolders(openFolders.length, 0, { uri: uri });
         } else {
             await vscode.commands.executeCommand('vscode.openFolder', uri, openBehavior === OpenBehavior.OpenInNewWindow /* forceNewWindow */);
             if (openBehavior === OpenBehavior.OpenInNewWindow) {


### PR DESCRIPTION
Fixes #752 

![image](https://user-images.githubusercontent.com/12476526/47947435-b920bc80-ded9-11e8-9a9d-12ccd5a419df.png)
Create new project -> language -> **add to workspace**

Now it opens the project folder in the current window instead of adding it as a workspace folder in an untitled workspace.

![image](https://user-images.githubusercontent.com/12476526/47947453-09981a00-deda-11e8-99fb-83b19c6cbeac.png)

`if (openFolders.length)` is what I used to check if no folders are open. Is this implicit coercion good practice? I didn't see any issues with using it since I think `openFolders` will always be an array based on its declaration:

```typescript
const openFolders: vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
```

Thanks!

