### PR TITLE
Provide func tasks programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.24.0"
+        "vscode": "^1.30.0"
     },
     "repository": {
         "type": "git",
@@ -587,6 +587,19 @@
             {
                 "fileMatch": "/proxies.json",
                 "url": "http://json.schemastore.org/proxies"
+            }
+        ],
+        "taskDefinitions": [
+            {
+                "type": "func",
+                "required": [
+                    "command"
+                ],
+                "properties": {
+                    "command": {
+                        "type": "string"
+                    }
+                }
             }
         ],
         "problemPatterns": [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
         "onCommand:azureFunctions.swapSlot",
         "workspaceContains:local.settings.json",
         "workspaceContains:host.json",
-        "onView:azureFunctionsExplorer"
+        "onView:azureFunctionsExplorer",
+        "onDebugInitialConfigurations"
     ],
     "main": "./out/src/extension",
     "contributes": {

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -21,7 +21,7 @@ import { IScriptFunctionTemplate } from '../../templates/parseScriptTemplates';
 import { TemplateProvider } from '../../templates/TemplateProvider';
 import * as workspaceUtil from '../../utils/workspace';
 import { createNewProject } from '../createNewProject/createNewProject';
-import { isFunctionProject } from '../createNewProject/validateFunctionProjects';
+import { isFunctionProject } from '../createNewProject/isFunctionProject';
 import { CSharpFunctionCreator } from './CSharpFunctionCreator';
 import { FunctionCreatorBase } from './FunctionCreatorBase';
 import { JavaFunctionCreator } from './JavaFunctionCreator';

--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -10,16 +10,15 @@ import * as path from 'path';
 import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { DialogResponses, parseError } from 'vscode-azureextensionui';
-import { gitignoreFileName, hostFileName, isWindows, localSettingsFileName, ProjectRuntime, publishTaskId, TemplateFilter } from '../../constants';
+import { func, funcWatchProblemMatcher, gitignoreFileName, hostFileName, hostStartCommand, isWindows, localSettingsFileName, ProjectRuntime, publishTaskId, TemplateFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { funcHostCommand, funcHostTaskLabel } from '../../funcCoreTools/funcHostTask';
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from "../../localize";
 import { getFuncExtensionSetting, promptForProjectRuntime, updateGlobalSetting } from '../../ProjectSettings';
 import { executeDotnetTemplateCommand } from '../../templates/executeDotnetTemplateCommand';
 import { cpUtils } from '../../utils/cpUtils';
 import { dotnetUtils } from '../../utils/dotnetUtils';
-import { funcWatchProblemMatcher, ProjectCreatorBase } from './ProjectCreatorBase';
+import { ProjectCreatorBase } from './ProjectCreatorBase';
 
 export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
@@ -77,13 +76,12 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
-                    label: funcHostTaskLabel,
-                    type: 'shell',
+                    type: func,
                     dependsOn: 'build',
                     options: {
                         cwd: `\${workspaceFolder}/${this._debugSubpath}`
                     },
-                    command: funcHostCommand,
+                    command: hostStartCommand,
                     isBackground: true,
                     problemMatcher: funcWatchProblemMatcher
                 }

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -9,14 +9,14 @@ import * as os from 'os';
 import * as path from 'path';
 import { InputBoxOptions, window } from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
-import { ProjectRuntime, TemplateFilter } from '../../constants';
+import { func, funcWatchProblemMatcher, hostStartCommand, ProjectRuntime, TemplateFilter } from '../../constants';
+import { javaDebugConfig } from '../../debug/JavaDebugProvider';
 import { ext } from '../../extensionVariables';
-import { funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
 import { localize } from "../../localize";
 import * as fsUtil from '../../utils/fs';
 import { validateMavenIdentifier, validatePackageName } from '../../utils/javaNameUtils';
 import { mavenUtils } from '../../utils/mavenUtils';
-import { funcWatchProblemMatcher, ProjectCreatorBase } from './ProjectCreatorBase';
+import { ProjectCreatorBase } from './ProjectCreatorBase';
 
 export class JavaProjectCreator extends ProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
@@ -113,23 +113,24 @@ export class JavaProjectCreator extends ProjectCreatorBase {
     }
 
     public getTasksJson(): {} {
+        const packageTaskLabel: string = 'package';
         return {
             version: '2.0.0',
             tasks: [
                 {
-                    label: funcHostTaskLabel,
-                    linux: {
-                        command: `sh -c "mvn clean package -B && func host start --language-worker -- \\\"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\\\" --script-root \\\"${this._javaTargetPath}\\\""`
-                    },
-                    osx: {
-                        command: `sh -c "mvn clean package -B && func host start --language-worker -- \\\"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\\\" --script-root \\\"${this._javaTargetPath}\\\""`
-                    },
-                    windows: {
-                        command: `powershell -command "mvn clean package -B; func host start --language-worker -- \\\"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005\\\" --script-root \\\"${this._javaTargetPath}\\\""`
-                    },
-                    type: 'shell',
+                    type: func,
+                    command: hostStartCommand,
+                    problemMatcher: funcWatchProblemMatcher,
                     isBackground: true,
-                    problemMatcher: funcWatchProblemMatcher
+                    options: {
+                        cwd: `\${workspaceFolder}/${this._javaTargetPath}`
+                    },
+                    dependsOn: packageTaskLabel
+                },
+                {
+                    label: packageTaskLabel,
+                    command: 'mvn clean package',
+                    type: 'shell'
                 }
             ]
         };
@@ -138,16 +139,7 @@ export class JavaProjectCreator extends ProjectCreatorBase {
     public getLaunchJson(): {} {
         return {
             version: '0.2.0',
-            configurations: [
-                {
-                    name: localize('azFunc.attachToJavaFunc', 'Attach to Java Functions'),
-                    type: 'java',
-                    request: 'attach',
-                    hostName: 'localhost',
-                    port: 5005,
-                    preLaunchTask: funcHostTaskLabel
-                }
-            ]
+            configurations: [javaDebugConfig]
         };
     }
 

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -3,15 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { installExtensionsId, ProjectRuntime, TemplateFilter } from "../../constants";
-import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
-import { localize } from "../../localize";
-import { ITaskOptions } from "./ITasksJson";
-import { funcWatchProblemMatcher } from "./ProjectCreatorBase";
+import { extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand, ProjectRuntime, TemplateFilter } from "../../constants";
+import { nodeDebugConfig } from "../../debug/NodeDebugProvider";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
-
-export const funcNodeDebugArgs: string = '--inspect=5858';
-export const funcNodeDebugEnvVar: string = 'languageWorkers__node__arguments';
 
 export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
@@ -25,49 +19,26 @@ export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public getLaunchJson(): {} {
         return {
             version: '0.2.0',
-            configurations: [
-                {
-                    name: localize('azFunc.attachToJavaScriptFunc', 'Attach to JavaScript Functions'),
-                    type: 'node',
-                    request: 'attach',
-                    port: 5858,
-                    preLaunchTask: funcHostTaskLabel
-                }
-            ]
+            configurations: [nodeDebugConfig]
         };
     }
 
     public getTasksJson(): {} {
-        let options: ITaskOptions | undefined;
         // tslint:disable-next-line:no-any
         const funcTask: any = {
-            label: funcHostTaskLabel,
-            type: 'shell',
-            command: funcHostCommand,
-            isBackground: true,
-            problemMatcher: funcWatchProblemMatcher
-        };
-
-        const installExtensionsTask: {} = {
-            label: installExtensionsId,
-            command: 'func extensions install',
-            type: 'shell'
+            type: func,
+            command: hostStartCommand,
+            problemMatcher: funcWatchProblemMatcher,
+            isBackground: true
         };
 
         // tslint:disable-next-line:no-unsafe-any
         const tasks: {}[] = [funcTask];
 
         if (this.runtime !== ProjectRuntime.v1) {
-            options = {};
-            options.env = {};
-            options.env[funcNodeDebugEnvVar] = funcNodeDebugArgs;
             // tslint:disable-next-line:no-unsafe-any
-            funcTask.options = options;
-
-            // tslint:disable-next-line:no-unsafe-any
-            funcTask.dependsOn = installExtensionsId;
-            this.preDeployTask = installExtensionsId;
-            tasks.push(installExtensionsTask);
+            funcTask.dependsOn = extInstallTaskName;
+            this.preDeployTask = extInstallTaskName;
         }
 
         return {

--- a/src/commands/createNewProject/ProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ProjectCreatorBase.ts
@@ -44,5 +44,3 @@ export abstract class ProjectCreatorBase {
         return ['ms-azuretools.vscode-azurefunctions'];
     }
 }
-
-export const funcWatchProblemMatcher: string = '$func-watch';

--- a/src/commands/createNewProject/ScriptProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ScriptProjectCreatorBase.ts
@@ -5,11 +5,10 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { gitignoreFileName, hostFileName, localSettingsFileName, ProjectRuntime, proxiesFileName, TemplateFilter } from '../../constants';
-import { funcHostCommand, funcHostTaskLabel } from "../../funcCoreTools/funcHostTask";
+import { func, funcWatchProblemMatcher, gitignoreFileName, hostFileName, hostStartCommand, localSettingsFileName, ProjectRuntime, proxiesFileName, TemplateFilter } from '../../constants';
 import { ILocalAppSettings } from '../../LocalAppSettings';
 import { confirmOverwriteFile, writeFormattedJson } from "../../utils/fs";
-import { funcWatchProblemMatcher, ProjectCreatorBase } from './ProjectCreatorBase';
+import { ProjectCreatorBase } from './ProjectCreatorBase';
 
 // tslint:disable-next-line:no-multiline-string
 const gitignore: string = `bin
@@ -53,11 +52,10 @@ export class ScriptProjectCreatorBase extends ProjectCreatorBase {
             version: '2.0.0',
             tasks: [
                 {
-                    label: funcHostTaskLabel,
-                    type: 'shell',
-                    command: funcHostCommand,
-                    isBackground: true,
-                    problemMatcher: funcWatchProblemMatcher
+                    type: func,
+                    command: hostStartCommand,
+                    problemMatcher: funcWatchProblemMatcher,
+                    isBackground: true
                 }
             ]
         };

--- a/src/commands/createNewProject/isFunctionProject.ts
+++ b/src/commands/createNewProject/isFunctionProject.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { hostFileName } from '../../constants';
+
+// Use 'host.json' as an indicator that this is a functions project
+export async function isFunctionProject(folderPath: string): Promise<boolean> {
+    return await fse.pathExists(path.join(folderPath, hostFileName));
+}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as appservice from 'vscode-azureappservice';
 import { AzureTreeItem, DialogResponses, IActionContext, IAzureUserInput, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
-import { deploySubpathSetting, extensionPrefix, funcPackId, installExtensionsId, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
+import { deploySubpathSetting, extensionPrefix, extInstallTaskName, funcPackId, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
 import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
 import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
@@ -306,7 +306,7 @@ function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRunti
             return publishTaskId;
         case ProjectLanguage.JavaScript:
             // "func extensions install" is only supported on v2
-            return runtime === ProjectRuntime.v1 ? undefined : installExtensionsId;
+            return runtime === ProjectRuntime.v1 ? undefined : extInstallTaskName;
         case ProjectLanguage.Python:
             return funcPackId;
         default:

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -6,8 +6,8 @@
 import * as unixPsTree from 'ps-tree';
 import * as vscode from 'vscode';
 import { IActionContext, UserCancelledError } from 'vscode-azureextensionui';
-import { extensionPrefix, isWindows } from '../constants';
-import { funcHostTaskLabel, isFuncHostTask, stopFuncHostPromise } from '../funcCoreTools/funcHostTask';
+import { extensionPrefix, funcHostStartCommand, isWindows } from '../constants';
+import { isFuncHostTask, stopFuncHostPromise } from '../funcCoreTools/funcHostTask';
 import { validateFuncCoreToolsInstalled } from '../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../localize';
 import { getFuncExtensionSetting } from '../ProjectSettings';
@@ -23,7 +23,7 @@ export async function pickFuncProcess(this: IActionContext): Promise<string | un
     const tasks: vscode.Task[] = await vscode.tasks.fetchTasks();
     const funcTask: vscode.Task | undefined = tasks.find(isFuncHostTask);
     if (!funcTask) {
-        throw new Error(localize('noFuncTask', 'Failed to find task with label "{0}".', funcHostTaskLabel));
+        throw new Error(localize('noFuncTask', 'Failed to find "{0}" task.', funcHostStartCommand));
     }
 
     const settingKey: string = 'pickProcessTimeout';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,5 +68,16 @@ export enum ScmType {
 }
 
 export const publishTaskId: string = 'publish';
-export const installExtensionsId: string = 'installExtensions';
 export const funcPackId: string = 'funcPack';
+
+export const func: string = 'func';
+export const extInstallCommand: string = 'extensions install';
+export const extInstallTaskName: string = `${func}: ${extInstallCommand}`;
+
+export const hostStartCommand: string = 'host start';
+export const hostStartTaskName: string = `${func}: ${hostStartCommand}`;
+export const funcHostStartCommand: string = `${func} ${hostStartCommand}`;
+
+export const funcWatchProblemMatcher: string = '$func-watch';
+
+export const localhost: string = '127.0.0.1';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,6 +73,7 @@ export const funcPackId: string = 'funcPack';
 export const func: string = 'func';
 export const extInstallCommand: string = 'extensions install';
 export const extInstallTaskName: string = `${func}: ${extInstallCommand}`;
+export const funcExtInstallCommand: string = `${func} ${extInstallCommand}`;
 
 export const hostStartCommand: string = 'host start';
 export const hostStartTaskName: string = `${func}: ${hostStartCommand}`;

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, ShellExecution, WorkspaceFolder } from 'vscode';
+import { isFunctionProject } from '../commands/createNewProject/isFunctionProject';
+
+export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
+    protected abstract defaultPort: number;
+    protected abstract debugConfig: DebugConfiguration;
+
+    private readonly _debugPorts: Map<WorkspaceFolder | undefined, number | undefined> = new Map();
+
+    public abstract getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution>;
+
+    public async provideDebugConfigurations(folder: WorkspaceFolder | undefined, _token?: CancellationToken): Promise<DebugConfiguration[]> {
+        const result: DebugConfiguration[] = [];
+        if (folder) {
+            if (await isFunctionProject(folder.uri.fsPath)) {
+                result.push(this.debugConfig);
+            }
+        }
+
+        return result;
+    }
+
+    public async resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, _token?: CancellationToken): Promise<DebugConfiguration> {
+        this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
+        return debugConfiguration;
+    }
+
+    protected getDebugPort(folder: WorkspaceFolder): number {
+        // tslint:disable-next-line:strict-boolean-expressions
+        return this._debugPorts.get(folder) || this.defaultPort;
+    }
+}

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, ProcessExecution, ShellExecution, Task, TaskProvider, workspace, WorkspaceFolder } from 'vscode';
+import { CancellationToken, ShellExecution, Task, TaskProvider, workspace, WorkspaceFolder } from 'vscode';
 import { isFunctionProject } from '../commands/createNewProject/isFunctionProject';
-import { extInstallCommand, func, funcHostStartCommand, funcWatchProblemMatcher, hostStartCommand, ProjectLanguage, projectLanguageSetting } from '../constants';
+import { extInstallCommand, func, funcExtInstallCommand, funcHostStartCommand, funcWatchProblemMatcher, hostStartCommand, ProjectLanguage, projectLanguageSetting } from '../constants';
 import { getFuncExtensionSetting } from '../ProjectSettings';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 import { JavaDebugProvider } from './JavaDebugProvider';
@@ -86,6 +86,6 @@ function getExtensionInstallTask(folder: WorkspaceFolder): Task {
         folder,
         extInstallCommand,
         func,
-        new ProcessExecution(func, ['extensions', 'install'])
+        new ShellExecution(funcExtInstallCommand)
     );
 }

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken, ProcessExecution, ShellExecution, Task, TaskProvider, workspace, WorkspaceFolder } from 'vscode';
+import { isFunctionProject } from '../commands/createNewProject/isFunctionProject';
+import { extInstallCommand, func, funcHostStartCommand, funcWatchProblemMatcher, hostStartCommand, ProjectLanguage, projectLanguageSetting } from '../constants';
+import { getFuncExtensionSetting } from '../ProjectSettings';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+import { JavaDebugProvider } from './JavaDebugProvider';
+import { NodeDebugProvider } from './NodeDebugProvider';
+import { PythonDebugProvider } from './PythonDebugProvider';
+
+export class FuncTaskProvider implements TaskProvider {
+    private readonly _nodeDebugProvider: NodeDebugProvider;
+    private readonly _pythonDebugProvider: PythonDebugProvider;
+    private readonly _javaDebugProvider: JavaDebugProvider;
+
+    constructor(nodeDebugProvider: NodeDebugProvider, pythonDebugProvider: PythonDebugProvider, javaDebugProvider: JavaDebugProvider) {
+        this._nodeDebugProvider = nodeDebugProvider;
+        this._pythonDebugProvider = pythonDebugProvider;
+        this._javaDebugProvider = javaDebugProvider;
+    }
+
+    public async provideTasks(_token?: CancellationToken | undefined): Promise<Task[]> {
+        const result: Task[] = [];
+        if (workspace.workspaceFolders) {
+            for (const folder of workspace.workspaceFolders) {
+                if (await isFunctionProject(folder.uri.fsPath)) {
+                    result.push(getExtensionInstallTask(folder));
+                    const hostStartTask: Task | undefined = await this.getHostStartTask(folder);
+                    if (hostStartTask) {
+                        result.push(hostStartTask);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public async resolveTask(_task: Task, _token?: CancellationToken | undefined): Promise<Task | undefined> {
+        // The resolveTask method returns undefined and is currently not called by VS Code. It is there to optimize task loading in the future.
+        // https://code.visualstudio.com/docs/extensions/example-tasks
+        return undefined;
+    }
+
+    private async getHostStartTask(folder: WorkspaceFolder): Promise<Task | undefined> {
+        const language: string | undefined = getFuncExtensionSetting(projectLanguageSetting, folder.uri.fsPath);
+        let debugProvider: FuncDebugProviderBase | undefined;
+        switch (language) {
+            case ProjectLanguage.Python:
+                debugProvider = this._pythonDebugProvider;
+                break;
+            case ProjectLanguage.JavaScript:
+                debugProvider = this._nodeDebugProvider;
+                break;
+            case ProjectLanguage.Java:
+                debugProvider = this._javaDebugProvider;
+                break;
+            default:
+        }
+
+        const shellExecution: ShellExecution = debugProvider ? await debugProvider.getShellExecution(folder) : new ShellExecution(funcHostStartCommand);
+        return new Task(
+            {
+                type: func,
+                command: hostStartCommand
+            },
+            folder,
+            hostStartCommand,
+            func,
+            shellExecution,
+            funcWatchProblemMatcher
+        );
+    }
+}
+
+function getExtensionInstallTask(folder: WorkspaceFolder): Task {
+    return new Task(
+        {
+            type: func,
+            command: extInstallCommand
+        },
+        folder,
+        extInstallCommand,
+        func,
+        new ProcessExecution(func, ['extensions', 'install'])
+    );
+}

--- a/src/debug/JavaDebugProvider.ts
+++ b/src/debug/JavaDebugProvider.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DebugConfiguration, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { funcHostStartCommand, hostStartTaskName, localhost } from '../constants';
+import { localize } from '../localize';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+
+export const defaultJavaDebugPort: number = 5005;
+
+export const javaDebugConfig: DebugConfiguration = {
+    name: localize('attachJava', 'Attach to Java Functions'),
+    type: 'java',
+    request: 'attach',
+    hostName: localhost,
+    port: defaultJavaDebugPort,
+    preLaunchTask: hostStartTaskName
+};
+
+export class JavaDebugProvider extends FuncDebugProviderBase {
+    protected readonly defaultPort: number = defaultJavaDebugPort;
+    protected readonly debugConfig: DebugConfiguration = javaDebugConfig;
+
+    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+        const port: number = this.getDebugPort(folder);
+        const options: ShellExecutionOptions = { env: { languageWorkers__java__arguments: `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${port}` } };
+        return new ShellExecution(funcHostStartCommand, options);
+    }
+}

--- a/src/debug/NodeDebugProvider.ts
+++ b/src/debug/NodeDebugProvider.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DebugConfiguration, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { funcHostStartCommand, hostStartTaskName } from '../constants';
+import { localize } from '../localize';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+
+export const defaultNodeDebugPort: number = 9229;
+
+export const nodeDebugConfig: DebugConfiguration = {
+    name: localize('attachJS', 'Attach to JavaScript Functions'),
+    type: 'node',
+    request: 'attach',
+    port: defaultNodeDebugPort,
+    preLaunchTask: hostStartTaskName
+};
+
+export class NodeDebugProvider extends FuncDebugProviderBase {
+    protected readonly defaultPort: number = defaultNodeDebugPort;
+    protected readonly debugConfig: DebugConfiguration = nodeDebugConfig;
+
+    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+        const port: number = this.getDebugPort(folder);
+        const options: ShellExecutionOptions = { env: { languageWorkers__node__arguments: `--inspect=${port}` } };
+        return new ShellExecution(funcHostStartCommand, options);
+    }
+}

--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DebugConfiguration, Extension, extensions, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { convertToVenvCommand } from '../commands/createNewProject/PythonProjectCreator';
+import { funcHostStartCommand, hostStartTaskName, localhost } from '../constants';
+import { localize } from '../localize';
+import { getFuncExtensionSetting } from '../ProjectSettings';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+
+export const defaultPythonDebugPort: number = 9091;
+
+export const pythonDebugConfig: DebugConfiguration = {
+    name: localize('attachPython', 'Attach to Python Functions'),
+    type: 'python',
+    request: 'attach',
+    port: defaultPythonDebugPort,
+    preLaunchTask: hostStartTaskName
+};
+
+export class PythonDebugProvider extends FuncDebugProviderBase {
+    protected readonly defaultPort: number = defaultPythonDebugPort;
+    protected readonly debugConfig: DebugConfiguration = pythonDebugConfig;
+
+    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+        let command: string = funcHostStartCommand;
+        const port: number = this.getDebugPort(folder);
+        const venvName: string | undefined = getFuncExtensionSetting<string>('pythonVenv', folder.uri.fsPath);
+        if (venvName) {
+            command = convertToVenvCommand(venvName, process.platform, command);
+        }
+        const options: ShellExecutionOptions = { env: { languageWorkers__python__arguments: await getPythonCommand(localhost, port) } };
+        return new ShellExecution(command, options);
+    }
+}
+
+async function getPythonCommand(host: string, port: number): Promise<string> {
+    const pyExtensionId: string = 'ms-python.python';
+    const pyExtension: Extension<IPythonExtensionApi> | undefined = extensions.getExtension<IPythonExtensionApi>(pyExtensionId);
+    if (pyExtension) {
+        if (!pyExtension.isActive) {
+            await pyExtension.activate();
+        }
+
+        // tslint:disable-next-line:strict-boolean-expressions
+        if (pyExtension.exports && pyExtension.exports.debug) {
+            return (await pyExtension.exports.debug.getRemoteLauncherCommand(host, port)).join(' ');
+        } else {
+            throw new Error(localize('pyExtOutOfDate', 'You must update extension with id "{0}" to debug Python projects.', pyExtensionId));
+        }
+    } else {
+        throw new Error(localize('noPyExt', 'You must install extension with id "{0}" to debug Python projects.', pyExtensionId));
+    }
+}

--- a/src/debug/PythonExtension.api.d.ts
+++ b/src/debug/PythonExtension.api.d.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface IPythonExtensionApi {
+	debug: {
+		/**
+		 * Generate an array of strings for commands to pass to the Python executable to launch the debugger for remote debugging.
+		 * Users can append another array of strings of what they want to execute along with relevant arguments to Python.
+		 * E.g `['/Users/..../pythonVSCode/pythonFiles/experimental/ptvsd_launcher.py', '--host', 'localhost', '--port', '57039', '--wait']`
+		*/
+		getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches?: boolean): Promise<string[]>
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,11 @@ import { restartFunctionApp } from './commands/restartFunctionApp';
 import { startFunctionApp } from './commands/startFunctionApp';
 import { stopFunctionApp } from './commands/stopFunctionApp';
 import { swapSlot } from './commands/swapSlot';
+import { func } from './constants';
+import { FuncTaskProvider } from './debug/FuncTaskProvider';
+import { JavaDebugProvider } from './debug/JavaDebugProvider';
+import { NodeDebugProvider } from './debug/NodeDebugProvider';
+import { PythonDebugProvider } from './debug/PythonDebugProvider';
 import { ext } from './extensionVariables';
 import { registerFuncHostTaskEvents } from './funcCoreTools/funcHostTask';
 import { installOrUpdateFuncCoreTools } from './funcCoreTools/installOrUpdateFuncCoreTools';
@@ -129,6 +134,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<AzureE
         registerCommand('azureFunctions.createSlot', async (node?: AzureParentTreeItem) => await createChildNode(SlotsTreeItem.contextValue, node));
         registerCommand('azureFunctions.toggleAppSettingVisibility', async (node: AppSettingTreeItem) => { await node.toggleValueVisibility(); }, 250);
         registerFuncHostTaskEvents();
+
+        const nodeDebugProvider: NodeDebugProvider = new NodeDebugProvider();
+        const pythonDebugProvider: PythonDebugProvider = new PythonDebugProvider();
+        const javaDebugProvider: JavaDebugProvider = new JavaDebugProvider();
+        // These don't actually overwrite "node", "python", etc. - they just add to it
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('node', nodeDebugProvider));
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('python', pythonDebugProvider));
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', javaDebugProvider));
+        context.subscriptions.push(vscode.workspace.registerTaskProvider(func, new FuncTaskProvider(nodeDebugProvider, pythonDebugProvider, javaDebugProvider)));
     });
 
     return createApiProvider([]);

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -5,19 +5,19 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, registerEvent } from 'vscode-azureextensionui';
+import { hostStartCommand } from '../constants';
 import { localize } from '../localize';
 
 let isFuncHostRunning: boolean = false;
 
-export const funcHostTaskLabel: string = 'runFunctionsHost';
-export const funcHostCommand: string = 'func host start';
-export const funcHostNameRegEx: RegExp = /run\s*functions\s*host/i;
+// The name of the task before we started providing it in FuncTaskProvider.ts
+export const oldFuncHostNameRegEx: RegExp = /run\s*functions\s*host/i;
 
 export let stopFuncHostPromise: Promise<void> = Promise.resolve();
 
 export function isFuncHostTask(task: vscode.Task): boolean {
     // task.name resolves to the task's id (deprecated https://github.com/Microsoft/vscode/issues/57707), then label
-    return funcHostNameRegEx.test(task.name);
+    return oldFuncHostNameRegEx.test(task.name) || task.name === hostStartCommand;
 }
 
 export function registerFuncHostTaskEvents(): void {


### PR DESCRIPTION
By providing func tasks programmatically, we get the following benefits:
1. We can call the python extension api to get the debugger command instead of installing ptvsd into a user's project. This protects us from any breaking changes in ptvsd
1. We can fix things under the covers without having to manually change a user's project
1. We don't have to write as much stuff to the user's launch.json/tasks.json

I'm somewhat hesitant to merge this PR to master because it relies on a few fixes only in insiders, but I think it's worth it to give it some bake time since it affects a high priority scenario (debug) within our extension.

Fixes #822 
Fixes #821

I've also filed a few issues for remaining work: #932 #933 #935