### PR TITLE
Add Event Grid trigger and clean up storage/cosmos triggers

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,12 +11,6 @@ export class NoWorkspaceError extends Error {
     public message: string = localize('azFunc.noWorkspaceError', 'You must have a workspace open to perform this operation.');
 }
 
-export class ArgumentError extends Error {
-    constructor(obj: object) {
-        super(localize('azFunc.argumentError', 'Invalid {0}.', obj.constructor.name));
-    }
-}
-
 export class NoSubscriptionError extends Error {
     public message: string = localize('azFunc.noSubscriptionError', 'You must be signed in to Azure to perform this operation.');
 }

--- a/src/templates/DotnetTemplateRetriever.ts
+++ b/src/templates/DotnetTemplateRetriever.ts
@@ -81,9 +81,14 @@ export function getDotnetVerifiedTemplateIds(runtime: string): string[] {
 
     if (runtime === ProjectRuntime.v1) {
         verifiedTemplateIds = verifiedTemplateIds.concat([
+            'EventGridTrigger',
             'GenericWebHook',
             'GitHubWebHook',
             'HttpTriggerWithParameters'
+        ]);
+    } else {
+        verifiedTemplateIds = verifiedTemplateIds.concat([
+            'DurableFunctionsOrchestration'
         ]);
     }
 

--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -102,20 +102,16 @@ export function getScriptVerifiedTemplateIds(runtime: string): string[] {
             'ManualTrigger-JavaScript'
         ]);
     } else {
-        // Python is only supported in v2
         // For JavaScript, only include triggers that require extensions in v2. v1 doesn't have the same support for 'func extensions install'
         verifiedTemplateIds = verifiedTemplateIds.concat([
             'CosmosDBTrigger-JavaScript',
+            'EventGridTrigger-JavaScript',
             'ServiceBusQueueTrigger-JavaScript',
-            'ServiceBusTopicTrigger-JavaScript',
-            'BlobTrigger-Python',
-            'HttpTrigger-Python',
-            'QueueTrigger-Python',
-            'TimerTrigger-Python',
-            'CosmosDBTrigger-Python',
-            'ServiceBusQueueTrigger-Python',
-            'ServiceBusTopicTrigger-Python'
+            'ServiceBusTopicTrigger-JavaScript'
         ]);
+
+        // Python is only supported in v2 - same functions as JavaScript
+        verifiedTemplateIds = verifiedTemplateIds.concat(verifiedTemplateIds.map(t => t.replace('JavaScript', 'Python')));
     }
 
     return verifiedTemplateIds;

--- a/src/tree/FunctionTreeItem.ts
+++ b/src/tree/FunctionTreeItem.ts
@@ -9,12 +9,12 @@ import { ProgressLocation, window } from 'vscode';
 import { functionsAdminRequest, ISiteTreeRoot } from 'vscode-azureappservice';
 import { AzureParentTreeItem, AzureTreeItem, DialogResponses } from 'vscode-azureextensionui';
 import { ProjectRuntime } from '../constants';
-import { ArgumentError } from '../errors';
 import { ext } from '../extensionVariables';
 import { FunctionConfig, HttpAuthLevel } from '../FunctionConfig';
 import { localize } from '../localize';
 import { convertStringToRuntime } from '../ProjectSettings';
 import { nodeUtils } from '../utils/nodeUtils';
+import { nonNullProp } from '../utils/nonNull';
 
 export class FunctionTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     public static contextValue: string = 'azFuncFunction';
@@ -27,11 +27,7 @@ export class FunctionTreeItem extends AzureTreeItem<ISiteTreeRoot> {
 
     private constructor(parent: AzureParentTreeItem, func: WebSiteManagementModels.FunctionEnvelope) {
         super(parent);
-        if (!func.id) {
-            throw new ArgumentError(func);
-        }
-
-        this._name = getFunctionNameFromId(func.id);
+        this._name = getFunctionNameFromId(nonNullProp(func, 'id'));
 
         this.config = new FunctionConfig(func.config);
     }

--- a/test/functionTemplates.test.ts
+++ b/test/functionTemplates.test.ts
@@ -22,17 +22,17 @@ async function validateTemplateCounts(templates: TemplateProvider, source: strin
     assert.equal(jsTemplatesv1.length, 8, `Unexpected JavaScript v1 ${source} templates count.`);
 
     const jsTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.JavaScript, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(jsTemplatesv2.length, 7, `Unexpected JavaScript v2 ${source} templates count.`);
+    assert.equal(jsTemplatesv2.length, 8, `Unexpected JavaScript v2 ${source} templates count.`);
 
     const javaTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Java, ProjectRuntime.v2, TemplateFilter.Verified);
     assert.equal(javaTemplates.length, 4, `Unexpected Java ${source} templates count.`);
 
     const cSharpTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v1, TemplateFilter.Verified);
-    assert.equal(cSharpTemplates.length, 10, `Unexpected CSharp (.NET Framework) ${source} templates count.`);
+    assert.equal(cSharpTemplates.length, 11, `Unexpected CSharp (.NET Framework) ${source} templates count.`);
 
     const cSharpTemplatesv2: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.CSharp, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(cSharpTemplatesv2.length, 7, `Unexpected CSharp (.NET Core) ${source} templates count.`);
+    assert.equal(cSharpTemplatesv2.length, 8, `Unexpected CSharp (.NET Core) ${source} templates count.`);
 
     const pythonTemplates: IFunctionTemplate[] = await templates.getTemplates(ProjectLanguage.Python, ProjectRuntime.v2, TemplateFilter.Verified);
-    assert.equal(pythonTemplates.length, 7, `Unexpected Python ${source} templates count.`);
+    assert.equal(pythonTemplates.length, 8, `Unexpected Python ${source} templates count.`);
 }


### PR DESCRIPTION
- Add Event Grid and DurableFunctionsOrchestration triggers to "Verified" category where possible. Related to https://github.com/Microsoft/vscode-azurefunctions/issues/690
- Storage and Cosmos triggers are now more sovereign friendly (not going to claim they actually work because I haven't tested on a sovereign)
- Removed `ArgumentError` because it was a worse version of `nonNullProp` and `nonNullValue`