### PR TITLE
Update disabled state logic for v2

### DIFF
--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -49,15 +49,7 @@ export class FunctionsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
             this,
             funcs,
             'azFuncInvalidFunction',
-            async (fe: WebSiteManagementModels.FunctionEnvelope) => {
-                const treeItem: FunctionTreeItem = new FunctionTreeItem(this, fe);
-                if (treeItem.config.isHttpTrigger) {
-                    // We want to cache the trigger url so that it is instantaneously copied when the user performs the copy action
-                    // (Otherwise there might be a second or two delay which could lead to confusion)
-                    await treeItem.initializeTriggerUrl();
-                }
-                return treeItem;
-            },
+            async (fe: WebSiteManagementModels.FunctionEnvelope) => await FunctionTreeItem.createFunctionTreeItem(this, fe),
             (fe: WebSiteManagementModels.FunctionEnvelope) => {
                 return fe.id ? getFunctionNameFromId(fe.id) : undefined;
             }

--- a/tslint.json
+++ b/tslint.json
@@ -63,6 +63,12 @@
         "prefer-object-spread": false,
         "no-return-await": false,
         "no-parameter-reassignment": false,
-        "no-object-literal-type-assertion": false
+        "no-object-literal-type-assertion": false,
+        "function-name": [
+            true,
+            {
+                "static-method-regex": "^[a-z][\\w_]+$"
+            }
+        ]
     }
 }


### PR DESCRIPTION
v1 and v2 of the functions runtime disable functions in different ways. Update logic to reflect that. And clean up code a bit - I think this was originally written before `refreshImpl` or `description` existed

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/780