### PR TITLE
Clean up two telemetry events

### DIFF
--- a/src/commands/createNewProject/validateFunctionProjects.ts
+++ b/src/commands/createNewProject/validateFunctionProjects.ts
@@ -22,6 +22,7 @@ import { createVirtualEnviornment } from './PythonProjectCreator';
 
 export async function validateFunctionProjects(actionContext: IActionContext, folders: vscode.WorkspaceFolder[] | undefined): Promise<void> {
     actionContext.suppressTelemetry = true;
+    actionContext.properties.isActivationEvent = 'true';
     if (folders) {
         for (const folder of folders) {
             const folderPath: string = folder.uri.fsPath;

--- a/src/utils/getCliFeedJson.ts
+++ b/src/utils/getCliFeedJson.ts
@@ -37,6 +37,7 @@ export async function tryGetCliFeedJson(): Promise<cliFeedJsonResponse | undefin
     return await callWithTelemetryAndErrorHandling('azureFunctions.tryGetCliFeedJson', async function (this: IActionContext): Promise<cliFeedJsonResponse> {
         this.properties.isActivationEvent = 'true';
         this.suppressErrorDisplay = true;
+        this.suppressTelemetry = true;
         const funcJsonOptions: request.OptionsWithUri = {
             method: 'GET',
             uri: funcCliFeedUrl


### PR DESCRIPTION
- validateFunctionProjects has been manually excluded in our telemetry queries for almost a year, and I'm not sure why I never just added isActivationEvent
- tryGetCliFeedJson doesn't record any properties/measurements, so no need to track unless there's an error