### PR TITLE
Prompt for --build-native-deps if "func pack" fails for Python projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9120,9 +9120,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.29.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.29.1.tgz",
-            "integrity": "sha512-/FvBSUrRVNZLV+Kt6NmK5tNs47+gfZIkZUurTaK6kIfaYO2uCe3yD80s8guxMw3DRz4QKBsgNtZCNA0QwD7zHw==",
+            "version": "0.30.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.30.0.tgz",
+            "integrity": "sha512-0SwOpS/8sZqsH5G0YHyDzCgEWBaEEf85THxzpI2OFB36Vn7TXhMwY9XzPV9f3bHlCGE/im/zosqXdgqq+SHA9Q==",
             "requires": {
                 "archiver": "^2.0.3",
                 "azure-arm-resource": "^3.0.0-preview",

--- a/package.json
+++ b/package.json
@@ -863,7 +863,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "^0.29.1",
+        "vscode-azureappservice": "^0.30.0",
         "vscode-azureextensionui": "^0.20.0",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.0.0",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -322,11 +322,11 @@ function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRunti
 }
 
 async function promptToBuildNativeDeps(actionContext: IActionContext, deployFsPath: string, scmType: string | undefined): Promise<appservice.IPreDeployTaskResult> {
-    const flag: string = '--build-native-deps';
-    const message: string = localize('funcPackFailed', 'Failed to package your project. Use a Docker container to build incompatible dependencies?', flag);
+    const message: string = localize('funcPackFailed', 'Failed to package your project. Use a Docker container to build incompatible dependencies?');
     const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.learnMore);
     if (result === DialogResponses.yes) {
         actionContext.properties.preDeployTaskResponse = 'packNativeDeps';
+        const flag: string = '--build-native-deps';
         await updateWorkspaceSetting(preDeployTaskSetting, `${packTaskName} ${flag}`, deployFsPath);
         return await appservice.tryRunPreDeployTask(actionContext, deployFsPath, scmType, extensionPrefix);
     } else if (result === DialogResponses.learnMore) {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import { ext } from '../extensionVariables';
 import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { HttpAuthLevel } from '../FunctionConfig';
 import { localize } from '../localize';
-import { convertStringToRuntime, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, updateGlobalSetting } from '../ProjectSettings';
+import { convertStringToRuntime, getFuncExtensionSetting, getProjectLanguage, getProjectRuntime, updateGlobalSetting, updateWorkspaceSetting } from '../ProjectSettings';
 import { FunctionsTreeItem } from '../tree/FunctionsTreeItem';
 import { FunctionTreeItem } from '../tree/FunctionTreeItem';
 import { ProductionSlotTreeItem } from '../tree/ProductionSlotTreeItem';
@@ -100,8 +100,8 @@ export async function deploy(this: IActionContext, target?: vscode.Uri | string 
         telemetryProperties.cancelStep = '';
     }
 
-    const preDeployResult: appservice.IPreDeployTaskResult = await appservice.runPreDeployTask(this, deployFsPath, siteConfig.scmType, extensionPrefix);
-    await handlePreDeployTaskResult(preDeployResult, language, runtime);
+    const preDeployResult: appservice.IPreDeployTaskResult = await appservice.tryRunPreDeployTask(this, deployFsPath, siteConfig.scmType, extensionPrefix);
+    await handlePreDeployTaskResult(this, deployFsPath, siteConfig.scmType, preDeployResult, language, runtime);
 
     if (siteConfig.scmType === ScmType.LocalGit) {
         // preDeploy tasks are not required for LocalGit so subpath may not exist
@@ -275,7 +275,12 @@ async function verifyRuntimeIsCompatible(localRuntime: ProjectRuntime, ui: IAzur
     }
 }
 
-async function handlePreDeployTaskResult(result: appservice.IPreDeployTaskResult, language: ProjectLanguage, runtime: ProjectRuntime): Promise<void> {
+async function handlePreDeployTaskResult(actionContext: IActionContext, deployFsPath: string, scmType: string | undefined, result: appservice.IPreDeployTaskResult, language: ProjectLanguage, runtime: ProjectRuntime): Promise<void> {
+    // https://github.com/Microsoft/vscode-azurefunctions/issues/826
+    if (result.taskName === packTaskName && result.exitCode === 4) {
+        result = await promptToBuildNativeDeps(actionContext, deployFsPath, scmType);
+    }
+
     const messageLines: string[] = [];
     if (!result.taskName) {
         const recommendedTaskName: string | undefined = getRecommendedTaskName(language, runtime);
@@ -290,6 +295,8 @@ async function handlePreDeployTaskResult(result: appservice.IPreDeployTaskResult
         messageLines.push(localize('noPreDeployTaskError', 'Did not find preDeploy task "{0}". Change the "{1}.{2}" setting, manually edit your task.json, or re-initialize your VS Code config with the following steps:', result.taskName, extensionPrefix, preDeployTaskSetting));
         const fullMessage: string = getFullPreDeployMessage(messageLines);
         throw new Error(fullMessage);
+    } else if (result.exitCode !== undefined && result.exitCode !== 0) {
+        await appservice.handleFailedPreDeployTask(actionContext, result);
     }
 }
 
@@ -311,6 +318,25 @@ function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRunti
             return packTaskName;
         default:
             return undefined; // preDeployTask not needed
+    }
+}
+
+async function promptToBuildNativeDeps(actionContext: IActionContext, deployFsPath: string, scmType: string | undefined): Promise<appservice.IPreDeployTaskResult> {
+    const flag: string = '--build-native-deps';
+    const message: string = localize('funcPackFailed', 'Failed to package your project. Use a Docker container to build incompatible dependencies?', flag);
+    const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.learnMore);
+    if (result === DialogResponses.yes) {
+        actionContext.properties.preDeployTaskResponse = 'packNativeDeps';
+        await updateWorkspaceSetting(preDeployTaskSetting, `${packTaskName} ${flag}`, deployFsPath);
+        return await appservice.tryRunPreDeployTask(actionContext, deployFsPath, scmType, extensionPrefix);
+    } else if (result === DialogResponses.learnMore) {
+        actionContext.properties.preDeployTaskResponse = 'packLearnMore';
+        // tslint:disable-next-line:no-floating-promises
+        opn('https://aka.ms/func-python-publish');
+        throw new UserCancelledError();
+    } else {
+        actionContext.properties.preDeployTaskResponse = 'cancel';
+        throw new UserCancelledError();
     }
 }
 


