### PR TITLE
Don't hard code terminal separators in Python projects

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as appservice from 'vscode-azureappservice';
 import { AzureTreeItem, DialogResponses, IActionContext, IAzureUserInput, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
-import { deploySubpathSetting, extensionPrefix, extInstallTaskName, funcPackId, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
+import { deploySubpathSetting, extensionPrefix, extInstallTaskName, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
 import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
 import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
@@ -308,7 +308,7 @@ function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRunti
             // "func extensions install" is only supported on v2
             return runtime === ProjectRuntime.v1 ? undefined : extInstallTaskName;
         case ProjectLanguage.Python:
-            return funcPackId;
+            return packTaskName;
         default:
             return undefined; // preDeployTask not needed
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,6 @@ export enum ScmType {
 }
 
 export const publishTaskId: string = 'publish';
-export const funcPackId: string = 'funcPack';
 
 export const func: string = 'func';
 export const extInstallCommand: string = 'extensions install';
@@ -78,6 +77,10 @@ export const funcExtInstallCommand: string = `${func} ${extInstallCommand}`;
 export const hostStartCommand: string = 'host start';
 export const hostStartTaskName: string = `${func}: ${hostStartCommand}`;
 export const funcHostStartCommand: string = `${func} ${hostStartCommand}`;
+
+export const packCommand: string = 'pack';
+export const packTaskName: string = `${func}: ${packCommand}`;
+export const funcPackCommand: string = `${func} ${packCommand}`;
 
 export const funcWatchProblemMatcher: string = '$func-watch';
 

--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DebugConfiguration, Extension, extensions, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
-import { convertToVenvCommand } from '../commands/createNewProject/PythonProjectCreator';
 import { funcHostStartCommand, hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
-import { getFuncExtensionSetting } from '../ProjectSettings';
+import { venvUtils } from '../utils/venvUtils';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 
 export const defaultPythonDebugPort: number = 9091;
@@ -25,12 +24,8 @@ export class PythonDebugProvider extends FuncDebugProviderBase {
     protected readonly debugConfig: DebugConfiguration = pythonDebugConfig;
 
     public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
-        let command: string = funcHostStartCommand;
+        const command: string = venvUtils.convertToVenvTask(folder, funcHostStartCommand);
         const port: number = this.getDebugPort(folder);
-        const venvName: string | undefined = getFuncExtensionSetting<string>('pythonVenv', folder.uri.fsPath);
-        if (venvName) {
-            command = convertToVenvCommand(venvName, process.platform, command);
-        }
         const options: ShellExecutionOptions = { env: { languageWorkers__python__arguments: await getPythonCommand(localhost, port) } };
         return new ShellExecution(command, options);
     }

--- a/src/debug/getPythonTasks.ts
+++ b/src/debug/getPythonTasks.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ShellExecution, Task, WorkspaceFolder } from 'vscode';
+import { func, funcPackCommand, packCommand } from '../constants';
+import { venvUtils } from '../utils/venvUtils';
+
+export function getPythonTasks(folder: WorkspaceFolder): Task[] {
+    const commandLine: string = venvUtils.convertToVenvTask(folder, funcPackCommand);
+    const basicPack: Task = new Task(
+        {
+            type: func,
+            command: packCommand
+        },
+        folder,
+        packCommand,
+        func,
+        new ShellExecution(commandLine)
+    );
+
+    const buildNativeDeps: string = '--build-native-deps';
+    const advancedPackCommand: string = `${packCommand} ${buildNativeDeps}`;
+    const advancedCommandLine: string = `${commandLine} ${buildNativeDeps}`;
+    const advancedPack: Task = new Task(
+        {
+            type: func,
+            command: advancedPackCommand
+        },
+        folder,
+        advancedPackCommand,
+        func,
+        new ShellExecution(advancedCommandLine)
+    );
+
+    return [basicPack, advancedPack];
+}

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -6,7 +6,7 @@
 import * as cp from 'child_process';
 import * as os from 'os';
 import * as vscode from 'vscode';
-import { isWindows, Platform } from '../constants';
+import { isWindows } from '../constants';
 import { localize } from '../localize';
 
 export namespace cpUtils {
@@ -89,18 +89,5 @@ export namespace cpUtils {
      */
     export function wrapArgInQuotes(arg: string): string {
         return quotationMark + arg + quotationMark;
-    }
-
-    export function joinCommands(platform: NodeJS.Platform, ...commands: string[]): string {
-        let separator: string;
-        switch (platform) {
-            case Platform.Windows:
-                separator = ' ; ';
-                break;
-            default:
-                separator = ' && ';
-                break;
-        }
-        return commands.join(separator);
     }
 }

--- a/src/utils/venvUtils.ts
+++ b/src/utils/venvUtils.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import { workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { Platform } from "../constants";
+import { ext } from '../extensionVariables';
+import { getFuncExtensionSetting } from '../ProjectSettings';
+import { cpUtils } from './cpUtils';
+
+export namespace venvUtils {
+    const bashAndCmdSeparator: string = ' && ';
+    const powerShellSeparator: string = ' ; ';
+
+    export function convertToVenvTask(folder: WorkspaceFolder, ...commands: string[]): string {
+        const venvName: string | undefined = getFuncExtensionSetting<string>('pythonVenv', folder.uri.fsPath);
+        if (venvName) {
+            commands.unshift(getVenvActivateCommand(venvName));
+        }
+
+        let separator: string = bashAndCmdSeparator;
+        if (process.platform === Platform.Windows) {
+            const config: WorkspaceConfiguration = workspace.getConfiguration();
+            const shell: string | undefined = config.get('terminal.integrated.shell.windows');
+            if (shell && /(powershell|pwsh)/i.test(shell)) {
+                separator = powerShellSeparator;
+            }
+        }
+
+        return commands.join(separator);
+    }
+
+    export async function runPythonCommandInVenv(venvName: string, folderPath: string, command: string): Promise<void> {
+        // child_process uses cmd or bash, not PowerShell
+        command = getVenvActivateCommand(venvName) + bashAndCmdSeparator + command;
+        await cpUtils.executeCommand(ext.outputChannel, folderPath, command);
+    }
+
+    export function getVenvActivatePath(venvName: string): string {
+        switch (process.platform) {
+            case Platform.Windows:
+                return path.join('.', venvName, 'Scripts', 'activate');
+            default:
+                return path.join('.', venvName, 'bin', 'activate');
+        }
+    }
+
+    function getVenvActivateCommand(venvName: string): string {
+        const venvActivatePath: string = getVenvActivatePath(venvName);
+        switch (process.platform) {
+            case Platform.Windows:
+                return venvActivatePath;
+            default:
+                return `. ${venvActivatePath}`;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/760

We were always using PowerShell separators on Windows, which wasn't working if they had `cmd` set as their shell. Now all tasks are provided dynamically and we can detect the correct separator to use.

Tested on Mac and Windows with both `cmd` and `PowerShell`.

Depends on this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/936