### PR TITLE
Use vscode clipboard api instead of clipboardy package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/clipboardy": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@types/clipboardy/-/clipboardy-1.1.0.tgz",
-            "integrity": "sha512-KOxf4ah9diZWmREM5jCupx2+pZaBPwKk5d5jeNK2+TY6IgEO35uhG55NnDT4cdXeRX8irDSHQPtdRrr0JOTQIw==",
-            "dev": true
-        },
         "@types/events": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -323,11 +317,6 @@
                 "diagnostic-channel-publishers": "0.2.1",
                 "zone.js": "0.7.6"
             }
-        },
-        "arch": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
         },
         "archive-type": {
             "version": "4.0.0",
@@ -1062,15 +1051,6 @@
                 }
             }
         },
-        "clipboardy": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-            "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-            "requires": {
-                "arch": "^2.1.0",
-                "execa": "^0.8.0"
-            }
-        },
         "cliui": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -1254,16 +1234,6 @@
             "requires": {
                 "crc": "^3.4.4",
                 "readable-stream": "^2.0.0"
-            }
-        },
-        "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-            "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
             }
         },
         "crypt": {
@@ -1799,20 +1769,6 @@
                 "split": "0.3",
                 "stream-combiner": "~0.0.4",
                 "through": "~2.3.1"
-            }
-        },
-        "execa": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-            "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-            "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -2764,11 +2720,6 @@
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
             "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
             "dev": true
-        },
-        "get-stream": {
-            "version": "3.0.0",
-            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
             "version": "2.0.6",
@@ -4201,7 +4152,8 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "3.0.1",
@@ -4536,15 +4488,6 @@
             "requires": {
                 "lodash._reinterpolate": "^3.0.0",
                 "lodash.escape": "^3.0.0"
-            }
-        },
-        "lru-cache": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
-            "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^3.0.2"
             }
         },
         "make-dir": {
@@ -4982,14 +4925,6 @@
                 "once": "^1.3.2"
             }
         },
-        "npm-run-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-            "requires": {
-                "path-key": "^2.0.0"
-            }
-        },
         "nth-check": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -5201,11 +5136,6 @@
                 "os-tmpdir": "^1.0.0"
             }
         },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-        },
         "p-retry": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
@@ -5312,11 +5242,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "path-key": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.6",
@@ -5448,11 +5373,6 @@
             "requires": {
                 "event-stream": "=3.3.4"
             }
-        },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
             "version": "1.1.29",
@@ -5871,24 +5791,6 @@
                 }
             }
         },
-        "shebang-command": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-            "requires": {
-                "shebang-regex": "^1.0.0"
-            }
-        },
-        "shebang-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-        },
-        "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-        },
         "simple-git": {
             "version": "1.92.0",
             "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.92.0.tgz",
@@ -6278,11 +6180,6 @@
             "requires": {
                 "is-natural-number": "^4.0.1"
             }
-        },
-        "strip-eof": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "supports-color": {
             "version": "2.0.0",
@@ -7307,6 +7204,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -7394,11 +7292,6 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
             "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
-        },
-        "yallist": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-            "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         },
         "yargs": {
             "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.24.0"
+        "vscode": "^1.30.0"
     },
     "repository": {
         "type": "git",
@@ -802,7 +802,6 @@
         "test": "gulp test"
     },
     "devDependencies": {
-        "@types/clipboardy": "^1.1.0",
         "@types/fs-extra": "^4.0.3",
         "@types/glob": "^7.1.1",
         "@types/gulp": "^4.0.5",
@@ -839,7 +838,6 @@
         "azure-arm-sb": "^2.3.0-preview",
         "azure-arm-storage": "^4.0.0",
         "azure-arm-website": "^5.3.0",
-        "clipboardy": "^1.2.2",
         "extract-zip": "^1.6.6",
         "fs-extra": "^4.0.2",
         "ms-rest-azure": "^2.3.1",

--- a/src/commands/copyFunctionUrl.ts
+++ b/src/commands/copyFunctionUrl.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as clipboardy from 'clipboardy';
+import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
@@ -14,7 +14,7 @@ export async function copyFunctionUrl(node?: FunctionTreeItem): Promise<void> {
     }
 
     if (node.config.isHttpTrigger) {
-        await clipboardy.write(node.triggerUrl);
+        await vscode.env.clipboard.writeText(node.triggerUrl);
     } else {
         throw new Error(localize('CopyFailedForNonHttp', 'Function URLs can only be used for HTTP triggers.'));
     }

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -8,14 +8,13 @@ are grateful to these developers for their contribution to open source.
 1. fs-extra (https://github.com/jprichardson/node-fs-extra)
 2. request-promise (https://github.com/request/request-promise)
 3. xml2js (https://github.com/Leonidas-from-XIV/node-xml2js)
-4. clipboardy (https://github.com/sindresorhus/clipboardy)
-5. xregexp (https://github.com/slevithan/xregexp)
-6. opn (https://github.com/sindresorhus/opn)
-7. semver (https://github.com/npm/node-semver)
-8. portfinder (https://github.com/indexzero/node-portfinder)
-9. websocket (https://github.com/theturtle32/WebSocket-Node)
-10. extract-zip (https://github.com/maxogden/extract-zip)
-11. ps-tree (https://github.com/indexzero/ps-tree)
+4. xregexp (https://github.com/slevithan/xregexp)
+5. opn (https://github.com/sindresorhus/opn)
+6. semver (https://github.com/npm/node-semver)
+7. portfinder (https://github.com/indexzero/node-portfinder)
+8. websocket (https://github.com/theturtle32/WebSocket-Node)
+9. extract-zip (https://github.com/maxogden/extract-zip)
+10. ps-tree (https://github.com/indexzero/ps-tree)
 
 fs-extra NOTICES BEGIN HERE
 =============================
@@ -85,22 +84,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 END OF xml2js NOTICES AND INFORMATION
-==================================
-
-clipboardy NOTICES BEGIN HERE
-=============================
-
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-END OF clipboardy NOTICES AND INFORMATION
 ==================================
 
 xregexp NOTICES BEGIN HERE


### PR DESCRIPTION
I was hesitant to bump the minimum VS Code version just for a clipboard api that was already solved by a third party tool, but now I have to bump the miminum version anyways for https://github.com/Microsoft/vscode-azurefunctions/pull/936

Verified it works on all 3 OS's