### PR TITLE
Allow deploying Python to dedicated linux plan

### DIFF
--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -50,12 +50,10 @@ export class FunctionAppProvider extends SubscriptionTreeItem {
             this,
             webAppCollection,
             'azFuncInvalidFunctionApp',
-            async (site: WebSiteManagementModels.Site) => {
+            (site: WebSiteManagementModels.Site) => {
                 const siteClient: SiteClient = new SiteClient(site, this.root);
                 if (siteClient.isFunctionApp) {
-                    const asp: WebSiteManagementModels.AppServicePlan | undefined = await siteClient.getAppServicePlan();
-                    const isLinuxPreview: boolean = siteClient.kind.toLowerCase().includes('linux') && !!asp && !!asp.sku && !!asp.sku.tier && asp.sku.tier.toLowerCase() === 'dynamic';
-                    return new ProductionSlotTreeItem(this, siteClient, isLinuxPreview);
+                    return new ProductionSlotTreeItem(this, siteClient);
                 }
                 return undefined;
             },
@@ -83,7 +81,7 @@ export class FunctionAppProvider extends SubscriptionTreeItem {
         }
 
         const site: WebSiteManagementModels.Site = await createFunctionApp(actionContext, this.root, createOptions, showCreatingTreeItem);
-        return new ProductionSlotTreeItem(this, new SiteClient(site, this.root), createOptions.os === 'linux' /* isLinuxPreview */);
+        return new ProductionSlotTreeItem(this, new SiteClient(site, this.root));
     }
 }
 

--- a/src/tree/ProductionSlotTreeItem.ts
+++ b/src/tree/ProductionSlotTreeItem.ts
@@ -16,8 +16,8 @@ export class ProductionSlotTreeItem extends SlotTreeItemBase {
 
     private readonly _slotsTreeItem: SlotsTreeItem;
 
-    public constructor(parent: AzureParentTreeItem, client: SiteClient, isLinuxPreview: boolean) {
-        super(parent, client, isLinuxPreview);
+    public constructor(parent: AzureParentTreeItem, client: SiteClient) {
+        super(parent, client);
         this._slotsTreeItem = new SlotsTreeItem(this);
     }
 

--- a/src/tree/SlotTreeItem.ts
+++ b/src/tree/SlotTreeItem.ts
@@ -12,8 +12,8 @@ export class SlotTreeItem extends SlotTreeItemBase {
     public readonly contextValue: string = SlotTreeItem.contextValue;
     public readonly parent: SlotsTreeItem;
 
-    public constructor(parent: SlotsTreeItem, client: SiteClient, isLinuxPreview: boolean) {
-        super(parent, client, isLinuxPreview);
+    public constructor(parent: SlotsTreeItem, client: SiteClient) {
+        super(parent, client);
     }
 
     public get label(): string {

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -15,7 +15,6 @@ import { ProxyTreeItem } from './ProxyTreeItem';
 
 export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot> {
     public logStreamPath: string = '';
-    public readonly isLinuxPreview: boolean;
     public readonly appSettingsTreeItem: AppSettingsTreeItem;
     public deploymentsNode: DeploymentsTreeItem | undefined;
 
@@ -27,14 +26,13 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
     private readonly _functionsTreeItem: FunctionsTreeItem;
     private readonly _proxiesTreeItem: ProxiesTreeItem;
 
-    public constructor(parent: AzureParentTreeItem, client: SiteClient, isLinuxPreview: boolean) {
+    public constructor(parent: AzureParentTreeItem, client: SiteClient) {
         super(parent);
         this._root = Object.assign({}, parent.root, { client });
         this._state = client.initialState;
         this._functionsTreeItem = new FunctionsTreeItem(this);
         this.appSettingsTreeItem = new AppSettingsTreeItem(this, 'azureFunctions.toggleAppSettingVisibility');
         this._proxiesTreeItem = new ProxiesTreeItem(this);
-        this.isLinuxPreview = isLinuxPreview;
     }
 
     // overrides ISubscriptionRoot with an object that also has SiteClient
@@ -52,7 +50,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
 
     public get description(): string | undefined {
         const stateDescription: string | undefined = this._state && this._state.toLowerCase() !== 'running' ? this._state : undefined;
-        const previewDescription: string | undefined = this.isLinuxPreview ? localize('linuxPreview', 'Linux Preview') : undefined;
+        const previewDescription: string | undefined = this.root.client.isLinux ? localize('linuxPreview', 'Linux Preview') : undefined;
         if (stateDescription && previewDescription) {
             return `${previewDescription} - ${stateDescription}`;
         } else {

--- a/src/tree/SlotsTreeItem.ts
+++ b/src/tree/SlotsTreeItem.ts
@@ -55,7 +55,7 @@ export class SlotsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             'azFuncInvalidSlot',
             async (site: WebSiteManagementModels.Site) => {
                 const siteClient: SiteClient = new SiteClient(site, this.root);
-                return new SlotTreeItem(this, siteClient, this.parent.isLinuxPreview);
+                return new SlotTreeItem(this, siteClient);
             },
             (site: WebSiteManagementModels.Site) => {
                 return site.name;
@@ -66,6 +66,6 @@ export class SlotsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public async createChildImpl(showCreatingTreeItem: (label: string) => void): Promise<AzureTreeItem<ISiteTreeRoot>> {
         const existingSlots: SlotTreeItem[] = <SlotTreeItem[]>await this.getCachedChildren();
         const newSite: WebSiteManagementModels.Site = await createSlot(this.root, existingSlots, showCreatingTreeItem);
-        return new SlotTreeItem(this, new SiteClient(newSite, this.root), this.parent.isLinuxPreview);
+        return new SlotTreeItem(this, new SiteClient(newSite, this.root));
     }
 }


### PR DESCRIPTION
There's no reason to block dedicated plans here (I think I just had never verified it worked, but it does). Also worth noting in the portal _all_ linux options show as preview, not just consumption.

![screen shot 2019-01-31 at 10 54 27 am](https://user-images.githubusercontent.com/11282622/52077761-99d01480-2546-11e9-8338-20dde796a76e.png)


Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/906
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/893