### PR TITLE
Let people deploy even if pre-deploy task fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 All notable changes to the "azurefunctions" extension will be documented in this file.
 
+## 0.13.1 - 2018-12-17
+
+### Fixed
+
+- Provide option to "Deploy Anyway" if pre-deploy task fails
+- If "azureFunctions.preDeployTask" is not set, do not run any task
+
 ## 0.13.0 - 2018-12-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "0.13.1-alpha",
+    "version": "0.13.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%extension.description%",
-    "version": "0.13.1-alpha",
+    "version": "0.13.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,6 +50,7 @@ export const hostFileName: string = 'host.json';
 export const localSettingsFileName: string = 'local.settings.json';
 export const proxiesFileName: string = 'proxies.json';
 export const tasksFileName: string = 'tasks.json';
+export const settingsFileName: string = 'settings.json';
 export const vscodeFolderName: string = '.vscode';
 export const gitignoreFileName: string = '.gitignore';
 


### PR DESCRIPTION
Before we released 0.13.0, pre deploy tasks would silently fail. We added an error message, but that's blocking some people from deploying (enough for a patch release IMO and Matt agrees). Matt came up with the "Deploy Anyway" button (similar to how you can select "Debug Anyway" if you have build errors). Only 13% of people create triggers that need to run `func extensions install`, so it's unnecessary to block in most cases.

I also wanted to make it easier to remove a `preDeployTask`, so I got rid of the logic that was setting defaults. It will still warn the user, but now we respect if they set `preDeployTask` to nothing.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/852

Related https://github.com/Microsoft/vscode-azurefunctions/issues/859
Related https://github.com/Microsoft/vscode-azurefunctions/issues/862

![screen shot 2018-12-14 at 2 09 50 pm](https://user-images.githubusercontent.com/11282622/50032703-5e838180-ffaa-11e8-85cc-30bd771fb446.png)
