### PR TITLE
Add new project support for F#

### DIFF
--- a/package.json
+++ b/package.json
@@ -681,6 +681,7 @@
                             "Bash",
                             "Batch",
                             "C#",
+                            "F#",
                             "C#Script",
                             "F#Script",
                             "Java",
@@ -694,6 +695,7 @@
                         "enumDescriptions": [
                             "%azFunc.projectLanguage.previewDescription%",
                             "%azFunc.projectLanguage.previewDescription%",
+                            "",
                             "",
                             "%azFunc.projectLanguage.previewDescription%",
                             "%azFunc.projectLanguage.previewDescription%",

--- a/src/ProjectSettings.ts
+++ b/src/ProjectSettings.ts
@@ -29,6 +29,7 @@ export async function promptForProjectLanguage(ui: IAzureUserInput): Promise<Pro
     const picks: QuickPickItem[] = [
         { label: ProjectLanguage.JavaScript },
         { label: ProjectLanguage.CSharp },
+        { label: ProjectLanguage.FSharp },
         { label: ProjectLanguage.CSharpScript },
         { label: ProjectLanguage.FSharpScript },
         { label: ProjectLanguage.Bash, description: previewDescription },

--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -24,8 +24,8 @@ export class JavaProjectCreator extends ProjectCreatorBase {
 
     private _javaTargetPath: string;
 
-    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined) {
-        super(functionAppPath, actionContext, runtime);
+    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
+        super(functionAppPath, actionContext, runtime, language);
         assert.notEqual(runtime, ProjectRuntime.v1, localize('noV1', 'Java does not support runtime "{0}".', ProjectRuntime.v1));
         this.runtime = ProjectRuntime.v2;
     }

--- a/src/commands/createNewProject/ProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ProjectCreatorBase.ts
@@ -13,14 +13,16 @@ export abstract class ProjectCreatorBase {
     public otherSettings: { [key: string]: string } = {};
     public abstract templateFilter: TemplateFilter;
     public runtime: ProjectRuntime | undefined;
+    public language: string;
 
     protected readonly functionAppPath: string;
     protected readonly actionContext: IActionContext;
 
-    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined) {
+    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
         this.functionAppPath = functionAppPath;
         this.actionContext = actionContext;
         this.runtime = runtime;
+        this.language = language;
     }
 
     public getLaunchJson(): {} | undefined {

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -37,8 +37,8 @@ export class PythonProjectCreator extends ScriptProjectCreatorBase {
 
     private _venvName: string | undefined;
 
-    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined) {
-        super(functionAppPath, actionContext, runtime);
+    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
+        super(functionAppPath, actionContext, runtime, language);
         assert.notEqual(runtime, ProjectRuntime.v1, localize('noV1', 'Python does not support runtime "{0}".', ProjectRuntime.v1));
         this.runtime = ProjectRuntime.v2;
     }

--- a/src/commands/createNewProject/TypeScriptProjectCreator.ts
+++ b/src/commands/createNewProject/TypeScriptProjectCreator.ts
@@ -14,8 +14,8 @@ const pruneTaskLabel: string = 'prune';
 export class TypeScriptProjectCreator extends JavaScriptProjectCreator {
     public readonly preDeployTask: string = pruneTaskLabel;
 
-    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined) {
-        super(functionAppPath, actionContext, runtime);
+    constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
+        super(functionAppPath, actionContext, runtime, language);
         this.funcignore = this.funcignore.concat('*.js.map', '*.ts', 'tsconfig.json');
     }
 

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -14,8 +14,8 @@ import { convertStringToRuntime, getGlobalFuncExtensionSetting } from '../../Pro
 import { gitUtils } from '../../utils/gitUtils';
 import * as workspaceUtil from '../../utils/workspace';
 import { createFunction } from '../createFunction/createFunction';
-import { CSharpProjectCreator } from './CSharpProjectCreator';
 import { CSharpScriptProjectCreator } from './CSharpScriptProjectCreator';
+import { DotnetProjectCreator } from './DotnetProjectCreator';
 import { initProjectForVSCode } from './initProjectForVSCode';
 import { JavaProjectCreator } from './JavaProjectCreator';
 import { JavaScriptProjectCreator } from './JavaScriptProjectCreator';
@@ -92,7 +92,7 @@ export async function createNewProject(
 }
 
 export function getProjectCreator(language: string, functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined): ProjectCreatorBase {
-    let projectCreatorType: new (functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined) => ProjectCreatorBase;
+    let projectCreatorType: new (functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) => ProjectCreatorBase;
     switch (language) {
         case ProjectLanguage.Java:
             projectCreatorType = JavaProjectCreator;
@@ -101,7 +101,8 @@ export function getProjectCreator(language: string, functionAppPath: string, act
             projectCreatorType = JavaScriptProjectCreator;
             break;
         case ProjectLanguage.CSharp:
-            projectCreatorType = CSharpProjectCreator;
+        case ProjectLanguage.FSharp:
+            projectCreatorType = DotnetProjectCreator;
             break;
         case ProjectLanguage.CSharpScript:
             projectCreatorType = CSharpScriptProjectCreator;
@@ -117,5 +118,5 @@ export function getProjectCreator(language: string, functionAppPath: string, act
             break;
     }
 
-    return new projectCreatorType(functionAppPath, actionContext, runtime);
+    return new projectCreatorType(functionAppPath, actionContext, runtime, language);
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as appservice from 'vscode-azureappservice';
 import { AzureTreeItem, DialogResponses, IActionContext, IAzureUserInput, TelemetryProperties, UserCancelledError } from 'vscode-azureextensionui';
-import { cSharpPublishTaskLabel, deploySubpathSetting, extensionPrefix, extInstallTaskName, javaPackageTaskLabel, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, ScmType } from '../constants';
+import { deploySubpathSetting, dotnetPublishTaskLabel, extensionPrefix, extInstallTaskName, javaPackageTaskLabel, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime, ScmType } from '../constants';
 import { ext } from '../extensionVariables';
 import { addLocalFuncTelemetry } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { HttpAuthLevel } from '../FunctionConfig';
@@ -299,7 +299,8 @@ function getFullPreDeployMessage(messageLines: string[]): string {
 function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRuntime): string | undefined {
     switch (language) {
         case ProjectLanguage.CSharp:
-            return cSharpPublishTaskLabel;
+        case ProjectLanguage.FSharp:
+            return dotnetPublishTaskLabel;
         case ProjectLanguage.JavaScript:
             // "func extensions install" is only supported on v2
             return runtime === ProjectRuntime.v1 ? undefined : extInstallTaskName;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,7 @@ export enum ScmType {
     GitHub = 'GitHub'
 }
 
-export const cSharpPublishTaskLabel: string = 'publish';
+export const dotnetPublishTaskLabel: string = 'publish';
 export const javaPackageTaskLabel: string = 'package';
 
 export const func: string = 'func';

--- a/src/tree/FunctionAppProvider.ts
+++ b/src/tree/FunctionAppProvider.ts
@@ -93,6 +93,7 @@ function setCreateOptionDefaults(createOptions: IAppCreateOptions, language: str
             createOptions.runtime = 'node';
             break;
         case ProjectLanguage.CSharp:
+        case ProjectLanguage.FSharp:
             createOptions.runtime = 'dotnet';
             break;
         case ProjectLanguage.Java:

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { createNewProject, DialogResponses, ext, IActionContext, Platform, ProjectLanguage, TestUserInput } from '../extension.bundle';
 import { longRunningTestsEnabled, runForAllTemplateSources, testFolderPath } from './global.test';
-import { getCSharpScriptValidateOptions, getCSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getScriptValidateOptions, getTypeScriptValidateOptions, validateProject } from './validateProject';
+import { getCSharpScriptValidateOptions, getCSharpValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getScriptValidateOptions, getTypeScriptValidateOptions, validateProject } from './validateProject';
 
 // tslint:disable-next-line:no-function-expression max-func-body-length
 suite('Create New Project Tests', async function (this: ISuiteCallbackContext): Promise<void> {
@@ -50,6 +50,15 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
             const projectPath: string = path.join(testFolderPath, source, csharpProject);
             await testCreateNewProject(projectPath, ProjectLanguage.CSharp);
             await validateProject(projectPath, getCSharpValidateOptions(csharpProject, 'netcoreapp2.1'));
+        });
+    });
+
+    const fsharpProject: string = 'FSharpProject';
+    test(fsharpProject, async () => {
+        await runForAllTemplateSources(async (source) => {
+            const projectPath: string = path.join(testFolderPath, source, fsharpProject);
+            await testCreateNewProject(projectPath, ProjectLanguage.FSharp, { hiddenLanguage: true });
+            await validateProject(projectPath, getFSharpValidateOptions(fsharpProject, 'netcoreapp2.1'));
         });
     });
 

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, ext, initProjectForVSCode, Platform, ProjectLanguage, TestUserInput } from '../extension.bundle';
 import { testFolderPath } from './global.test';
-import { getCSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
+import { getCSharpValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
 // tslint:disable-next-line:no-function-expression max-func-body-length
 suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackContext): Promise<void> {
@@ -77,6 +77,16 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         }
         await testInitProjectForVSCode(projectPath);
         await validateProject(projectPath, getPythonValidateOptions(pythonProject, venvName));
+    });
+
+    const fsharpProject: string = 'AutoDetectFSharpProject';
+    test(fsharpProject, async () => {
+        const projectPath: string = path.join(testFolderPath, fsharpProject);
+        const fsProjPath: string = path.join(projectPath, 'test.fsproj');
+        await fse.ensureFile(fsProjPath);
+        await fse.writeFile(fsProjPath, '<TargetFramework>netstandard2.0<\/TargetFramework>');
+        await testInitProjectForVSCode(projectPath);
+        await validateProject(projectPath, getFSharpValidateOptions('test', 'netstandard2.0'));
     });
 
     const javaProject: string = 'AutoDetectJavaProject';

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -116,6 +116,15 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
+    const multiFunctionProject: string = 'MultiFunctionProject';
+    test(multiFunctionProject, async () => {
+        const projectPath: string = path.join(testFolderPath, multiFunctionProject);
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerJS1', 'index.js'));
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerJS2', 'index.js'));
+        await testInitProjectForVSCode(projectPath);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
     const goodExtensionFile: string = 'Existing Extensions File';
     test(goodExtensionFile, async () => {
         const projectPath: string = path.join(testFolderPath, goodExtensionFile);

--- a/test/validateProject.ts
+++ b/test/validateProject.ts
@@ -63,6 +63,28 @@ export function getCSharpValidateOptions(projectName: string, targetFramework: s
     };
 }
 
+export function getFSharpValidateOptions(projectName: string, targetFramework: string): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.FSharp,
+            projectRuntime: ProjectRuntime.v2,
+            preDeployTask: 'publish',
+            deploySubpath: `bin/Release/${targetFramework}/publish`,
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+            `${projectName}.fsproj`
+        ],
+        expectedExtensionRecs: [
+            'ms-vscode.csharp',
+            'ionide.ionide-fsharp'
+        ],
+        excludedPaths: [
+            '.funcignore'
+        ]
+    };
+}
+
 export function getPythonValidateOptions(projectName: string, venvName: string): IValidateProjectOptions {
     return {
         expectedSettings: {


### PR DESCRIPTION
I've had this on my backlog forever and finally decided to work on it. With this project, users can debug and deploy:
![screen shot 2019-02-26 at 10 34 38 am](https://user-images.githubusercontent.com/11282622/53438079-ed9e1400-39b3-11e9-9a98-05d019b9e431.png)

Biggest piece missing is creating a trigger. I have an example commit [here](https://github.com/EricJizbaMSFT/fsExample/commit/37ab927fbabae4551f025e705ddcea30614b1a14) based on [this blogpost](https://mikhail.io/2017/12/precompiled-azure-functions-in-fsharp/), but ultimately we'll have to wait for https://github.com/Azure/azure-functions-templates/issues/627 to actually support this.

Because of that, I'm not showing "F#" in the prompt to create a project. User has to set "azureFunctions.projectLanguage" in user settings to "F#" _before_ creating a project to access this feature.

Related: https://github.com/Microsoft/vscode-azurefunctions/issues/315