### PR TITLE
Unblock users with project in a sub folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
         "onCommand:azureFunctions.connectToGitHub",
         "onCommand:azureFunctions.createSlot",
         "onCommand:azureFunctions.swapSlot",
-        "workspaceContains:local.settings.json",
         "workspaceContains:host.json",
+        "workspaceContains:*/host.json",
         "onView:azureFunctionsExplorer",
         "onDebugInitialConfigurations"
     ],

--- a/src/commands/createNewProject/isFunctionProject.ts
+++ b/src/commands/createNewProject/isFunctionProject.ts
@@ -11,3 +11,22 @@ import { hostFileName } from '../../constants';
 export async function isFunctionProject(folderPath: string): Promise<boolean> {
     return await fse.pathExists(path.join(folderPath, hostFileName));
 }
+
+/**
+ * Checks root folder and subFolders one level down
+ * If a single function project is found, returns that path
+ */
+export async function tryGetFunctionProjectRoot(folderPath: string): Promise<string | undefined> {
+    if (await isFunctionProject(folderPath)) {
+        return folderPath;
+    } else {
+        const subpaths: string[] = await fse.readdir(folderPath);
+        const matchingSubpaths: string[] = [];
+        await Promise.all(subpaths.map(async (subpath: string) => {
+            if (await isFunctionProject(path.join(folderPath, subpath))) {
+                matchingSubpaths.push(subpath);
+            }
+        }));
+        return matchingSubpaths.length === 1 ? path.join(folderPath, matchingSubpaths[0]) : undefined;
+    }
+}

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken, ShellExecution, Task, TaskProvider, workspace, WorkspaceFolder } from 'vscode';
-import { isFunctionProject } from '../commands/createNewProject/isFunctionProject';
+import { tryGetFunctionProjectRoot } from '../commands/createNewProject/isFunctionProject';
 import { extInstallCommand, func, funcExtInstallCommand, funcHostStartCommand, funcWatchProblemMatcher, hostStartCommand, ProjectLanguage, projectLanguageSetting } from '../constants';
 import { getFuncExtensionSetting } from '../ProjectSettings';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -28,7 +28,7 @@ export class FuncTaskProvider implements TaskProvider {
         const result: Task[] = [];
         if (workspace.workspaceFolders) {
             for (const folder of workspace.workspaceFolders) {
-                if (await isFunctionProject(folder.uri.fsPath)) {
+                if (await tryGetFunctionProjectRoot(folder.uri.fsPath)) {
                     result.push(getExtensionInstallTask(folder));
                     const language: string | undefined = getFuncExtensionSetting(projectLanguageSetting, folder.uri.fsPath);
                     const hostStartTask: Task | undefined = await this.getHostStartTask(folder, language);

--- a/src/debug/getPythonTasks.ts
+++ b/src/debug/getPythonTasks.ts
@@ -7,7 +7,7 @@ import { ShellExecution, Task, WorkspaceFolder } from 'vscode';
 import { func, funcPackCommand, packCommand } from '../constants';
 import { venvUtils } from '../utils/venvUtils';
 
-export function getPythonTasks(folder: WorkspaceFolder): Task[] {
+export function getPythonTasks(folder: WorkspaceFolder, projectRoot: string): Task[] {
     const commandLine: string = venvUtils.convertToVenvCommand(funcPackCommand, folder.uri.fsPath);
     const basicPack: Task = new Task(
         {
@@ -17,7 +17,7 @@ export function getPythonTasks(folder: WorkspaceFolder): Task[] {
         folder,
         packCommand,
         func,
-        new ShellExecution(commandLine)
+        new ShellExecution(commandLine, { cwd: projectRoot })
     );
 
     const buildNativeDeps: string = '--build-native-deps';
@@ -31,7 +31,7 @@ export function getPythonTasks(folder: WorkspaceFolder): Task[] {
         folder,
         advancedPackCommand,
         func,
-        new ShellExecution(advancedCommandLine)
+        new ShellExecution(advancedCommandLine, { cwd: projectRoot })
     );
 
     return [basicPack, advancedPack];


### PR DESCRIPTION
We've had quite a few users run into issues when their project is in a sub folder of the root. Unfortunately, our 0.14.0 release made this slightly worse because we're providing tasks in `FuncTaskProvider.ts` and we only provide them if we detect the root as a function project. I don't have time to completely fix the issue, but this work will unblock users and they can follow my steps here to manually configure their project: https://github.com/Microsoft/vscode-azurefunctions/issues/686#issuecomment-466252387