### PR TITLE
Workaround for tests on mac

### DIFF
--- a/test/TestOutputChannel.ts
+++ b/test/TestOutputChannel.ts
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// copied from https://github.com/Microsoft/vscode-azuretools/blob/master/dev/src/TestOutputChannel.ts
+// due to https://github.com/Microsoft/vscode-azurefunctions/issues/1008
+
+import { OutputChannel } from "vscode";
+
+export class TestOutputChannel implements OutputChannel {
+    public name: string = 'Extension Test Output';
+
+    public append(value: string): void {
+        // Technically this is wrong (because of the new line), but good enough for now
+        console.log(value);
+    }
+
+    public appendLine(value: string): void {
+        console.log(value);
+    }
+
+    public clear(): void {
+        // do nothing
+    }
+
+    public show(): void {
+        // do nothing
+    }
+
+    public hide(): void {
+        // do nothing
+    }
+
+    public dispose(): void {
+        // do nothing
+    }
+}

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -8,8 +8,8 @@ import { IHookCallbackContext } from 'mocha';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { TestOutputChannel } from 'vscode-azureextensiondev';
 import { ext, getRandomHexString, getTemplateProvider, TemplateProvider, TemplateSource, TestUserInput } from '../extension.bundle';
+import { TestOutputChannel } from './TestOutputChannel';
 
 export let longRunningTestsEnabled: boolean;
 export const testFolderPath: string = path.join(os.tmpdir(), `azFuncTest${getRandomHexString()}`);


### PR DESCRIPTION
Ever since a few weeks ago (probably since webpack commit), tests are not running on mac (locally or in Azure Dev Ops). I couldn't figure out a root cause fix, but copying the file to this repo works for now.

Related: https://github.com/Microsoft/vscode-azurefunctions/issues/1008