### PR TITLE
Improve python alias selection

### DIFF
--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -78,8 +78,8 @@ export async function selectTemplateFilter(projectPath: string, ui: IAzureUserIn
     return <TemplateFilter>result;
 }
 
-export function getGlobalFuncExtensionSetting<T>(key: string): T | undefined {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
+export function getGlobalFuncExtensionSetting<T>(key: string, prefix: string = extensionPrefix): T | undefined {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
     const result: { globalValue?: T } | undefined = projectConfiguration.inspect<T>(key);
     return result && result.globalValue;
 }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/753

~~Now users will always get a prompt like this~~:
![screen shot 2018-11-07 at 10 16 39 am](https://user-images.githubusercontent.com/11282622/48151490-44050c80-e276-11e8-8027-ef7bb6ad42f6.png)

~~Before they had no idea or control over which alias/version we used. This was especially problematic if we were defaulting to a 3.7 version of python which doesn't actually work with the func cli. (I still don't want to block them from using 3.7 because I don't like hard-coding a max version that could change in the future)~~

Edit: See updated comment with new experience