### PR DESCRIPTION
The func cli added an exit code (4) so that we could detect the case where a user should add "--build-native-deps" to "func pack". I guess it's somewhat common.

Depends on https://github.com/Microsoft/vscode-azuretools/pull/396
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/826

Dialog:
![screen shot 2019-02-05 at 10 43 29 am](https://user-images.githubusercontent.com/11282622/52301365-20b63000-293f-11e9-998e-4aa7aa2e64f0.png)

Logs from running tasks:
```
Terminal will be reused by tasks, press any key to close it.

Deleting the old .python_packages directory
pip download -r /Users/ericjizba/TestRepos/py1/requirements.txt --dest /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/azureworkerbro5s5h3
pip download --no-deps --only-binary :all: --platform manylinux1_x86_64 --python-version 36 --implementation cp --abi cp36m --dest /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/azureworkerevt70hen pyodbc==4.0.25
pip wheel --no-deps --no-binary :all: --wheel-dir /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/azureworkerw08u7uv0 pyodbc==4.0.25

There was an error restoring dependencies.ERROR: cannot install pyodbc-4.0.25 dependency: binary dependencies without wheels are not supported.  Use the --build-native-deps option to automatically build and configure the dependencies using a Docker container. More information at https://aka.ms/func-python-publish


The terminal process terminated with exit code: 4

Terminal will be reused by tasks, press any key to close it.

Deleting the old .python_packages directory
Running 'docker pull mcr.microsoft.com/azure-functions/python:2.0.12285'..done
Running 'docker run --rm -d mcr.microsoft.com/azure-functions/python:2.0.12285'..done
Running 'docker exec -t 4326ce mkdir -p /home/site/wwwroot/'..done
Running 'docker cp /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/zzj1cdpw.1l2/. 4326ce:/home/site/wwwroot'..done
Running 'docker cp /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/tmps1vTpt.tmp 4326ce:python_docker_build.sh'..done
Running 'docker cp /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/tmpcYtfF2.tmp 4326ce:python_bundle_script.py'..done
Running 'docker exec -t 4326ce chmod +x /python_docker_build.sh'..done
Running 'docker exec -t 4326ce chmod +x /python_bundle_script.py'..done
Running 'docker exec -t 4326ce /python_docker_build.sh'.......................................................done
Running 'docker cp 4326ce:/app.zip /var/folders/kr/kdg_ggqn32zbqlv_5tj4kj880000gn/T/s3uhqssx.wro'..done
Running 'docker kill 4326ce'..done
Creating a new package /Users/ericjizba/TestRepos/py1/py1.zip

Terminal will be reused by tasks, press any key to close it.
```