### PR TITLE
Make it easier to debug test failures

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -26,8 +26,6 @@ function test() {
     const env = process.env;
     env.DEBUGTELEMETRY = '1';
     env.MOCHA_timeout = String(10 * 1000);
-    env.MOCHA_reporter = 'mocha-junit-reporter';
-    env.MOCHA_FILE = path.join(__dirname, 'test-results.xml');
     return cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4842,6 +4842,33 @@
                 }
             }
         },
+        "mocha-multi-reporters": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+            "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash": "^4.16.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
         "moment": {
             "version": "2.22.2",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",

--- a/package.json
+++ b/package.json
@@ -826,6 +826,7 @@
         "gulp-filter": "^5.1.0",
         "mocha": "^5.2.0",
         "mocha-junit-reporter": "^1.18.0",
+        "mocha-multi-reporters": "^1.1.7",
         "tslint": "^5.7.0",
         "tslint-microsoft-contrib": "5.2.1",
         "ts-node": "^7.0.1",

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -8,8 +8,9 @@ import * as fse from 'fs-extra';
 import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ProjectLanguage, ProjectRuntime } from '../../src/constants';
+import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../src/constants';
 import { runForAllTemplateSources } from '../global.test';
+import { runWithSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpFunctionTester extends FunctionTesterBase {
@@ -87,7 +88,11 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
             const iotPath: string = 'messages/events';
             const connection: string = 'IoTHub_Setting';
             const projectPath: string = path.join(csTester.baseTestFolder, source);
-            await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { namespace: namespace, Path: iotPath, Connection: connection });
+            await runWithSetting(projectLanguageSetting, ProjectLanguage.CSharp, async () => {
+                await runWithSetting(projectRuntimeSetting, ProjectRuntime.v2, async () => {
+                    await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { namespace: namespace, Path: iotPath, Connection: connection });
+                });
+            });
             await csTester.validateFunction(projectPath, functionName);
         });
     });

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -9,10 +9,11 @@ import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, TestUserInput } from 'vscode-azureextensionui';
-import { ProjectLanguage, ProjectRuntime } from '../../src/constants';
+import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../src/constants';
 import { ext } from '../../src/extensionVariables';
 import { runForAllTemplateSources } from '../global.test';
 import { validateVSCodeProjectFiles } from '../initProjectForVSCode.test';
+import { runWithSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpScriptFunctionTester extends FunctionTesterBase {
@@ -57,7 +58,11 @@ suite('Create C# Script Function Tests', async () => {
         await runForAllTemplateSources(async (source) => {
             // Intentionally testing IoTHub trigger since a partner team plans to use that
             const projectPath: string = path.join(tester.baseTestFolder, source);
-            await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, iotTemplateId, iotFunctionName, iotFunctionSettings);
+            await runWithSetting(projectLanguageSetting, ProjectLanguage.CSharpScript, async () => {
+                await runWithSetting(projectRuntimeSetting, ProjectRuntime.v1, async () => {
+                    await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, iotTemplateId, iotFunctionName, iotFunctionSettings);
+                });
+            });
             await tester.validateFunction(projectPath, iotFunctionName);
         });
     });

--- a/test/createFunction/createFunction.JavaScript.test.ts
+++ b/test/createFunction/createFunction.JavaScript.test.ts
@@ -9,8 +9,9 @@ import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { JavaScriptProjectCreator } from '../../src/commands/createNewProject/JavaScriptProjectCreator';
-import { ProjectLanguage, ProjectRuntime } from '../../src/constants';
+import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../src/constants';
 import { runForAllTemplateSources } from '../global.test';
+import { runWithSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class JSFunctionTester extends FunctionTesterBase {
@@ -148,7 +149,11 @@ suite('Create JavaScript Function Tests', async function (this: ISuiteCallbackCo
             const authLevel: string = 'Anonymous';
             const projectPath: string = path.join(jsTester.baseTestFolder, source);
             // Intentionally testing weird casing for authLevel
-            await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { aUtHLevel: authLevel });
+            await runWithSetting(projectLanguageSetting, ProjectLanguage.JavaScript, async () => {
+                await runWithSetting(projectRuntimeSetting, JavaScriptProjectCreator.defaultRuntime, async () => {
+                    await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { aUtHLevel: authLevel });
+                });
+            });
             await jsTester.validateFunction(projectPath, functionName);
         });
     });

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -8,6 +8,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { TestOutputChannel } from 'vscode-azureextensiondev';
+import { TestUserInput } from 'vscode-azureextensionui';
 import { ext, TemplateSource } from '../src/extensionVariables';
 import { getTemplateProvider, TemplateProvider } from '../src/templates/TemplateProvider';
 
@@ -21,6 +22,7 @@ suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
     await vscode.commands.executeCommand('azureFunctions.refresh'); // activate the extension before tests begin
     await ext.templateProviderTask; // make sure default templates are loaded before setting up templates from other sources
     ext.outputChannel = new TestOutputChannel();
+    ext.ui = new TestUserInput([]);
 
     // Use prerelease func cli installed from gulp task (unless otherwise specified in env)
     ext.funcCliPath = process.env.FUNC_PATH || path.join(os.homedir(), 'tools', 'func', 'func');

--- a/test/index.ts
+++ b/test/index.ts
@@ -15,10 +15,11 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
+import * as path from 'path';
 // tslint:disable-next-line:no-require-imports no-submodule-imports
 import testRunner = require('vscode/lib/testrunner');
 
-const options: { [key: string]: string | boolean | number } = {
+const options: { [key: string]: string | boolean | number | object } = {
     ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
     useColors: true // colored output from test results
 };
@@ -37,13 +38,22 @@ const options: { [key: string]: string | boolean | number } = {
 //
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for all available options
 
+// Defaults
+options.reporter = 'mocha-multi-reporters';
+options.reporterOptions = {
+    reporterEnabled: 'spec, mocha-junit-reporter',
+    mochaJunitReporterReporterOptions: {
+        mochaFile: path.join(__dirname, '..', '..', 'test-results.xml')
+    }
+};
+
 for (const envVar of Object.keys(process.env)) {
     const match: RegExpMatchArray | null = envVar.match(/^mocha_(.+)/i);
     if (match) {
         const [, option] = match;
         // tslint:disable-next-line:strict-boolean-expressions
         let value: string | number = process.env[envVar] || '';
-        if (!isNaN(parseInt(value))) {
+        if (typeof value === 'string' && !isNaN(parseInt(value))) {
             value = parseInt(value);
         }
         options[option] = value;

--- a/test/runWithSetting.ts
+++ b/test/runWithSetting.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getGlobalFuncExtensionSetting, updateGlobalSetting } from '../src/ProjectSettings';
+
+export async function runWithSetting(key: string, value: string, callback: () => Promise<void>): Promise<void> {
+    const oldValue: string | undefined = getGlobalFuncExtensionSetting(key);
+    try {
+        await updateGlobalSetting(key, value);
+        await callback();
+    } finally {
+        await updateGlobalSetting(key, oldValue);
+    }
+}


### PR DESCRIPTION
I was having problems with tests when I tried to run them against Insiders for this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/936 These are just a few quality of life improvements that came out of that.
1. Use `mocha-multi-reporters` like stephen's done in other repos
1. Set `ext.ui` immediately. In some cases this will report "Unexpected call to showWarningMessage..." instead of a timeout
1. Added `runWithSetting` so that I had more control on when settings are used in tests. For example, if the `dispose` method of `FunctionTesterBase` failed at `fse.remove` these weren't getting set back