### PR TITLE
Add telemetry on whether func is installed

### DIFF
--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -10,6 +10,7 @@ import { InputBoxOptions, MessageItem, QuickPickItem, Uri, window, workspace } f
 import { DialogResponses, IActionContext, IAzureQuickPickItem, TelemetryProperties } from 'vscode-azureextensionui';
 import { localSettingsFileName, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TemplateFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { promptForAppSetting, validateAzureWebJobsStorage } from '../../LocalAppSettings';
 import { localize } from '../../localize';
 import { getProjectLanguage, getProjectRuntime, getTemplateFilter, promptForProjectLanguage, promptForProjectRuntime, selectTemplateFilter, updateWorkspaceSetting } from '../../ProjectSettings';
@@ -75,6 +76,7 @@ export async function createFunction(
     caseSensitiveFunctionSettings?: { [key: string]: string | undefined },
     language?: ProjectLanguage,
     runtime?: ProjectRuntime): Promise<void> {
+    addLocalFuncTelemetry(actionContext);
 
     const functionSettings: { [key: string]: string | undefined } = {};
     if (caseSensitiveFunctionSettings) {

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -8,6 +8,7 @@ import { ProgressLocation, QuickPickItem, QuickPickOptions, window } from 'vscod
 import { IActionContext } from 'vscode-azureextensionui';
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../constants';
 import { ext } from '../../extensionVariables';
+import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
 import { convertStringToRuntime, getFuncExtensionSetting, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
@@ -32,6 +33,7 @@ export async function createNewProject(
     templateId?: string,
     functionName?: string,
     caseSensitiveFunctionSettings?: { [key: string]: string | undefined }): Promise<void> {
+    addLocalFuncTelemetry(actionContext);
 
     if (functionAppPath === undefined) {
         functionAppPath = await workspaceUtil.selectWorkspaceFolder(ext.ui, localize('azFunc.selectFunctionAppFolderNew', 'Select the folder that will contain your function app'));

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -15,6 +15,7 @@ import { AzureTreeItem, DialogResponses, IActionContext, IAzureUserInput, Teleme
 import { deploySubpathSetting, extensionPrefix, funcPackId, installExtensionsId, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
 import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
+import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { localize } from '../localize';
 import { convertStringToRuntime, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, updateGlobalSetting } from '../ProjectSettings';
@@ -30,6 +31,8 @@ import { startStreamingLogs } from './logstream/startStreamingLogs';
 
 // tslint:disable-next-line:max-func-body-length
 export async function deploy(this: IActionContext, target?: vscode.Uri | string | SlotTreeItemBase, functionAppId?: string | {}): Promise<void> {
+    addLocalFuncTelemetry(this);
+
     const telemetryProperties: TelemetryProperties = this.properties;
     let deployFsPath: string;
     const newNodes: SlotTreeItemBase[] = [];

--- a/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
+++ b/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as semver from 'semver';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { cpUtils } from '../utils/cpUtils';
 
@@ -25,4 +26,16 @@ export async function getLocalFuncCoreToolsVersion(): Promise<string | null> {
         }
         return null;
     }
+}
+
+export function addLocalFuncTelemetry(actionContext: IActionContext): void {
+    actionContext.properties.funcCliVersion = 'unknown';
+
+    // tslint:disable-next-line:no-floating-promises
+    getLocalFuncCoreToolsVersion().then((version: string) => {
+        // tslint:disable-next-line:strict-boolean-expressions
+        actionContext.properties.funcCliVersion = version || 'none';
+    }).catch(() => {
+        actionContext.properties.funcCliVersion = 'none';
+    });
 }


### PR DESCRIPTION
There has been talk of taking a harder dependency on the func cli. One reason I don't want to do that is because I think there's a solid group of people that still create/deploy without having the func cli on their machine. This adds telemetry to validate that assumption.