### PR TITLE
Consolidate project test code into validateProject.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3912,12 +3912,12 @@
             }
         },
         "glob-gitignore": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.11.tgz",
-            "integrity": "sha512-lwUELCBEqLwUAKd2VdUl/t3HFfYPKbmjQfXsVaES5Amjvj3PZHzR0yQTSxcI4dFfMrZEZS3+e7Sthw+6a3Qgbg==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/glob-gitignore/-/glob-gitignore-1.0.14.tgz",
+            "integrity": "sha512-YuAEPqL58bOQDqDF2kMv009rIjSAtPs+WPzyGbwRWK+wD0UWQVRoP34Pz6yJ6ivco65C9tZnaIt0I3JCuQ8NZQ==",
             "requires": {
                 "glob": "^7.1.3",
-                "ignore": "^4.0.0",
+                "ignore": "^5.0.5",
                 "lodash.difference": "^4.5.0",
                 "lodash.union": "^4.6.0",
                 "make-array": "^1.0.5",
@@ -3925,9 +3925,9 @@
             },
             "dependencies": {
                 "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+                    "version": "5.0.5",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
+                    "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA=="
                 }
             }
         },
@@ -9212,9 +9212,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.31.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.31.1.tgz",
-            "integrity": "sha512-nI+DhEdGP60ugYbpG7271rul2cpeSTY7hQlgfZpg4HbY4/4fdDAU4FYIfCIpIPdToATrp4MleLq9N7A30dNRDw==",
+            "version": "0.31.2",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.31.2.tgz",
+            "integrity": "sha512-0Fqo07xegZxBOGUyq4qJmufcZP5En4QkScOAG04WjTHRHx9cPPLnIw0RU036KxZyWqpYxoJRXuFsd0sbKwwTYA==",
             "requires": {
                 "archiver": "^2.0.3",
                 "azure-arm-resource": "^3.0.0-preview",
@@ -9222,7 +9222,7 @@
                 "azure-arm-website": "^5.3.0",
                 "azure-storage": "^2.10.1",
                 "fs-extra": "^4.0.2",
-                "glob-gitignore": "^1.0.11",
+                "glob-gitignore": "^1.0.14",
                 "ms-rest": "^2.2.2",
                 "ms-rest-azure": "^2.4.4",
                 "opn": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -853,7 +853,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "^0.31.1",
+        "vscode-azureappservice": "^0.31.2",
         "vscode-azureextensionui": "^0.20.4",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.0.0",

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -9,8 +9,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, ext, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../../extension.bundle';
 import { runForAllTemplateSources } from '../global.test';
-import { validateVSCodeProjectFiles } from '../initProjectForVSCode.test';
 import { runWithFuncSetting } from '../runWithSetting';
+import { getCSharpScriptValidateOptions, validateProject } from '../validateProject';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class CSharpScriptFunctionTester extends FunctionTesterBase {
@@ -64,7 +64,7 @@ suite('Create C# Script Function Tests', async () => {
             ext.ui = new TestUserInput([DialogResponses.skipForNow.title]);
             await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'C#Script', '~1', false /* openFolder */, iotTemplateId, iotFunctionName, iotFunctionSettings);
             await tester.validateFunction(projectPath, iotFunctionName);
-            await validateVSCodeProjectFiles(projectPath);
+            await validateProject(projectPath, getCSharpScriptValidateOptions(ProjectRuntime.v1));
         });
     });
 });

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -106,7 +106,7 @@ suite('Create New Project Tests', async function (this: ISuiteCallbackContext): 
 
         const projectPath: string = path.join(testFolderPath, pythonProject);
         await testCreateNewProject(projectPath, ProjectLanguage.Python);
-        await validateProject(projectPath, getPythonValidateOptions(pythonProject));
+        await validateProject(projectPath, getPythonValidateOptions(pythonProject, '.env'));
     });
 
     const typeScriptProject: string = 'TypeScriptProject';

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -8,8 +8,9 @@ import * as fse from 'fs-extra';
 import { ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { deploySubpathSetting, DialogResponses, ext, extensionPrefix, IActionContext, initProjectForVSCode, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, TestUserInput } from '../extension.bundle';
+import { DialogResponses, ext, initProjectForVSCode, ProjectLanguage, TestUserInput } from '../extension.bundle';
 import { testFolderPath } from './global.test';
+import { getCSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
 // tslint:disable-next-line:no-function-expression max-func-body-length
 suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackContext): Promise<void> {
@@ -18,24 +19,28 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
     const javaScriptProject: string = 'AutoDetectJavaScriptProject';
     test(javaScriptProject, async () => {
         const projectPath: string = path.join(testFolderPath, javaScriptProject);
-        const indexJsPath: string = path.join(projectPath, 'HttpTriggerJS', 'index.js');
-        await fse.ensureFile(indexJsPath);
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerJS', 'index.js'));
         await testInitProjectForVSCode(projectPath);
-        await validateVSCodeProjectFiles(projectPath);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.JavaScript);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
     const javaScriptProjectWithExtensions: string = 'AutoDetectJavaScriptProjectWithExtensions';
     test(javaScriptProjectWithExtensions, async () => {
         const projectPath: string = path.join(testFolderPath, javaScriptProjectWithExtensions);
-        const indexJsPath: string = path.join(projectPath, 'HttpTriggerJS', 'index.js');
-        await fse.ensureFile(indexJsPath);
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerJS', 'index.js'));
         await fse.ensureFile(path.join(projectPath, 'extensions.csproj'));
         await testInitProjectForVSCode(projectPath);
-        await validateVSCodeProjectFiles(projectPath);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.JavaScript);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const typeScriptProject: string = 'AutoDetectTypeScriptProject';
+    test(typeScriptProject, async () => {
+        const projectPath: string = path.join(testFolderPath, typeScriptProject);
+        await fse.ensureFile(path.join(projectPath, 'HttpTrigger', 'index.ts'));
+        await fse.ensureFile(path.join(projectPath, 'tsconfig.json'));
+        await fse.ensureFile(path.join(projectPath, 'package.json'));
+        await testInitProjectForVSCode(projectPath);
+        await validateProject(projectPath, getTypeScriptValidateOptions());
     });
 
     const csharpProject: string = 'AutoDetectCSharpProject';
@@ -45,11 +50,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await fse.ensureFile(csProjPath);
         await fse.writeFile(csProjPath, '<TargetFramework>netstandard2.0<\/TargetFramework>');
         await testInitProjectForVSCode(projectPath);
-        await validateVSCodeProjectFiles(projectPath, true);
-        await validateExtensionRecommendation(projectPath, 'ms-vscode.csharp');
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.CSharp);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
-        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netstandard2.0/publish');
+        await validateProject(projectPath, getCSharpValidateOptions('test', 'netstandard2.0'));
     });
 
     const csharpProjectWithExtensions: string = 'AutoDetectCSharpProjectWithExtensions';
@@ -60,37 +61,43 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await fse.writeFile(csProjPath, '<TargetFramework>netstandard2.0<\/TargetFramework>');
         await fse.ensureFile(path.join(projectPath, 'extensions.csproj'));
         await testInitProjectForVSCode(projectPath);
-        await validateVSCodeProjectFiles(projectPath, true);
-        await validateExtensionRecommendation(projectPath, 'ms-vscode.csharp');
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.CSharp);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
-        await validateSetting(projectPath, `${extensionPrefix}.${deploySubpathSetting}`, 'bin/Release/netstandard2.0/publish');
+        await validateProject(projectPath, getCSharpValidateOptions('test', 'netstandard2.0'));
+    });
+
+    const pythonProject: string = 'AutoDetectPythonProject';
+    test(pythonProject, async () => {
+        const projectPath: string = path.join(testFolderPath, pythonProject);
+        await fse.ensureFile(path.join(projectPath, 'HttpTrigger', '__init__.py'));
+        await fse.ensureFile(path.join(projectPath, 'requirements.txt'));
+        await testInitProjectForVSCode(projectPath);
+        await validateProject(projectPath, getPythonValidateOptions(pythonProject));
     });
 
     const javaProject: string = 'AutoDetectJavaProject';
     test(javaProject, async () => {
+        const appName: string = 'javaApp1';
         const projectPath: string = path.join(testFolderPath, javaProject);
-        await fse.ensureFile(path.join(projectPath, 'pom.xml'));
+        const pomXmlPath: string = path.join(projectPath, 'pom.xml');
+        await fse.ensureFile(pomXmlPath);
+        await fse.writeFile(pomXmlPath, `<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <properties>
+        <functionAppName>${appName}</functionAppName>
+    </properties>
+</project>`);
+        await fse.ensureDir(path.join(projectPath, 'src'));
         await testInitProjectForVSCode(projectPath);
-        await validateVSCodeProjectFiles(projectPath, true);
-        await validateExtensionRecommendation(projectPath, 'vscjava.vscode-java-debug');
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.Java);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
+        await validateProject(projectPath, getJavaValidateOptions(appName));
     });
 
     const multiLanguageProject: string = 'MultiLanguageProject';
     test(multiLanguageProject, async () => {
         const projectPath: string = path.join(testFolderPath, multiLanguageProject);
-        const indexJsPath: string = path.join(projectPath, 'HttpTriggerTS', 'index.ts');
-        await fse.ensureFile(indexJsPath);
-        const runCsxPath: string = path.join(projectPath, 'HttpTriggerCSX', 'run.csx');
-        await fse.ensureFile(runCsxPath);
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerTS', 'index.ts'));
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerCSX', 'run.csx'));
         // Since this project has multiple languages, the user should be prompted to select the language
         // (In this case the user will select JavaScript)
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
-        await validateVSCodeProjectFiles(projectPath, false);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectLanguageSetting}`, ProjectLanguage.JavaScript);
-        await validateSetting(projectPath, `${extensionPrefix}.${projectRuntimeSetting}`, ProjectRuntime.v2);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
     const goodExtensionFile: string = 'Existing Extensions File';
@@ -100,9 +107,10 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await fse.ensureFile(extensionsJsonPath);
         await fse.writeFile(extensionsJsonPath, '{ "recommendations": [ "testid" ] }');
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
-        await validateVSCodeProjectFiles(projectPath);
+        const options: IValidateProjectOptions = getJavaScriptValidateOptions();
         // Verify the user's existing recommendations didn't get removed
-        await validateExtensionRecommendation(projectPath, 'testid');
+        options.expectedExtensionRecs.push('testid');
+        await validateProject(projectPath, options);
     });
 
     const badExtensionsFile: string = 'Poorly Formed Extensions File';
@@ -113,7 +121,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await fse.writeFile(extensionsJsonPath, '{');
         // This should simply prompt the user to overwrite the file since we can't parse it
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
-        await validateVSCodeProjectFiles(projectPath);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
     const goodSettingsFile: string = 'Existing Settings File';
@@ -121,11 +129,11 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         const projectPath: string = path.join(testFolderPath, goodSettingsFile);
         const settingsJsonPath: string = path.join(projectPath, '.vscode', 'settings.json');
         await fse.ensureFile(settingsJsonPath);
-        await fse.writeFile(settingsJsonPath, '{ "testSetting": "testValue" }');
+        await fse.writeFile(settingsJsonPath, '{ "azureFunctions.testSetting": "testValue" }');
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
-        await validateVSCodeProjectFiles(projectPath);
-        // tslint:disable-next-line:no-any
-        await validateSetting(projectPath, 'testSetting', 'testValue');
+        const options: IValidateProjectOptions = getJavaScriptValidateOptions();
+        options.expectedSettings.testSetting = 'testValue';
+        await validateProject(projectPath, options);
     });
 
     const badSettingsFile: string = 'Poorly Formed Settings File';
@@ -136,7 +144,7 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await fse.writeFile(settingsJson, '{');
         // This should simply prompt the user to overwrite the file since we can't parse it
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
-        await validateVSCodeProjectFiles(projectPath);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
     const badGitignoreFile: string = 'Bad gitignore File';
@@ -147,54 +155,24 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         // tslint:disable-next-line:no-multiline-string
         await fse.writeFile(gitignorePath, '.vscode');
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
-        await validateVSCodeProjectFiles(projectPath);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
     async function testInitProjectForVSCode(projectPath: string, ...inputs: (string | undefined)[]): Promise<void> {
+        // create mock files
+        await fse.ensureFile(path.join(projectPath, 'local.settings.json'));
+        await fse.ensureFile(path.join(projectPath, 'host.json'));
+        await fse.ensureFile(path.join(projectPath, '.funcignore'));
+        await fse.ensureFile(path.join(projectPath, '.gitignore'));
+        await fse.ensureDir(path.join(projectPath, '.git'));
+
         inputs.unshift(projectPath); // Select the test func app folder
         if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
             inputs.unshift('$(file-directory) Browse...'); // If the test environment has an open workspace, select the 'Browse...' option
         }
 
         ext.ui = new TestUserInput(inputs);
-        const actionContext: IActionContext = <IActionContext>{ properties: { isActivationEvent: 'false', result: 'Succeeded', error: '', errorMessage: '', cancelStep: '' }, measurements: {} };
-        await initProjectForVSCode(actionContext);
+        await initProjectForVSCode({ properties: {}, measurements: {} });
         assert.equal(inputs.length, 0, `Not all inputs were used: ${inputs}`);
     }
 });
-
-export async function validateVSCodeProjectFiles(projectPath: string, hasLaunchJson: boolean = true): Promise<void> {
-    const gitignorePath: string = path.join(projectPath, '.gitignore');
-    if (await fse.pathExists(gitignorePath)) {
-        const gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
-        assert.equal(gitignoreContents.indexOf('.vscode'), -1, 'The ".vscode" folder is being ignored.');
-    }
-
-    const vscodePath: string = path.join(projectPath, '.vscode');
-    assert.equal(await fse.pathExists(path.join(vscodePath, 'settings.json')), true, 'settings.json does not exist');
-
-    if (hasLaunchJson) {
-        assert.equal(await fse.pathExists(path.join(vscodePath, 'launch.json')), true, 'launch.json does not exist');
-    }
-
-    assert.equal(await fse.pathExists(path.join(vscodePath, 'tasks.json')), true, 'tasks.json does not exist');
-    await validateExtensionRecommendation(projectPath, 'ms-azuretools.vscode-azurefunctions');
-}
-
-async function validateExtensionRecommendation(projectPath: string, extensionId: string): Promise<void> {
-    const vscodePath: string = path.join(projectPath, '.vscode');
-    const extensionsPath: string = path.join(vscodePath, 'extensions.json');
-    assert.equal(await fse.pathExists(extensionsPath), true, 'extensions.json does not exist');
-    const extensionsContents: string = (await fse.readFile(extensionsPath)).toString();
-    assert.equal(extensionsContents.indexOf(extensionId) !== -1, true, `The extension ${extensionId} should be recommended.`);
-}
-
-export async function validateSetting(projectPath: string, key: string, value: string): Promise<void> {
-    const vscodePath: string = path.join(projectPath, '.vscode');
-    const settingsPath: string = path.join(vscodePath, 'settings.json');
-    assert.equal(await fse.pathExists(settingsPath), true, 'settings.json does not exist');
-    // tslint:disable-next-line:no-any
-    const settings: any = await fse.readJSON(settingsPath);
-    // tslint:disable-next-line:no-unsafe-any
-    assert.equal(settings[key], value, `The setting with key "${key}" is not set to value "${value}".`);
-}

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import { ISuiteCallbackContext } from 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { DialogResponses, ext, initProjectForVSCode, ProjectLanguage, TestUserInput } from '../extension.bundle';
+import { DialogResponses, ext, initProjectForVSCode, Platform, ProjectLanguage, TestUserInput } from '../extension.bundle';
 import { testFolderPath } from './global.test';
 import { getCSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
@@ -69,8 +69,14 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         const projectPath: string = path.join(testFolderPath, pythonProject);
         await fse.ensureFile(path.join(projectPath, 'HttpTrigger', '__init__.py'));
         await fse.ensureFile(path.join(projectPath, 'requirements.txt'));
+        const venvName: string = 'testEnv';
+        if (process.platform === Platform.Windows) {
+            await fse.ensureFile(path.join(projectPath, venvName, 'Scripts', 'activate'));
+        } else {
+            await fse.ensureFile(path.join(projectPath, venvName, 'bin', 'activate'));
+        }
         await testInitProjectForVSCode(projectPath);
-        await validateProject(projectPath, getPythonValidateOptions(pythonProject));
+        await validateProject(projectPath, getPythonValidateOptions(pythonProject, venvName));
     });
 
     const javaProject: string = 'AutoDetectJavaProject';

--- a/test/validateProject.ts
+++ b/test/validateProject.ts
@@ -63,14 +63,15 @@ export function getCSharpValidateOptions(projectName: string, targetFramework: s
     };
 }
 
-export function getPythonValidateOptions(projectName: string): IValidateProjectOptions {
+export function getPythonValidateOptions(projectName: string, venvName: string): IValidateProjectOptions {
     return {
         expectedSettings: {
             projectLanguage: ProjectLanguage.Python,
             projectRuntime: ProjectRuntime.v2,
             preDeployTask: 'func: pack',
             deploySubpath: `${projectName}.zip`,
-            templateFilter: 'Verified'
+            templateFilter: 'Verified',
+            pythonVenv: venvName
         },
         expectedPaths: [
             'requirements.txt'

--- a/test/validateProject.ts
+++ b/test/validateProject.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { extensionPrefix, ProjectLanguage, ProjectRuntime } from '../extension.bundle';
+
+export function getJavaScriptValidateOptions(): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.JavaScript,
+            projectRuntime: ProjectRuntime.v2,
+            deploySubpath: '.',
+            preDeployTask: 'func: extensions install',
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+        ],
+        expectedExtensionRecs: [
+        ]
+    };
+}
+
+export function getTypeScriptValidateOptions(): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.TypeScript,
+            projectRuntime: ProjectRuntime.v2,
+            deploySubpath: '.',
+            preDeployTask: 'prune',
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+            'tsconfig.json',
+            'package.json'
+        ],
+        expectedExtensionRecs: [
+        ]
+    };
+}
+
+export function getCSharpValidateOptions(projectName: string, targetFramework: string): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.CSharp,
+            projectRuntime: ProjectRuntime.v2,
+            preDeployTask: 'publish',
+            deploySubpath: `bin/Release/${targetFramework}/publish`,
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+            `${projectName}.csproj`
+        ],
+        expectedExtensionRecs: [
+            'ms-vscode.csharp'
+        ],
+        excludedPaths: [
+            '.funcignore'
+        ]
+    };
+}
+
+export function getPythonValidateOptions(projectName: string): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.Python,
+            projectRuntime: ProjectRuntime.v2,
+            preDeployTask: 'func: pack',
+            deploySubpath: `${projectName}.zip`,
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+            'requirements.txt'
+        ],
+        expectedExtensionRecs: [
+            'ms-python.python'
+        ]
+    };
+}
+
+export function getJavaValidateOptions(appName: string): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.Java,
+            projectRuntime: ProjectRuntime.v2,
+            preDeployTask: 'package',
+            deploySubpath: `target/azure-functions/${appName}/`,
+            templateFilter: 'Verified'
+        },
+        expectedPaths: [
+            'src',
+            'pom.xml'
+        ],
+        expectedExtensionRecs: [
+            'vscjava.vscode-java-debug'
+        ],
+        excludedPaths: [
+            '.funcignore'
+        ]
+    };
+}
+
+export function getCSharpScriptValidateOptions(runtime: ProjectRuntime = ProjectRuntime.v2): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: ProjectLanguage.CSharpScript,
+            projectRuntime: runtime,
+            deploySubpath: '.',
+            templateFilter: 'Core'
+        },
+        expectedPaths: [
+        ],
+        expectedExtensionRecs: [
+            'ms-vscode.csharp'
+        ]
+    };
+}
+
+export function getScriptValidateOptions(language: string): IValidateProjectOptions {
+    return {
+        expectedSettings: {
+            projectLanguage: language,
+            projectRuntime: ProjectRuntime.v2,
+            templateFilter: 'All'
+        },
+        expectedPaths: [
+        ],
+        expectedExtensionRecs: [
+        ],
+        excludedPaths: [
+            '.vscode/launch.json'
+        ]
+    };
+}
+
+const commonExpectedPaths: string[] = [
+    'host.json',
+    'local.settings.json',
+    '.gitignore',
+    '.git',
+    '.funcignore',
+    '.vscode/tasks.json',
+    '.vscode/launch.json',
+    '.vscode/extensions.json',
+    '.vscode/settings.json'
+];
+
+export interface IValidateProjectOptions {
+    expectedSettings: { [key: string]: string };
+    expectedPaths: string[];
+    expectedExtensionRecs: string[];
+
+    /**
+     * Any paths listed in commonExpectedPaths that for some reason don't exist for this language
+     */
+    excludedPaths?: string[];
+}
+
+export async function validateProject(projectPath: string, options: IValidateProjectOptions): Promise<void> {
+    //
+    // Validate expected files
+    //
+    let paths: string[] = commonExpectedPaths.filter(p1 => !options.excludedPaths || !options.excludedPaths.find(p2 => p1 === p2));
+    paths = paths.concat(options.expectedPaths);
+    await Promise.all(paths.map(async p => {
+        assert.equal(await fse.pathExists(path.join(projectPath, p)), true, `Path "${p}" does not exist.`);
+    }));
+
+    //
+    // Validate extensions.json
+    //
+    const extensionsContents: string = (await fse.readFile(path.join(projectPath, '.vscode', 'extensions.json'))).toString();
+    const recs: string[] = options.expectedExtensionRecs.concat('ms-azuretools.vscode-azurefunctions');
+    for (const rec of recs) {
+        assert.notEqual(extensionsContents.indexOf(rec), -1, `The extension "${rec}" was not found in extensions.json.`);
+    }
+
+    //
+    // Validate settings.json
+    //
+    const settings: { [key: string]: string } = <{ [key: string]: string }>await fse.readJSON(path.join(projectPath, '.vscode', 'settings.json'));
+    const keys: string[] = Object.keys(options.expectedSettings);
+    for (const key of keys) {
+        const value: string = options.expectedSettings[key];
+        assert.equal(settings[`${extensionPrefix}.${key}`], value, `The setting with key "${key}" is not set to value "${value}".`);
+    }
+
+    //
+    // Validate .gitignore
+    //
+    const gitignoreContents: string = (await fse.readFile(path.join(projectPath, '.gitignore'))).toString();
+    assert.equal(gitignoreContents.indexOf('.vscode'), -1, 'The ".vscode" folder is being ignored.');
+}

--- a/tslint.json
+++ b/tslint.json
@@ -79,6 +79,10 @@
             "property-declaration",
             "variable-declaration",
             "member-variable-declaration"
+        ],
+        "prefer-template": [
+            true,
+            "allow-single-concat"
         ]
     }
 }


### PR DESCRIPTION
No product changes - just test code.

I found that project tests were spotty in their coverage and decided to clean up/consolidate. Now, `createNewProject.test.ts` and `initProjectForVSCode.test.ts` share a lot more logic/validation. This makes sense because ideally users end up with the same project no matter if they create it from our extension or if they create it outside of VS Code.

Also just includes more validation like checking "preDeployTask"/"deploySubpath" and more expected paths.