### PR TITLE
Prompt user to install func cli before debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -765,11 +765,6 @@
                         "description": "%azFunc.pickProcessTimeoutDescription%",
                         "default": 60
                     },
-                    "azureFunctions.showFuncInstallation": {
-                        "type": "boolean",
-                        "description": "%azFunc.showFuncInstallationDescription%",
-                        "default": true
-                    },
                     "azureFunctions.templateVersion": {
                         "type": "string",
                         "description": "%azFunc.templateVersion%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -41,7 +41,6 @@
     "azFunc.enableRemoteDebugging": "Enable remote debugging, an experimental feature that only supports Java-based Functions Apps.",
     "azFunc.deleteProxy": "Delete Proxy...",
     "azFunc.pickProcessTimeoutDescription": "The timeout (in seconds) to be used when searching for the Azure Functions host process. Since a build is required every time you F5, you may need to adjust this based on how long your build takes.",
-    "azFunc.showFuncInstallationDescription": "Show a warning to install Azure Functions Core Tools CLI when you create a new project if the CLI is not installed.",
     "azFunc.templateVersion": "A runtime release version (any runtime) that species which templates will be used rather than the latest templates.  This version will be used for ALL runtimes. (Requires a restart of VS Code to take effect)",
     "azFunc.projectOpenBehaviorDescription": "The behavior to use after creating a new project. The options are \"AddToWorkspace\", \"OpenInNewWindow\", or \"OpenInCurrentWindow\".",
     "azFunc.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -53,7 +53,7 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
 
     public async onCreateNewProject(): Promise<void> {
         const funcCoreRequired: string = localize('funcCoreRequired', 'Azure Functions Core Tools must be installed to create, debug, and deploy local Python Functions projects.');
-        if (!await validateFuncCoreToolsInstalled(true /* forcePrompt */, funcCoreRequired)) {
+        if (!await validateFuncCoreToolsInstalled(funcCoreRequired)) {
             throw new UserCancelledError();
         }
 

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -9,7 +9,6 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
-import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
 import { convertStringToRuntime, getGlobalFuncExtensionSetting } from '../../ProjectSettings';
 import { gitUtils } from '../../utils/gitUtils';
@@ -79,10 +78,6 @@ export async function createNewProject(
     });
     // don't wait
     window.showInformationMessage(localize('finishedCreating', 'Finished creating project.'));
-
-    // don't wait
-    // tslint:disable-next-line:no-floating-promises
-    validateFuncCoreToolsInstalled();
 
     if (openFolder) {
         await workspaceUtil.ensureFolderIsOpen(functionAppPath, actionContext);

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -14,7 +14,7 @@ import { getFuncExtensionSetting } from '../ProjectSettings';
 import { getWindowsProcessTree, IProcessTreeNode, IWindowsProcessTree } from '../utils/windowsProcessTree';
 
 export async function pickFuncProcess(this: IActionContext): Promise<string | undefined> {
-    if (!await validateFuncCoreToolsInstalled(true /* forcePrompt */)) {
+    if (!await validateFuncCoreToolsInstalled()) {
         throw new UserCancelledError();
     }
 

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -5,6 +5,8 @@
 
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, ShellExecution, WorkspaceFolder } from 'vscode';
 import { isFunctionProject } from '../commands/createNewProject/isFunctionProject';
+import { hostStartTaskName } from '../constants';
+import { validateFuncCoreToolsInstalled } from '../funcCoreTools/validateFuncCoreToolsInstalled';
 
 export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
     protected abstract defaultPort: number;
@@ -25,8 +27,14 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
         return result;
     }
 
-    public async resolveDebugConfiguration?(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, _token?: CancellationToken): Promise<DebugConfiguration> {
+    public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, _token?: CancellationToken): Promise<DebugConfiguration | undefined> {
         this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
+        if (debugConfiguration.preLaunchTask === hostStartTaskName) {
+            if (!await validateFuncCoreToolsInstalled()) {
+                return undefined;
+            }
+        }
+
         return debugConfiguration;
     }
 


### PR DESCRIPTION
C# was already handled in `pickFuncProcess`, this leverages `FuncDebugProviderBase` to add the logic to other languages. Also removes prompt after creating project

Fixes #358