### PR TITLE
Refactor ProjectCreator code

### DIFF
--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -6,7 +6,7 @@
 import { TemplateFilter } from "../../constants";
 import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
-import { funcWatchProblemMatcher } from "./IProjectCreator";
+import { funcWatchProblemMatcher } from "./ProjectCreatorBase";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -6,8 +6,8 @@
 import { installExtensionsId, ProjectRuntime, TemplateFilter } from "../../constants";
 import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
-import { funcWatchProblemMatcher } from "./IProjectCreator";
 import { ITaskOptions } from "./ITasksJson";
+import { funcWatchProblemMatcher } from "./ProjectCreatorBase";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export const funcNodeDebugArgs: string = '--inspect=5858';
@@ -37,7 +37,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
         };
     }
 
-    public getTasksJson(runtime: string): {} {
+    public getTasksJson(): {} {
         let options: ITaskOptions | undefined;
         // tslint:disable-next-line:no-any
         const funcTask: any = {
@@ -63,7 +63,7 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
         // tslint:disable-next-line:no-unsafe-any
         const tasks: {}[] = [funcTask];
 
-        if (runtime !== ProjectRuntime.v1) {
+        if (this.runtime !== ProjectRuntime.v1) {
             options = {};
             options.env = {};
             options.env[funcNodeDebugEnvVar] = funcNodeDebugArgs;

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -9,7 +9,7 @@ import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime,
 import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { ILocalAppSettings } from '../../LocalAppSettings';
 import { confirmOverwriteFile, writeFormattedJson } from "../../utils/fs";
-import { funcWatchProblemMatcher, ProjectCreatorBase } from './IProjectCreator';
+import { funcWatchProblemMatcher, ProjectCreatorBase } from './ProjectCreatorBase';
 
 // tslint:disable-next-line:no-multiline-string
 const gitignore: string = `bin
@@ -46,7 +46,7 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.All;
     public readonly functionsWorkerRuntime: string | undefined;
 
-    public getTasksJson(_runtime: string): {} {
+    public getTasksJson(): {} {
         return {
             version: '2.0.0',
             tasks: [
@@ -64,7 +64,7 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
         };
     }
 
-    public async addNonVSCodeFiles(): Promise<void> {
+    public async onCreateNewProject(): Promise<void> {
         const hostJsonPath: string = path.join(this.functionAppPath, hostFileName);
         if (await confirmOverwriteFile(hostJsonPath)) {
             const hostJson: {} = {
@@ -104,5 +104,9 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
         if (await confirmOverwriteFile(gitignorePath)) {
             await fse.writeFile(gitignorePath, gitignore);
         }
+    }
+
+    public async onInitProjectForVSCode(): Promise<void> {
+        // nothing to do here
     }
 }

--- a/test/functionTemplates.test.ts
+++ b/test/functionTemplates.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { JavaProjectCreator } from '../src/commands/createNewProject/JavaProjectCreator';
 import { ProjectLanguage, ProjectRuntime, TemplateFilter } from '../src/constants';
 import { FunctionTemplates } from '../src/templates/FunctionTemplates';
 import { IFunctionTemplate } from '../src/templates/IFunctionTemplate';
@@ -25,7 +24,7 @@ async function validateTemplateCounts(templates: FunctionTemplates, source: stri
     const jsTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.JavaScript, ProjectRuntime.v2, TemplateFilter.Verified);
     assert.equal(jsTemplatesv2.length, 7, `Unexpected JavaScript v2 ${source} templates count.`);
 
-    const javaTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Java, JavaProjectCreator.defaultRuntime, TemplateFilter.Verified);
+    const javaTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Java, ProjectRuntime.v2, TemplateFilter.Verified);
     assert.equal(javaTemplates.length, 4, `Unexpected Java ${source} templates count.`);
 
     const cSharpTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v1, TemplateFilter.Verified);


### PR DESCRIPTION
Should be no functional change with this PR. Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/251 and addresses this 'TODO' from `PythonProjectCreator.ts`:
```
// The code in getTasksJson occurs for createNewProject _and_ initProjectForVSCode, which is why the next few lines are here even if they're only somewhat related to 'getting the tasks.json'
// We should probably refactor this eventually to make it more clear what's going on.
```

There's two main scenarios that use the 'ProjectCreator' and I added two methods (`onCreateNewProject` and `onInitProjectForVSCode`) to hopefully make it clear what code is executed for each:
1. Create new project (pretty self-explanatory)
1. Init project for use with VS Code. That's this dialog:
![screen shot 2018-11-05 at 11 24 03 am](https://user-images.githubusercontent.com/11282622/48021383-5273ec80-e0ed-11e8-8827-ae59600ff617.png)