### PR TITLE
Clean up generated tasks.json

### DIFF
--- a/docs/debugConfig.md
+++ b/docs/debugConfig.md
@@ -9,8 +9,7 @@ The first option is to add `languageWorkers__node__arguments` to your `runFuncti
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Run Functions Host",
-      "identifier": "runFunctionsHost",
+      "label": "runFunctionsHost",
       "type": "shell",
       "command": "func host start",
       "options": {
@@ -19,27 +18,7 @@ The first option is to add `languageWorkers__node__arguments` to your `runFuncti
         }
       },
       "isBackground": true,
-      "presentation": {
-        "reveal": "always"
-      },
-      "problemMatcher": [
-        {
-          "owner": "azureFunctions",
-          "pattern": [
-            {
-              "regexp": "\\b\\B",
-              "file": 1,
-              "location": 2,
-              "message": 3
-            }
-          ],
-          "background": {
-            "activeOnStart": true,
-            "beginsPattern": "^.*Stopping host.*",
-            "endsPattern": "^.*Job host started.*"
-          }
-        }
-      ]
+      "problemMatcher": "$func-watch"
     }
   ]
 }
@@ -50,37 +29,16 @@ The second option requires two steps:
 1. Pass the `--language-worker` parameter to `func host start` in your `runFunctionsHost` task in `.vscode\tasks.json` as seen below:
     ```json
     {
-    "version": "2.0.0",
-    "tasks": [
+      "version": "2.0.0",
+      "tasks": [
         {
-        "label": "Run Functions Host",
-        "identifier": "runFunctionsHost",
-        "type": "shell",
-        "command": "func host start --language-worker -- \"--inspect=5858\"",
-        "isBackground": true,
-        "presentation": {
-            "reveal": "always"
-        },
-        "problemMatcher": [
-            {
-            "owner": "azureFunctions",
-            "pattern": [
-                {
-                "regexp": "\\b\\B",
-                "file": 1,
-                "location": 2,
-                "message": 3
-                }
-            ],
-            "background": {
-                "activeOnStart": true,
-                "beginsPattern": "^.*Stopping host.*",
-                "endsPattern": "^.*Job host started.*"
-            }
-            }
-        ]
+          "label": "runFunctionsHost",
+          "type": "shell",
+          "command": "func host start --language-worker -- \"--inspect=5858\"",
+          "isBackground": true,
+          "problemMatcher": "$func-watch"
         }
-    ]
+      ]
     }
     ```
 

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -50,9 +50,6 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     label: 'clean',
                     command: 'dotnet clean',
                     type: 'shell',
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: '$msCompile'
                 },
                 {
@@ -64,18 +61,12 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                         kind: 'build',
                         isDefault: true
                     },
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: '$msCompile'
                 },
                 {
                     label: 'clean release',
                     command: 'dotnet clean --configuration Release',
                     type: 'shell',
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: '$msCompile'
                 },
                 {
@@ -83,9 +74,6 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     command: 'dotnet publish --configuration Release',
                     type: 'shell',
                     dependsOn: 'clean release',
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: '$msCompile'
                 },
                 {
@@ -97,9 +85,6 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     },
                     command: funcHostCommand,
                     isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: funcWatchProblemMatcher
                 }
             ]

--- a/src/commands/createNewProject/CSharpScriptProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpScriptProjectCreator.ts
@@ -4,32 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { TemplateFilter } from "../../constants";
-import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
-import { funcWatchProblemMatcher } from "./ProjectCreatorBase";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class CSharpScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Core;
     public readonly deploySubpath: string = '.';
-
-    public getTasksJson(): {} {
-        return {
-            version: '2.0.0',
-            tasks: [
-                {
-                    label: funcHostTaskLabel,
-                    type: 'shell',
-                    command: funcHostCommand,
-                    isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
-                    problemMatcher: funcWatchProblemMatcher
-                }
-            ]
-        };
-    }
 
     public getLaunchJson(): {} {
         return {

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -129,9 +129,6 @@ export class JavaProjectCreator extends ProjectCreatorBase {
                     },
                     type: 'shell',
                     isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: funcWatchProblemMatcher
                 }
             ]

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -45,19 +45,13 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
             type: 'shell',
             command: funcHostCommand,
             isBackground: true,
-            presentation: {
-                reveal: 'always'
-            },
             problemMatcher: funcWatchProblemMatcher
         };
 
         const installExtensionsTask: {} = {
             label: installExtensionsId,
             command: 'func extensions install',
-            type: 'shell',
-            presentation: {
-                reveal: 'always'
-            }
+            type: 'shell'
         };
 
         // tslint:disable-next-line:no-unsafe-any

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -105,9 +105,6 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                         command: convertToVenvCommand(venvSettingReference, Platform.Linux, funcExtensionsCommand, pipInstallCommand, funcHostCommand)
                     },
                     isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
                     options: {
                         env: {
                             languageWorkers__python__arguments: '-m ptvsd --host 127.0.0.1 --port 9091'
@@ -127,10 +124,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
                     linux: {
                         command: convertToVenvCommand(venvSettingReference, Platform.Linux, funcPackCommand)
                     },
-                    isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    }
+                    isBackground: true
                 }
             ]
         };

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -57,9 +57,6 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
                     type: 'shell',
                     command: funcHostCommand,
                     isBackground: true,
-                    presentation: {
-                        reveal: 'always'
-                    },
                     problemMatcher: funcWatchProblemMatcher
                 }
             ]


### PR DESCRIPTION
There was some unnecessary code here. Specifically:
1. presentation.reveal already defaults to 'always'
1. CSharpScriptProjectCreator doesn't need to re-implement getTasksJson because it's the same as ScriptProjectCreatorBase
1. Update docs/debugConfig.md to reflect what the tasks should actually look like these days