### PR TITLE
Add VS Code bot

### DIFF
--- a/.github/locker.yml
+++ b/.github/locker.yml
@@ -1,0 +1,5 @@
+{
+    daysAfterClose: 45,
+    daysSinceLastUpdate: 7,
+    perform: true
+}

--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,0 +1,6 @@
+{
+    daysUntilClose: 21,
+    needsMoreInfoLabel: 'needs more info',
+    perform: true,
+    closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"
+}


### PR DESCRIPTION
These two rules will:
* Automatically closes any issue marked "needs more info" if there has been no response in the past 21 days.
* Automatically locks issues 45 days after they are closed.

(At least hopefully - I'll wait to see if it works before adding to all repos haha)