### PR TITLE
Increase unit test timeout and clean up folder only at the end

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -25,7 +25,7 @@ import { gulp_installAzureAccount, gulp_webpack } from 'vscode-azureextensiondev
 function test() {
     const env = process.env;
     env.DEBUGTELEMETRY = '1';
-    env.MOCHA_timeout = String(10 * 1000);
+    env.MOCHA_timeout = String(20 * 1000);
     env.CODE_TESTS_PATH = path.join(__dirname, 'dist/test');
     return cp.spawn('node', ['./node_modules/vscode/bin/test'], { stdio: 'inherit', env });
 }

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -5,31 +5,23 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ext, getRandomHexString, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TemplateFilter, templateFilterSetting, TestUserInput } from '../../extension.bundle';
-import { runForAllTemplateSources } from '../global.test';
+import { ext, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TemplateFilter, templateFilterSetting, TestUserInput } from '../../extension.bundle';
+import { runForAllTemplateSources, testFolderPath } from '../global.test';
 import { runWithSetting } from '../runWithSetting';
 
-export abstract class FunctionTesterBase implements vscode.Disposable {
-    public readonly baseTestFolder: string;
+export abstract class FunctionTesterBase {
+    public baseTestFolder: string;
 
     protected abstract _language: ProjectLanguage;
     protected abstract _runtime: ProjectRuntime;
 
-    constructor() {
-        this.baseTestFolder = path.join(os.tmpdir(), `azFunc.createFuncTests${getRandomHexString()}`);
-    }
-
     public async initAsync(): Promise<void> {
+        this.baseTestFolder = path.join(testFolderPath, `createFunction${this._language}${this._runtime}`);
         await runForAllTemplateSources(async (source) => {
             await this.initializeTestFolder(path.join(this.baseTestFolder, source));
         });
-    }
-
-    public async dispose(): Promise<void> {
-        await fse.remove(this.baseTestFolder);
     }
 
     public async testCreateFunction(templateName: string, ...inputs: (string | undefined)[]): Promise<void> {
@@ -68,7 +60,7 @@ export abstract class FunctionTesterBase implements vscode.Disposable {
                 });
             });
         });
