### PR TITLE
Allow advanced creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -765,6 +765,11 @@
                         "type": "boolean",
                         "description": "%azFunc.enableSlotsDescription%",
                         "default": false
+                    },
+                    "azureFunctions.advancedCreation": {
+                        "type": "boolean",
+                        "description": "%azFunc.advancedCreationDescription%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -59,5 +59,6 @@
     "azFunc.ConnectToGitHub": "Connect to GitHub Repository...",
     "azFunc.disconnectRepo": "Disconnect from Repo...",
     "azFunc.createSlot": "Create Slot...",
-    "azFunc.swapSlot": "Swap Slot..."
+    "azFunc.swapSlot": "Swap Slot...",
+    "azFunc.advancedCreationDescription": "Enables advanced creation of function apps, which bypasses several defaults and prompts instead."
 }

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -78,19 +78,32 @@ export class FunctionAppProvider extends SubscriptionTreeItem {
             createFunctionAppSettings: async (context: IAppSettingsContext): Promise<WebSiteManagementModels.NameValuePair[]> => await createFunctionAppSettings(context, runtime, language)
         };
 
-        // There are two things in preview right now:
-        // 1. Python support
-        // 2. Linux support
-        // Python only works on Linux, so we have to use Linux when creating a function app. For other languages, we will stick with Windows until Linux GA's
-        if (language === ProjectLanguage.Python) {
-            createOptions.os = 'linux';
-            createOptions.runtime = 'python';
-        } else {
-            createOptions.os = 'windows';
+        if (!getFuncExtensionSetting('advancedCreation')) {
+            setCreateOptionDefaults(createOptions, language);
         }
 
         const site: WebSiteManagementModels.Site = await createFunctionApp(actionContext, this.root, createOptions, showCreatingTreeItem);
         return new ProductionSlotTreeItem(this, new SiteClient(site, this.root), createOptions.os === 'linux' /* isLinuxPreview */);
+    }
+}
+
+function setCreateOptionDefaults(createOptions: IAppCreateOptions, language: string | undefined): void {
+    createOptions.os = 'windows';
+    switch (language) {
+        case ProjectLanguage.JavaScript:
+            createOptions.runtime = 'node';
+            break;
+        case ProjectLanguage.CSharp:
+            createOptions.runtime = 'dotnet';
+            break;
+        case ProjectLanguage.Java:
+            createOptions.runtime = 'java';
+            break;
+        case ProjectLanguage.Python:
+            createOptions.runtime = 'python';
+            createOptions.os = 'linux';
+            break;
+        default:
     }
 }
 


### PR DESCRIPTION
Based on the same behavior in app service repo. We were defaulting a few things (os and runtime) without giving user's the option to ever change it. Now they can be prompted for both if they want. More properties will likely be added later (allow premium plan instead of consumption plan, for example).

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/811

Related PR: https://github.com/Microsoft/vscode-azuretools/pull/365