### PR TITLE
Add to workspace with no folders open opens in current window

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -142,6 +142,10 @@ export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionC
             await updateGlobalSetting(projectOpenBehaviorSetting, openBehavior);
         }
 
+        if (openBehavior === OpenBehavior.AddToWorkspace && !openFolders.length) {
+            openBehavior = OpenBehavior.OpenInCurrentWindow;
+        }
+
         const uri: vscode.Uri = vscode.Uri.file(fsPath);
         if (openBehavior === OpenBehavior.AddToWorkspace) {
             vscode.workspace.updateWorkspaceFolders(openFolders.length, 0, { uri: uri });

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -142,7 +142,7 @@ export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionC
             await updateGlobalSetting(projectOpenBehaviorSetting, openBehavior);
         }
 
-        if (openBehavior === OpenBehavior.AddToWorkspace && 0 === openFolders.length) {
+        if (openBehavior === OpenBehavior.AddToWorkspace && openFolders.length === 0) {
             openBehavior = OpenBehavior.OpenInCurrentWindow;
         }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -142,7 +142,7 @@ export async function ensureFolderIsOpen(fsPath: string, actionContext: IActionC
             await updateGlobalSetting(projectOpenBehaviorSetting, openBehavior);
         }
 
-        if (openBehavior === OpenBehavior.AddToWorkspace && !openFolders.length) {
+        if (openBehavior === OpenBehavior.AddToWorkspace && 0 === openFolders.length) {
             openBehavior = OpenBehavior.OpenInCurrentWindow;
         }
 


### PR DESCRIPTION
Fixes #752 

![image](https://user-images.githubusercontent.com/12476526/47947435-b920bc80-ded9-11e8-9a9d-12ccd5a419df.png)
Create new project -> language -> **add to workspace**

Now it opens the project folder in the current window instead of adding it as a workspace folder in an untitled workspace.

![image](https://user-images.githubusercontent.com/12476526/47947453-09981a00-deda-11e8-99fb-83b19c6cbeac.png)