-        assert.equal(inputs.length, 0, 'Not all inputs were used.');
+        assert.equal(inputs.length, 0, `Not all inputs were used: ${inputs}`);
 
         await this.validateFunction(testFolder, funcName);
     }

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -34,12 +34,6 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
         await csTester.initAsync();
     });
 
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await csTester.dispose();
-    });
-
     const blobTrigger: string = 'BlobTrigger';
     test(blobTrigger, async () => {
         await csTester.testCreateFunction(

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, ext, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../../extension.bundle';
@@ -30,12 +29,6 @@ suite('Create C# Script Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createFunction/createFunction.FSharpScript.test.ts
+++ b/test/createFunction/createFunction.FSharpScript.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create F# Script Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createFunction/createFunction.JavaScript.test.ts
+++ b/test/createFunction/createFunction.JavaScript.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
+import { ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { JavaScriptProjectCreator, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../extension.bundle';
@@ -26,18 +26,10 @@ class JSFunctionTester extends FunctionTesterBase {
 
 // tslint:disable-next-line:max-func-body-length no-function-expression
 suite('Create JavaScript Function Tests', async function (this: ISuiteCallbackContext): Promise<void> {
-    this.timeout(6 * 1000);
-
     const jsTester: JSFunctionTester = new JSFunctionTester();
 
     suiteSetup(async () => {
         await jsTester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await jsTester.dispose();
     });
 
     const blobTrigger: string = 'Blob trigger';

--- a/test/createFunction/createFunction.PHP.test.ts
+++ b/test/createFunction/createFunction.PHP.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create PHP Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP GET';

--- a/test/createFunction/createFunction.PowerShell.test.ts
+++ b/test/createFunction/createFunction.PowerShell.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create PowerShell Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createFunction/createFunction.Python.test.ts
+++ b/test/createFunction/createFunction.Python.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create Python Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createFunction/createFunction.TypeScript.test.ts
+++ b/test/createFunction/createFunction.TypeScript.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create TypeScript Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createFunction/createFunction.bash.test.ts
+++ b/test/createFunction/createFunction.bash.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create Bash Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const queueTrigger: string = 'Queue trigger';

--- a/test/createFunction/createFunction.batch.test.ts
+++ b/test/createFunction/createFunction.batch.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
-import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
 import { ProjectLanguage, ProjectRuntime, ScriptProjectCreatorBase } from '../../extension.bundle';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -26,12 +25,6 @@ suite('Create Batch Function Tests', async () => {
 
     suiteSetup(async () => {
         await tester.initAsync();
-    });
-
-    // tslint:disable-next-line:no-function-expression
-    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
-        this.timeout(15 * 1000);
-        await tester.dispose();
     });
 
     const httpTrigger: string = 'HTTP trigger';

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -9,22 +9,13 @@ import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { createNewProject, deploySubpathSetting, DialogResponses, ext, extensionPrefix, getRandomHexString, IActionContext, Platform, ProjectLanguage, TestUserInput } from '../extension.bundle';
-import { longRunningTestsEnabled, runForAllTemplateSources } from './global.test';
+import { createNewProject, deploySubpathSetting, DialogResponses, ext, extensionPrefix, IActionContext, Platform, ProjectLanguage, TestUserInput } from '../extension.bundle';
+import { longRunningTestsEnabled, runForAllTemplateSources, testFolderPath } from './global.test';
 import { validateSetting, validateVSCodeProjectFiles } from './initProjectForVSCode.test';
 
 // tslint:disable-next-line:no-function-expression max-func-body-length
 suite('Create New Project Tests', async function (this: ISuiteCallbackContext): Promise<void> {
     this.timeout(60 * 1000);
-    const testFolderPath: string = path.join(os.tmpdir(), `azFunc.createNewProjectTests${getRandomHexString()}`);
-
-    suiteSetup(async () => {
-        await fse.ensureDir(testFolderPath);
-    });
-
-    suiteTeardown(async () => {
-        await fse.remove(testFolderPath);
-    });
 
     const javaProject: string = 'JavaProject';
     test(javaProject, async function (this: IHookCallbackContext): Promise<void> {
@@ -168,7 +159,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
         const ui: TestUserInput = new TestUserInput(inputs);
         ext.ui = ui;
         await createNewProject(<IActionContext>{ properties: {}, measurements: {} }, undefined, previewLanguage ? language : undefined, undefined, false);
-        assert.equal(inputs.length, 0, 'Not all inputs were used.');
+        assert.equal(inputs.length, 0, `Not all inputs were used: ${inputs}`);
 
         assert.equal(await fse.pathExists(path.join(projectPath, '.gitignore')), true, '.gitignore does not exist');
         assert.equal(await fse.pathExists(path.join(projectPath, 'host.json')), true, 'host.json does not exist');

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -6,23 +6,14 @@
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import { ISuiteCallbackContext } from 'mocha';
-import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { deploySubpathSetting, DialogResponses, ext, extensionPrefix, getRandomHexString, IActionContext, initProjectForVSCode, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../extension.bundle';
+import { deploySubpathSetting, DialogResponses, ext, extensionPrefix, IActionContext, initProjectForVSCode, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../extension.bundle';
+import { testFolderPath } from './global.test';
 
 // tslint:disable-next-line:no-function-expression max-func-body-length
 suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackContext): Promise<void> {
     this.timeout(30 * 1000);
-    const testFolderPath: string = path.join(os.tmpdir(), `azFunc.initProjectForVSCodeTests${getRandomHexString()}`);
-
-    suiteSetup(async () => {
-        await fse.ensureDir(testFolderPath);
-    });
-
-    suiteTeardown(async () => {
-        await fse.remove(testFolderPath);
-    });
 
     const javaScriptProject: string = 'AutoDetectJavaScriptProject';
     test(javaScriptProject, async () => {
@@ -168,7 +159,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         ext.ui = new TestUserInput(inputs);
         const actionContext: IActionContext = <IActionContext>{ properties: { isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '', cancelStep: '' }, measurements: {} };
         await initProjectForVSCode(actionContext);
-        assert.equal(inputs.length, 0, 'Not all inputs were used.');
+        assert.equal(inputs.length, 0, `Not all inputs were used: ${inputs}`);
     }
 });
 


### PR DESCRIPTION
Unit tests have been really flakey lately, especially on windows, and I don't know why. This PR does a few things to mitigate that:
1. Increase the timeout to 20 seconds for everything
1. Clean up the root test folder at the end instead of cleaning intermediary folders along the way