### PR TITLE
Use "node" for TypeScript project when creating function app in Azure

### DIFF
--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -89,6 +89,7 @@ function setCreateOptionDefaults(createOptions: IAppCreateOptions, language: str
     createOptions.os = 'windows';
     switch (language) {
         case ProjectLanguage.JavaScript:
+        case ProjectLanguage.TypeScript:
             createOptions.runtime = 'node';
             break;
         case ProjectLanguage.CSharp:


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/1032