### PR TITLE
Bump minimum VS Code version to 1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.31.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
1.31.0 was release so I'll bump the version now.

Fixes #935