### PR TITLE
Remove black box from Java deploy and use common settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -750,6 +750,11 @@
                         "description": "%azFunc.showDebugConfigWarningDescription%",
                         "default": true
                     },
+                    "azureFunctions.showJavaDeployConfigWarning": {
+                        "type": "boolean",
+                        "description": "%azFunc.showJavaDeployConfigWarningDescription%",
+                        "default": true
+                    },
                     "azureFunctions.showPythonVenvWarning": {
                         "type": "boolean",
                         "description": "%azFunc.showPythonVenvWarningDescription%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,6 +34,7 @@
     "azFunc.show64BitWarningDescription": "Show a warning to install a 64-bit version of the Azure Functions Core Tools when you create a .NET Framework project.",
     "azFunc.showProjectWarningDescription": "Show a warning when an Azure Functions project was detected that has not been initialized for use in VS Code.",
     "azFunc.showDebugConfigWarningDescription": "Show a warning when an Azure Functions project was detected that has an out-of-date debug configuration.",
+    "azFunc.showDeployConfigWarningDescription": "Show a warning when an Azure Functions Java project was detected that has an out-of-date deploy configuration.",
     "azFunc.showPythonVenvWarningDescription": "Show a warning when an Azure Functions Python project was detected that does not have a virtual environment.",
     "azFunc.showDeploySubpathWarningDescription": "Show a warning when the \"deploySubpath\" setting does not match the selected folder for deploying.",
     "azFunc.startStreamingLogs": "Start Streaming Logs",

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,7 +34,7 @@
     "azFunc.show64BitWarningDescription": "Show a warning to install a 64-bit version of the Azure Functions Core Tools when you create a .NET Framework project.",
     "azFunc.showProjectWarningDescription": "Show a warning when an Azure Functions project was detected that has not been initialized for use in VS Code.",
     "azFunc.showDebugConfigWarningDescription": "Show a warning when an Azure Functions project was detected that has an out-of-date debug configuration.",
-    "azFunc.showDeployConfigWarningDescription": "Show a warning when an Azure Functions Java project was detected that has an out-of-date deploy configuration.",
+    "azFunc.showJavaDeployConfigWarningDescription": "Show a warning when an Azure Functions Java project was detected that has an out-of-date deploy configuration.",
     "azFunc.showPythonVenvWarningDescription": "Show a warning when an Azure Functions Python project was detected that does not have a virtual environment.",
     "azFunc.showDeploySubpathWarningDescription": "Show a warning when the \"deploySubpath\" setting does not match the selected folder for deploying.",
     "azFunc.startStreamingLogs": "Start Streaming Logs",

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -18,8 +18,11 @@ import { validateMavenIdentifier, validatePackageName } from '../../utils/javaNa
 import { mavenUtils } from '../../utils/mavenUtils';
 import { ProjectCreatorBase } from './ProjectCreatorBase';
 
+const packageTaskLabel: string = 'package';
+
 export class JavaProjectCreator extends ProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
+    public preDeployTask: string = packageTaskLabel;
 
     private _javaTargetPath: string;
 
@@ -110,10 +113,11 @@ export class JavaProjectCreator extends ProjectCreatorBase {
                 this._javaTargetPath = `target/azure-functions/${functionAppName}/`;
             }
         }
