### PR TITLE
Remove Python feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ See [here](https://github.com/Azure/azure-functions-core-tools/blob/master/READM
 ### Python
 
 * [Python 3.6.x](https://www.python.org/downloads/)
-* To enable project creation and debugging, set `azureFunctions.enablePython` to true. **IMPORTANT**: Python support in Azure is still in private preview.
 
 ## Managing Azure Subscriptions
 

--- a/package.json
+++ b/package.json
@@ -673,11 +673,6 @@
                         "type": "string",
                         "description": "%azFunc.preDeployTaskDescription%"
                     },
-                    "azureFunctions.enablePython": {
-                        "type": "boolean",
-                        "description": "%azFunc.enablePythonDescription%",
-                        "default": false
-                    },
                     "azureFunctions.pythonVenv": {
                         "scope": "resource",
                         "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,7 +52,6 @@
     "azFunc.projectRuntime.v2Description": "Azure Functions v2 (.NET Standard)",
     "azFunc.projectRuntime.betaDescription": "DEPRECATED Use \"~2\" instead.",
     "azFunc.projectLanguage.previewDescription": "(Preview)",
-    "azFunc.enablePythonDescription": "Enable Python support when creating new projects. Local support is in preview and deploying to Azure is in private preview.",
     "azFunc.pythonVenvDescription": "The name of the Python virtual environment used for your project. A virtual environment is required to debug and deploy Python functions.",
     "azFunc.enableSlotsDescription": "Enable preview support for slots."
 }

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -11,7 +11,7 @@ import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
-import { convertStringToRuntime, getFuncExtensionSetting, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
+import { convertStringToRuntime, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
 import { gitUtils } from '../../utils/gitUtils';
 import * as workspaceUtil from '../../utils/workspace';
 import { createFunction } from '../createFunction/createFunction';
@@ -44,16 +44,14 @@ export async function createNewProject(
         language = getGlobalFuncExtensionSetting(projectLanguageSetting);
 
         if (!language) {
+            const previewDescription: string = localize('previewDescription', '(Preview)');
             // Only display 'supported' languages that can be debugged in VS Code
             const languagePicks: QuickPickItem[] = [
                 { label: ProjectLanguage.JavaScript, description: '' },
                 { label: ProjectLanguage.CSharp, description: '' },
-                { label: ProjectLanguage.Java, description: '' }
+                { label: ProjectLanguage.Python, description: previewDescription },
+                { label: ProjectLanguage.Java, description: previewDescription }
             ];
-
-            if (getFuncExtensionSetting('enablePython')) {
-                languagePicks.push({ label: ProjectLanguage.Python, description: '(Preview)' });
-            }
 
             const options: QuickPickOptions = { placeHolder: localize('azFunc.selectFuncTemplate', 'Select a language for your function project') };
             language = (await ext.ui.showQuickPick(languagePicks, options)).label;


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/807

Also I'm not sure why Java didn't have "(Preview)" in it's description. It should since that's still in preview in Azure.