### PR TITLE
Use platform specific "path.join" for pip install command

### DIFF
--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -80,8 +80,16 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
         const venvSettingReference: string = `\${config:${fullPythonVenvSetting}}`;
 
         function getPipInstallCommand(platform: NodeJS.Platform): string {
-            const subFolder: string = platform === Platform.Windows ? 'Scripts' : 'bin';
-            return `${path.join('.', venvSettingReference, subFolder, 'python')} -m pip install -r requirements.txt`;
+            let subFolder: string;
+            let osPathJoin: (...p: string[]) => string;
+            if (platform === Platform.Windows) {
+                subFolder = 'Scripts';
+                osPathJoin = path.win32.join;
+            } else {
+                subFolder = 'bin';
+                osPathJoin = path.posix.join;
+            }
+            return `${osPathJoin('.', venvSettingReference, subFolder, 'python')} -m pip install -r requirements.txt`;
         }
 
         return {


### PR DESCRIPTION
This is what the task looks like after my change:
```
{
  "label": "pipInstall",
  "type": "shell",
  "osx": {
    "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
  },
  "windows": {
    "command": "${config:azureFunctions.pythonVenv}\\Scripts\\python -m pip install -r requirements.txt"
  },
  "linux": {
    "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
  },
  "problemMatcher": []
}
```
Previously, the path separator would work on the _original_ OS, but not if someone cloned their repo to a different OS.