### PR TITLE
Add Java "package" task as recommended preDeployTask

### DIFF
--- a/src/commands/createNewProject/CSharpProjectCreator.ts
+++ b/src/commands/createNewProject/CSharpProjectCreator.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { DialogResponses, parseError } from 'vscode-azureextensionui';
-import { func, funcWatchProblemMatcher, gitignoreFileName, hostFileName, hostStartCommand, isWindows, localSettingsFileName, ProjectRuntime, publishTaskId, TemplateFilter } from '../../constants';
+import { cSharpPublishTaskLabel, func, funcWatchProblemMatcher, gitignoreFileName, hostFileName, hostStartCommand, isWindows, localSettingsFileName, ProjectRuntime, TemplateFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { tryGetLocalRuntimeVersion } from '../../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from "../../localize";
@@ -23,7 +23,7 @@ import { ProjectCreatorBase } from './ProjectCreatorBase';
 export class CSharpProjectCreator extends ProjectCreatorBase {
     public deploySubpath: string;
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
-    public preDeployTask: string = publishTaskId;
+    public preDeployTask: string = cSharpPublishTaskLabel;
 
     private _debugSubpath: string;
 
@@ -69,7 +69,7 @@ export class CSharpProjectCreator extends ProjectCreatorBase {
                     problemMatcher: '$msCompile'
                 },
                 {
-                    label: publishTaskId,
+                    label: cSharpPublishTaskLabel,
                     command: 'dotnet publish --configuration Release',
                     type: 'shell',
                     dependsOn: 'clean release',

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { InputBoxOptions, window } from 'vscode';
 import { IActionContext } from "vscode-azureextensionui";
-import { func, funcWatchProblemMatcher, hostStartCommand, ProjectRuntime, TemplateFilter } from '../../constants';
+import { func, funcWatchProblemMatcher, hostStartCommand, javaPackageTaskLabel, ProjectRuntime, TemplateFilter } from '../../constants';
 import { javaDebugConfig } from '../../debug/JavaDebugProvider';
 import { ext } from '../../extensionVariables';
 import { localize } from "../../localize";
@@ -18,11 +18,9 @@ import { validateMavenIdentifier, validatePackageName } from '../../utils/javaNa
 import { mavenUtils } from '../../utils/mavenUtils';
 import { ProjectCreatorBase } from './ProjectCreatorBase';
 
-const packageTaskLabel: string = 'package';
-
 export class JavaProjectCreator extends ProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
-    public preDeployTask: string = packageTaskLabel;
+    public preDeployTask: string = javaPackageTaskLabel;
 
     private _javaTargetPath: string;
 
@@ -129,10 +127,10 @@ export class JavaProjectCreator extends ProjectCreatorBase {
                     options: {
                         cwd: `\${workspaceFolder}/${this._javaTargetPath}`
                     },
-                    dependsOn: packageTaskLabel
+                    dependsOn: javaPackageTaskLabel
                 },
                 {
-                    label: packageTaskLabel,
+                    label: javaPackageTaskLabel,
                     command: 'mvn clean package',
                     type: 'shell'
                 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as appservice from 'vscode-azureappservice';
 import { AzureTreeItem, DialogResponses, IActionContext, IAzureUserInput, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
-import { deploySubpathSetting, extensionPrefix, extInstallTaskName, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, publishTaskId, ScmType } from '../constants';
+import { cSharpPublishTaskLabel, deploySubpathSetting, extensionPrefix, extInstallTaskName, javaPackageTaskLabel, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, ScmType } from '../constants';
 import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
 import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
@@ -283,12 +283,14 @@ function getFullPreDeployMessage(messageLines: string[]): string {
 function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRuntime): string | undefined {
     switch (language) {
         case ProjectLanguage.CSharp:
-            return publishTaskId;
+            return cSharpPublishTaskLabel;
         case ProjectLanguage.JavaScript:
             // "func extensions install" is only supported on v2
             return runtime === ProjectRuntime.v1 ? undefined : extInstallTaskName;
         case ProjectLanguage.Python:
             return packTaskName;
+        case ProjectLanguage.Java:
+            return javaPackageTaskLabel;
         default:
             return undefined; // preDeployTask not needed
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,8 @@ export enum ScmType {
     GitHub = 'GitHub'
 }
 
-export const publishTaskId: string = 'publish';
+export const cSharpPublishTaskLabel: string = 'publish';
+export const javaPackageTaskLabel: string = 'package';
 
 export const func: string = 'func';
 export const extInstallCommand: string = 'extensions install';


### PR DESCRIPTION
Low risk fix to leverage existing logic to warn users if they don't have a preDeployTask and we think they should. It helps mitigate the [breaking changes](https://github.com/Microsoft/vscode-azurefunctions/pull/965) in Java. We already have a notification when they open the project, but this logic happens when they actually deploy.