### PR TITLE
Fix and consolidate venvUtils for all terminals/OS's

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -30,5 +30,7 @@ export * from './src/templates/IFunctionTemplate';
 export * from './src/templates/TemplateProvider';
 export * from './src/tree/FunctionAppProvider';
 export * from './src/utils/fs';
+export * from './src/utils/cpUtils';
+export * from './src/utils/venvUtils';
 export * from 'vscode-azureappservice';
 export * from 'vscode-azureextensionui';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "0.13.2-alpha",
+    "version": "0.14.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%extension.description%",
-    "version": "0.13.2-alpha",
+    "version": "0.14.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -15,8 +15,8 @@ import { localize } from "./localize";
 
 const previewDescription: string = localize('previewDescription', '(Preview)');
 
-export async function updateGlobalSetting<T = string>(section: string, value: T): Promise<void> {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(extensionPrefix);
+export async function updateGlobalSetting<T = string>(section: string, value: T, prefix: string = extensionPrefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix);
     await projectConfiguration.update(section, value, ConfigurationTarget.Global);
 }
 

--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -9,7 +9,7 @@ import opn = require("opn");
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
-import { deploySubpathSetting, preDeployTaskSetting, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, tasksFileName, vscodeFolderName } from '../../constants';
+import { deploySubpathSetting, preDeployTaskSetting, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, pythonVenvSetting, tasksFileName, vscodeFolderName } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { oldFuncHostNameRegEx } from "../../funcCoreTools/funcHostTask";
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
@@ -18,7 +18,7 @@ import { getFuncExtensionSetting, updateGlobalSetting, updateWorkspaceSetting } 
 import { initProjectForVSCode } from './initProjectForVSCode';
 import { isFunctionProject } from './isFunctionProject';
 import { ITask, ITasksJson } from './ITasksJson';
-import { createVirtualEnviornment, makeVenvDebuggable, pythonVenvSetting } from './PythonProjectCreator';
+import { createVirtualEnviornment } from './PythonProjectCreator';
 
 export async function validateFunctionProjects(actionContext: IActionContext, folders: vscode.WorkspaceFolder[] | undefined): Promise<void> {
     actionContext.suppressTelemetry = true;
@@ -173,7 +173,6 @@ async function verifyPythonVenv(folderPath: string, actionContext: IActionContex
                 await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('creatingVenv', 'Creating virtual environment...') }, async () => {
                     // create venv
                     await createVirtualEnviornment(venvName, folderPath);
-                    await makeVenvDebuggable(venvName, folderPath);
                 });
 
                 actionContext.properties.createdPythonVenv = 'true';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,7 @@ export const deploySubpathSetting: string = 'deploySubpath';
 export const templateVersionSetting: string = 'templateVersion';
 export const preDeployTaskSetting: string = 'preDeployTask';
 export const filesExcludeSetting: string = 'files.exclude';
