### PR TITLE
Fix bad merge of TypeScriptFunctionCreator

### DIFF
--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -146,7 +146,7 @@ export async function createFunction(
             functionCreator = new CSharpFunctionCreator(functionAppPath, template, actionContext);
             break;
         case ProjectLanguage.TypeScript:
-            functionCreator = new TypeScriptFunctionCreator(functionAppPath, <IScriptFunctionTemplate>template, language);
+            functionCreator = new TypeScriptFunctionCreator(functionAppPath, <IScriptFunctionTemplate>template, actionContext, language);
             break;
         default:
             functionCreator = new ScriptFunctionCreator(functionAppPath, <IScriptFunctionTemplate>template, actionContext, language);


### PR DESCRIPTION
Some sort of bad merge between these two recent PRs:
https://github.com/Microsoft/vscode-azurefunctions/pull/994
https://github.com/Microsoft/vscode-azurefunctions/pull/1000