+
+        this.deploySubpath = this._javaTargetPath;
     }
 
     public getTasksJson(): {} {
-        const packageTaskLabel: string = 'package';
         return {
             version: '2.0.0',
             tasks: [

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -110,6 +110,7 @@ async function verifyJSDebugConfigIsValid(projectLanguage: string | undefined, f
                 const message: string = localize('uninitializedWarning', 'Your debug configuration is out of date and may not work with the latest version of the Azure Functions Core Tools.');
                 const learnMoreLink: string = 'https://aka.ms/AA1vrxa';
                 if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
+                    actionContext.suppressErrorDisplay = false;
                     await initProjectForVSCode(actionContext, folderPath, projectLanguage);
                     actionContext.properties.updatedDebugConfig = 'true';
                 }
@@ -129,6 +130,7 @@ async function verifyJavaDeployConfigIsValid(projectLanguage: string | undefined
         const message: string = localize('updateJavaDeployConfig', 'Your deploy configuration is out of date and may not work with the latest version of the Azure Functions extension for VS Code.');
         const learnMoreLink: string = 'https://aka.ms/AA41zno';
         if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
+            actionContext.suppressErrorDisplay = false;
             await initProjectForVSCode(actionContext, folderPath, projectLanguage);
             actionContext.properties.updatedJavaDebugConfig = 'true';
         }
@@ -167,6 +169,7 @@ async function verifyPythonVenv(folderPath: string, actionContext: IActionContex
             const message: string = localize('uninitializedWarning', 'Failed to find Python virtual environment "{0}", which is required to debug and deploy your Azure Functions project.', venvName);
             const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, createVenv, DialogResponses.dontWarnAgain);
             if (result === createVenv) {
+                actionContext.suppressErrorDisplay = false;
                 await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('creatingVenv', 'Creating virtual environment...') }, async () => {
                     // create venv
                     await createVirtualEnviornment(venvName, folderPath);

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -34,9 +34,18 @@ export async function validateFunctionProjects(actionContext: IActionContext, fo
 
                     const projectLanguage: string | undefined = getFuncExtensionSetting(projectLanguageSetting, folderPath);
                     actionContext.properties.projectLanguage = projectLanguage;
-                    await verifyJSDebugConfigIsValid(projectLanguage, folderPath, actionContext);
-                    await verifyJavaDeployConfigIsValid(projectLanguage, folderPath, actionContext);
-                    await verifyPythonVenv(projectLanguage, folderPath, actionContext);
+                    switch (projectLanguage) {
+                        case ProjectLanguage.JavaScript:
+                            await verifyJSDebugConfigIsValid(projectLanguage, folderPath, actionContext);
+                            break;
+                        case ProjectLanguage.Java:
+                            await verifyJavaDeployConfigIsValid(projectLanguage, folderPath, actionContext);
+                            break;
+                        case ProjectLanguage.Python:
+                            await verifyPythonVenv(folderPath, actionContext);
+                            break;
+                        default:
+                    }
                 } else {
                     actionContext.properties.isInitialized = 'false';
                     if (await promptToInitializeProject(folderPath)) {
@@ -81,30 +90,28 @@ function isInitializedProject(folderPath: string): boolean {
  * See https://aka.ms/AA1vrxa for more info
  */
 async function verifyJSDebugConfigIsValid(projectLanguage: string | undefined, folderPath: string, actionContext: IActionContext): Promise<void> {
-    if (projectLanguage === ProjectLanguage.JavaScript) {
-        const localProjectRuntime: ProjectRuntime | undefined = await tryGetLocalRuntimeVersion();
-        if (localProjectRuntime === ProjectRuntime.v2) {
-            const tasksJsonPath: string = path.join(folderPath, vscodeFolderName, tasksFileName);
-            const rawTasksData: string = (await fse.readFile(tasksJsonPath)).toString();
+    const localProjectRuntime: ProjectRuntime | undefined = await tryGetLocalRuntimeVersion();
+    if (localProjectRuntime === ProjectRuntime.v2) {
+        const tasksJsonPath: string = path.join(folderPath, vscodeFolderName, tasksFileName);
+        const rawTasksData: string = (await fse.readFile(tasksJsonPath)).toString();
 
-            const funcNodeDebugEnvVar: string = 'languageWorkers__node__arguments';
-            const oldFuncNodeDebugEnvVar: string = funcNodeDebugEnvVar.replace(/__/g, ':'); // Also check against an old version of the env var that works in most (but not all) cases
-            if (!rawTasksData.includes(funcNodeDebugEnvVar) && !rawTasksData.includes(oldFuncNodeDebugEnvVar)) {
-                const tasksContent: ITasksJson = <ITasksJson>JSON.parse(rawTasksData);
+        const funcNodeDebugEnvVar: string = 'languageWorkers__node__arguments';
+        const oldFuncNodeDebugEnvVar: string = funcNodeDebugEnvVar.replace(/__/g, ':'); // Also check against an old version of the env var that works in most (but not all) cases
+        if (!rawTasksData.includes(funcNodeDebugEnvVar) && !rawTasksData.includes(oldFuncNodeDebugEnvVar)) {
+            const tasksContent: ITasksJson = <ITasksJson>JSON.parse(rawTasksData);
 
-                // NOTE: Only checking against oldFuncHostNameRegEx (where label looks like "runFunctionsHost")
-                // If they're using the tasks our extension provides (where label looks like "func: host start"), they are already good-to-go
-                const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => oldFuncHostNameRegEx.test(t.label));
-                if (funcTask) {
-                    actionContext.properties.debugConfigValid = 'false';
+            // NOTE: Only checking against oldFuncHostNameRegEx (where label looks like "runFunctionsHost")
+            // If they're using the tasks our extension provides (where label looks like "func: host start"), they are already good-to-go
+            const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => oldFuncHostNameRegEx.test(t.label));
+            if (funcTask) {
+                actionContext.properties.debugConfigValid = 'false';
 
-                    const settingKey: string = 'showDebugConfigWarning';
-                    const message: string = localize('uninitializedWarning', 'Your debug configuration is out of date and may not work with the latest version of the Azure Functions Core Tools.');
-                    const learnMoreLink: string = 'https://aka.ms/AA1vrxa';
-                    if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
-                        await initProjectForVSCode(actionContext, folderPath, projectLanguage);
-                        actionContext.properties.updatedDebugConfig = 'true';
-                    }
+                const settingKey: string = 'showDebugConfigWarning';
+                const message: string = localize('uninitializedWarning', 'Your debug configuration is out of date and may not work with the latest version of the Azure Functions Core Tools.');
+                const learnMoreLink: string = 'https://aka.ms/AA1vrxa';
+                if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
+                    await initProjectForVSCode(actionContext, folderPath, projectLanguage);
+                    actionContext.properties.updatedDebugConfig = 'true';
                 }
             }
         }
@@ -112,20 +119,18 @@ async function verifyJSDebugConfigIsValid(projectLanguage: string | undefined, f
 }
 
 async function verifyJavaDeployConfigIsValid(projectLanguage: string | undefined, folderPath: string, actionContext: IActionContext): Promise<void> {
-    if (projectLanguage === ProjectLanguage.Java) {
-        const preDeployTask: string | undefined = getFuncExtensionSetting<string>(preDeployTaskSetting, folderPath);
-        const deploySubPath: string | undefined = getFuncExtensionSetting<string>(deploySubpathSetting, folderPath);
+    const preDeployTask: string | undefined = getFuncExtensionSetting<string>(preDeployTaskSetting, folderPath);
+    const deploySubPath: string | undefined = getFuncExtensionSetting<string>(deploySubpathSetting, folderPath);
 
-        if (!preDeployTask && !deploySubPath) {
-            actionContext.properties.javaDeployConfigValid = 'false';
+    if (!preDeployTask && !deploySubPath) {
+        actionContext.properties.javaDeployConfigValid = 'false';
 
-            const settingKey: string = 'showJavaDeployConfigWarning';
-            const message: string = localize('updateJavaDeployConfig', 'Your deploy configuration is out of date and may not work with the latest version of the Azure Functions extension for VS Code.');
-            const learnMoreLink: string = 'https://aka.ms/AA41zno';
-            if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
-                await initProjectForVSCode(actionContext, folderPath, projectLanguage);
-                actionContext.properties.updatedJavaDebugConfig = 'true';
-            }
+        const settingKey: string = 'showJavaDeployConfigWarning';
+        const message: string = localize('updateJavaDeployConfig', 'Your deploy configuration is out of date and may not work with the latest version of the Azure Functions extension for VS Code.');
+        const learnMoreLink: string = 'https://aka.ms/AA41zno';
+        if (await promptToUpdateProject(folderPath, settingKey, message, learnMoreLink)) {
+            await initProjectForVSCode(actionContext, folderPath, projectLanguage);
+            actionContext.properties.updatedJavaDebugConfig = 'true';
         }
     }
 }
@@ -151,30 +156,28 @@ async function promptToUpdateProject(fsPath: string, settingKey: string, message
     return false;
 }
 
-async function verifyPythonVenv(projectLanguage: string | undefined, folderPath: string, actionContext: IActionContext): Promise<void> {
-    if (projectLanguage === ProjectLanguage.Python) {
-        const venvName: string | undefined = getFuncExtensionSetting(pythonVenvSetting, folderPath);
-        if (venvName && !await fse.pathExists(path.join(folderPath, venvName))) {
-            actionContext.properties.pythonVenvExists = 'false';
+async function verifyPythonVenv(folderPath: string, actionContext: IActionContext): Promise<void> {
+    const venvName: string | undefined = getFuncExtensionSetting(pythonVenvSetting, folderPath);
+    if (venvName && !await fse.pathExists(path.join(folderPath, venvName))) {
+        actionContext.properties.pythonVenvExists = 'false';
 
-            const settingKey: string = 'showPythonVenvWarning';
-            if (getFuncExtensionSetting<boolean>(settingKey)) {
-                const createVenv: vscode.MessageItem = { title: localize('createVenv', 'Create virtual environment') };
-                const message: string = localize('uninitializedWarning', 'Failed to find Python virtual environment "{0}", which is required to debug and deploy your Azure Functions project.', venvName);
-                const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, createVenv, DialogResponses.dontWarnAgain);
-                if (result === createVenv) {
-                    await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('creatingVenv', 'Creating virtual environment...') }, async () => {
-                        // create venv
-                        await createVirtualEnviornment(venvName, folderPath);
-                        await makeVenvDebuggable(venvName, folderPath);
-                    });
+        const settingKey: string = 'showPythonVenvWarning';
+        if (getFuncExtensionSetting<boolean>(settingKey)) {
+            const createVenv: vscode.MessageItem = { title: localize('createVenv', 'Create virtual environment') };
+            const message: string = localize('uninitializedWarning', 'Failed to find Python virtual environment "{0}", which is required to debug and deploy your Azure Functions project.', venvName);
+            const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, createVenv, DialogResponses.dontWarnAgain);
+            if (result === createVenv) {
+                await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('creatingVenv', 'Creating virtual environment...') }, async () => {
+                    // create venv
+                    await createVirtualEnviornment(venvName, folderPath);
+                    await makeVenvDebuggable(venvName, folderPath);
+                });
 
-                    actionContext.properties.createdPythonVenv = 'true';
-                    // don't wait
-                    vscode.window.showInformationMessage(localize('finishedCreatingVenv', 'Finished creating virtual environment.'));
-                } else if (result === DialogResponses.dontWarnAgain) {
-                    await updateGlobalSetting(settingKey, false);
-                }
+                actionContext.properties.createdPythonVenv = 'true';
+                // don't wait
+                vscode.window.showInformationMessage(localize('finishedCreatingVenv', 'Finished creating virtual environment.'));
+            } else if (result === DialogResponses.dontWarnAgain) {
+                await updateGlobalSetting(settingKey, false);
             }
         }
     }


### PR DESCRIPTION
Java projects have unique logic to run a preDeployTask and pick the folder to deploy which is pretty black-box-y. Instead, it should use the `preDeployTask` and `deploySubpath` settings. These settings let the user customize their project as they see fit and makes the experience consistent across all languages. Since this could break people, I added a [wiki](https://github.com/Microsoft/vscode-azurefunctions/wiki/Breaking-Changes-to-Java-Deploy-Configuration) and notification to update their project (similar to other breaking changes in the past).

The current release seems like the best time to do this since I already refactored how the tasks/launch works in [this PR](https://github.com/Microsoft/vscode-azurefunctions/pull/936) and we might as well change it all up at once. Plus it'd be nice to get this done before Java goes GA in the platform (no idea when that is).