+export const pythonVenvSetting: string = 'pythonVenv';
 
 export enum ProjectLanguage {
     Bash = 'Bash',

--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -24,7 +24,7 @@ export class PythonDebugProvider extends FuncDebugProviderBase {
     protected readonly debugConfig: DebugConfiguration = pythonDebugConfig;
 
     public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
-        const command: string = venvUtils.convertToVenvTask(folder, funcHostStartCommand);
+        const command: string = venvUtils.convertToVenvCommand(funcHostStartCommand, folder.uri.fsPath);
         const port: number = this.getDebugPort(folder);
         const options: ShellExecutionOptions = { env: { languageWorkers__python__arguments: await getPythonCommand(localhost, port) } };
         return new ShellExecution(command, options);

--- a/src/debug/getPythonTasks.ts
+++ b/src/debug/getPythonTasks.ts
@@ -8,7 +8,7 @@ import { func, funcPackCommand, packCommand } from '../constants';
 import { venvUtils } from '../utils/venvUtils';
 
 export function getPythonTasks(folder: WorkspaceFolder): Task[] {
-    const commandLine: string = venvUtils.convertToVenvTask(folder, funcPackCommand);
+    const commandLine: string = venvUtils.convertToVenvCommand(funcPackCommand, folder.uri.fsPath);
     const basicPack: Task = new Task(
         {
             type: func,

--- a/src/utils/venvUtils.ts
+++ b/src/utils/venvUtils.ts
@@ -3,57 +3,106 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
 import * as path from 'path';
-import { workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
-import { Platform } from "../constants";
+import { workspace, WorkspaceConfiguration } from 'vscode';
+import { Platform, pythonVenvSetting } from "../constants";
 import { ext } from '../extensionVariables';
 import { getFuncExtensionSetting } from '../ProjectSettings';
 import { cpUtils } from './cpUtils';
 
 export namespace venvUtils {
-    const bashAndCmdSeparator: string = ' && ';
-    const powerShellSeparator: string = ' ; ';
-
-    export function convertToVenvTask(folder: WorkspaceFolder, ...commands: string[]): string {
-        const venvName: string | undefined = getFuncExtensionSetting<string>('pythonVenv', folder.uri.fsPath);
-        if (venvName) {
-            commands.unshift(getVenvActivateCommand(venvName));
-        }
-
-        let separator: string = bashAndCmdSeparator;
-        if (process.platform === Platform.Windows) {
-            const config: WorkspaceConfiguration = workspace.getConfiguration();
-            const shell: string | undefined = config.get('terminal.integrated.shell.windows');
-            if (shell && /(powershell|pwsh)/i.test(shell)) {
-                separator = powerShellSeparator;
-            }
-        }
-
-        return commands.join(separator);
+    enum Terminal {
+        bash,
+        cmd,
+        powerShell
     }
 
-    export async function runPythonCommandInVenv(venvName: string, folderPath: string, command: string): Promise<void> {
+    export function convertToVenvCommand(command: string, folderPath: string, platform: NodeJS.Platform = process.platform): string {
+        const terminal: Terminal = getTerminal(platform);
+        const venvName: string | undefined = getFuncExtensionSetting<string>(pythonVenvSetting, folderPath);
+        if (venvName) {
+            return joinCommands(terminal, getVenvActivateCommand(venvName, terminal, platform), command);
+        } else {
+            return command;
+        }
+    }
+
+    export function convertToVenvPythonCommand(command: string, venvName: string, platform: NodeJS.Platform): string {
+        const terminal: Terminal = getTerminal(platform);
+        const pythonPath: string = getVenvPath(venvName, 'python', platform, getPathJoin(terminal));
+        return `${pythonPath} -m ${command}`;
+    }
+
+    export async function runCommandInVenv(command: string, venvName: string, folderPath: string): Promise<void> {
         // child_process uses cmd or bash, not PowerShell
-        command = getVenvActivateCommand(venvName) + bashAndCmdSeparator + command;
+        const terminal: Terminal = process.platform === Platform.Windows ? Terminal.cmd : Terminal.bash;
+        command = joinCommands(terminal, getVenvActivateCommand(venvName, terminal, process.platform), command);
         await cpUtils.executeCommand(ext.outputChannel, folderPath, command);
     }
 
-    export function getVenvActivatePath(venvName: string): string {
-        switch (process.platform) {
-            case Platform.Windows:
-                return path.join('.', venvName, 'Scripts', 'activate');
-            default:
-                return path.join('.', venvName, 'bin', 'activate');
+    export async function venvExists(venvName: string, rootFolder: string): Promise<boolean> {
+        const venvPath: string = path.join(rootFolder, venvName);
+        if (await fse.pathExists(venvPath)) {
+            const stat: fse.Stats = await fse.stat(venvPath);
+            if (stat.isDirectory()) {
+                const venvActivatePath: string = getVenvPath(venvName, 'activate', process.platform, path.join);
+                if (await fse.pathExists(path.join(rootFolder, venvActivatePath))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function getTerminal(platform: NodeJS.Platform): Terminal {
+        if (platform === Platform.Windows) {
+            const config: WorkspaceConfiguration = workspace.getConfiguration();
+            const terminalSetting: string | undefined = config.get('terminal.integrated.shell.windows');
+            if (!terminalSetting || /(powershell|pwsh)/i.test(terminalSetting)) {
+                // powershell is the default if setting isn't defined
+                return Terminal.powerShell;
+            } else if (/bash/i.test(terminalSetting)) {
+                return Terminal.bash;
+            } else {
+                return Terminal.cmd;
+            }
+        } else {
+            return Terminal.bash;
         }
     }
 
-    function getVenvActivateCommand(venvName: string): string {
-        const venvActivatePath: string = getVenvActivatePath(venvName);
-        switch (process.platform) {
-            case Platform.Windows:
-                return venvActivatePath;
-            default:
+    function getVenvActivateCommand(venvName: string, terminal: Terminal, platform: NodeJS.Platform): string {
+        const venvActivatePath: string = getVenvPath(venvName, 'activate', platform, getPathJoin(terminal));
+        switch (terminal) {
+            case Terminal.bash:
                 return `. ${venvActivatePath}`;
+            default:
+                return venvActivatePath;
+        }
+    }
+
+    function getVenvPath(venvName: string, lastFs: string, platform: NodeJS.Platform, pathJoin: (...p: string[]) => string): string {
+        const middleFs: string = platform === Platform.Windows ? 'Scripts' : 'bin';
+        const paths: string[] = ['.', venvName, middleFs, lastFs];
+        return pathJoin(...paths);
+    }
+
+    function getPathJoin(terminal: Terminal): (...p: string[]) => string {
+        switch (terminal) {
+            case Terminal.bash:
+                return path.posix.join;
+            default:
+                return path.win32.join;
+        }
+    }
+
+    function joinCommands(terminal: Terminal, ...commands: string[]): string {
+        switch (terminal) {
+            case Terminal.powerShell:
+                return commands.join(' ; ');
+            default:
+                return commands.join(' && '); // bash and cmd
         }
     }
 }

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ext, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TemplateFilter, templateFilterSetting, TestUserInput } from '../../extension.bundle';
 import { runForAllTemplateSources, testFolderPath } from '../global.test';
-import { runWithSetting } from '../runWithSetting';
+import { runWithFuncSetting } from '../runWithSetting';
 
 export abstract class FunctionTesterBase {
     public baseTestFolder: string;
@@ -53,9 +53,9 @@ export abstract class FunctionTesterBase {
         }
 
         ext.ui = new TestUserInput(inputs);
-        await runWithSetting(templateFilterSetting, TemplateFilter.All, async () => {
-            await runWithSetting(projectLanguageSetting, this._language, async () => {
-                await runWithSetting(projectRuntimeSetting, this._runtime, async () => {
+        await runWithFuncSetting(templateFilterSetting, TemplateFilter.All, async () => {
+            await runWithFuncSetting(projectLanguageSetting, this._language, async () => {
+                await runWithFuncSetting(projectRuntimeSetting, this._runtime, async () => {
                     await vscode.commands.executeCommand('azureFunctions.createFunction');
                 });
             });

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../extension.bundle';
 import { runForAllTemplateSources } from '../global.test';
-import { runWithSetting } from '../runWithSetting';
+import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpFunctionTester extends FunctionTesterBase {
@@ -82,8 +82,8 @@ suite('Create C# Function Tests', async function (this: ISuiteCallbackContext): 
             const iotPath: string = 'messages/events';
             const connection: string = 'IoTHub_Setting';
             const projectPath: string = path.join(csTester.baseTestFolder, source);
-            await runWithSetting(projectLanguageSetting, ProjectLanguage.CSharp, async () => {
-                await runWithSetting(projectRuntimeSetting, ProjectRuntime.v2, async () => {
+            await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.CSharp, async () => {
+                await runWithFuncSetting(projectRuntimeSetting, ProjectRuntime.v2, async () => {
                     await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { namespace: namespace, Path: iotPath, Connection: connection });
                 });
             });

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { DialogResponses, ext, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../../extension.bundle';
 import { runForAllTemplateSources } from '../global.test';
 import { validateVSCodeProjectFiles } from '../initProjectForVSCode.test';
-import { runWithSetting } from '../runWithSetting';
+import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpScriptFunctionTester extends FunctionTesterBase {
@@ -49,8 +49,8 @@ suite('Create C# Script Function Tests', async () => {
         await runForAllTemplateSources(async (source) => {
             // Intentionally testing IoTHub trigger since a partner team plans to use that
             const projectPath: string = path.join(tester.baseTestFolder, source);
-            await runWithSetting(projectLanguageSetting, ProjectLanguage.CSharpScript, async () => {
-                await runWithSetting(projectRuntimeSetting, ProjectRuntime.v1, async () => {
+            await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.CSharpScript, async () => {
+                await runWithFuncSetting(projectRuntimeSetting, ProjectRuntime.v1, async () => {
                     await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, iotTemplateId, iotFunctionName, iotFunctionSettings);
                 });
             });

--- a/test/createFunction/createFunction.JavaScript.test.ts
+++ b/test/createFunction/createFunction.JavaScript.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { JavaScriptProjectCreator, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../../extension.bundle';
 import { runForAllTemplateSources } from '../global.test';
-import { runWithSetting } from '../runWithSetting';
+import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class JSFunctionTester extends FunctionTesterBase {
@@ -140,8 +140,8 @@ suite('Create JavaScript Function Tests', async function (this: ISuiteCallbackCo
             const authLevel: string = 'Anonymous';
             const projectPath: string = path.join(jsTester.baseTestFolder, source);
             // Intentionally testing weird casing for authLevel
-            await runWithSetting(projectLanguageSetting, ProjectLanguage.JavaScript, async () => {
-                await runWithSetting(projectRuntimeSetting, JavaScriptProjectCreator.defaultRuntime, async () => {
+            await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.JavaScript, async () => {
+                await runWithFuncSetting(projectRuntimeSetting, JavaScriptProjectCreator.defaultRuntime, async () => {
                     await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { aUtHLevel: authLevel });
                 });
             });

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -12,7 +12,7 @@ import { TestOutputChannel } from 'vscode-azureextensiondev';
 import { ext, getRandomHexString, getTemplateProvider, TemplateProvider, TemplateSource, TestUserInput } from '../extension.bundle';
 
 export let longRunningTestsEnabled: boolean;
-export let testFolderPath: string;
+export const testFolderPath: string = path.join(os.tmpdir(), `azFuncTest${getRandomHexString()}`);
 
 let templatesMap: Map<TemplateSource, TemplateProvider>;
 
@@ -20,7 +20,6 @@ let templatesMap: Map<TemplateSource, TemplateProvider>;
 suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
     this.timeout(120 * 1000);
 
-    testFolderPath = path.join(os.tmpdir(), `azFuncTest${getRandomHexString()}`);
     await fse.ensureDir(testFolderPath);
 
     await vscode.commands.executeCommand('azureFunctions.refresh'); // activate the extension before tests begin

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -45,7 +45,8 @@ suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
     longRunningTestsEnabled = !/^(false|0)?$/i.test(process.env.ENABLE_LONG_RUNNING_TESTS || '');
 });
 
-suiteTeardown(async () => {
+suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
+    this.timeout(40 * 1000);
     await fse.remove(testFolderPath);
 });
 

--- a/test/runWithSetting.ts
+++ b/test/runWithSetting.ts
@@ -3,14 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getGlobalFuncExtensionSetting, updateGlobalSetting } from "../extension.bundle";
+import { extensionPrefix, getGlobalFuncExtensionSetting, updateGlobalSetting } from "../extension.bundle";
 
-export async function runWithSetting(key: string, value: string, callback: () => Promise<void>): Promise<void> {
-    const oldValue: string | undefined = getGlobalFuncExtensionSetting(key);
+export async function runWithFuncSetting(key: string, value: string | undefined, callback: () => Promise<void>): Promise<void> {
+    await runWithSettingInternal(key, value, extensionPrefix, callback);
+}
+
+export async function runWithSetting(key: string, value: string | undefined, callback: () => Promise<void>): Promise<void> {
+    await runWithSettingInternal(key, value, '', callback);
+}
+
+async function runWithSettingInternal(key: string, value: string | undefined, prefix: string, callback: () => Promise<void>): Promise<void> {
+    const oldValue: string | undefined = getGlobalFuncExtensionSetting(key, prefix);
     try {
-        await updateGlobalSetting(key, value);
+        await updateGlobalSetting(key, value, prefix);
         await callback();
     } finally {
-        await updateGlobalSetting(key, oldValue);
+        await updateGlobalSetting(key, oldValue, prefix);
     }
 }

--- a/test/venvUtils.test.ts
+++ b/test/venvUtils.test.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fse from 'fs-extra';
+import { IHookCallbackContext, ITestCallbackContext } from 'mocha';
+import * as path from 'path';
+import { cpUtils, ext, getGlobalFuncExtensionSetting, Platform, pythonVenvSetting, updateGlobalSetting, venvUtils } from '../extension.bundle';
+import { longRunningTestsEnabled, testFolderPath } from './global.test';
+import { runWithSetting } from './runWithSetting';
+
+suite('venvUtils Tests', () => {
+    const command: string = 'do a thing';
+    const terminalSetting: string = 'terminal.integrated.shell.windows';
+    const venvName: string = '.env';
+    const testFolder: string = path.join(testFolderPath, 'venvUtils');
+    let oldVenvValue: string | undefined;
+
+    suiteSetup(async function (this: IHookCallbackContext): Promise<void> {
+        oldVenvValue = getGlobalFuncExtensionSetting(pythonVenvSetting);
+        await updateGlobalSetting(pythonVenvSetting, venvName);
+
+        if (longRunningTestsEnabled) {
+            this.timeout(60 * 1000);
+            await fse.ensureDir(testFolder);
+            const pyAlias: string = process.platform === Platform.Windows ? 'py' : 'python';
+            await cpUtils.executeCommand(ext.outputChannel, testFolder, pyAlias, '-m', 'venv', venvName);
+        }
+    });
+
+    suiteTeardown(async () => {
+        await updateGlobalSetting(pythonVenvSetting, oldVenvValue);
+    });
+
+    test('venvExists true', async function (this: ITestCallbackContext): Promise<void> {
+        if (!longRunningTestsEnabled) {
+            this.skip();
+        }
+
+        assert.equal(await venvUtils.venvExists(venvName, testFolder), true);
+    });
+
+    test('venvExists false', async () => {
+        assert.equal(await venvUtils.venvExists('nonExistentPath', testFolder), false);
+
+        const fileName: string = 'notAVenvFile';
+        await fse.ensureFile(path.join(testFolder, fileName));
+        assert.equal(await venvUtils.venvExists(fileName, testFolder), false);
+
+        const folderName: string = 'notAVenvFolder';
+        await fse.ensureDir(path.join(testFolder, folderName));
+        assert.equal(await venvUtils.venvExists(folderName, testFolder), false);
+    });
+
+    test('runCommandInVenv', async function (this: ITestCallbackContext): Promise<void> {
+        if (!longRunningTestsEnabled) {
+            this.skip();
+        }
+
+        await venvUtils.runCommandInVenv('python --version', venvName, testFolder);
+    });
+
+    test('convertToVenvCommand Windows powershell', async () => {
+        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Windows), '.env\\Scripts\\activate ; do a thing');
+            assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Windows), '.env\\Scripts\\python -m do a thing');
+        });
+    });
+
+    test('convertToVenvCommand Windows pwsh', async () => {
+        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\pwsh.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Windows), '.env\\Scripts\\activate ; do a thing');
+            assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Windows), '.env\\Scripts\\python -m do a thing');
+        });
+    });
+
+    test('convertToVenvCommand Windows cmd', async () => {
+        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\cmd.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Windows), '.env\\Scripts\\activate && do a thing');
+            assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Windows), '.env\\Scripts\\python -m do a thing');
+        });
+    });
+
+    test('convertToVenvCommand Windows git bash', async () => {
+        await runWithSetting(terminalSetting, 'C:\\Program Files\\Git\\bin\\bash.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Windows), '. .env/Scripts/activate && do a thing');
+            assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Windows), '.env/Scripts/python -m do a thing');
+        });
+    });
+
+    test('convertToVenvCommand Windows bash', async () => {
+        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\bash.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Windows), '. .env/Scripts/activate && do a thing');
+            assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Windows), '.env/Scripts/python -m do a thing');
+        });
+    });
+
+    test('convertToVenvCommand Mac', async () => {
+        assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.MacOS), '. .env/bin/activate && do a thing');
+        assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.MacOS), '.env/bin/python -m do a thing');
+    });
+
+    test('convertToVenvCommand Linux', async () => {
+        assert.equal(venvUtils.convertToVenvCommand(command, testFolder, Platform.Linux), '. .env/bin/activate && do a thing');
+        assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, Platform.Linux), '.env/bin/python -m do a thing');
+    });
+});


### PR DESCRIPTION
I ran into two bugs while testing the release candidate:
1. The tasks.json we generate is meant to work if someone pushes their project to GitHub and clones it on a different OS. That wasn't the case for our "pipInstall" task because it always used the path separator from the _original_ OS
1. Windows users with their terminal set to bash would fail to debug

In order to fix, I ended up doing quite a bit of refactoring of venvUtils and added several tests to cover all the weird edge cases. Here's the list of terminals: https://code.visualstudio.com/docs/editor/integrated-terminal#_configuration

I also removed the logic to install "pylint" by default. It's just another command that could fail and it slows down project creation. We originally did it because the Python extension was super annoying and prompted you to install pylint every time, but now they at least have a "Don't show again" button. Fixes #814 