### PR TITLE
Remove "Skip for Now" button from maven warning

### DIFF
--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -18,7 +18,7 @@ export namespace mavenUtils {
             await cpUtils.executeCommand(undefined, workingDirectory, mvnCommand, '--version');
         } catch (error) {
             const message: string = localize('azFunc.mvnNotFound', 'Failed to find "maven", please ensure that the maven bin directory is in your system path.');
-            const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, DialogResponses.learnMore, DialogResponses.skipForNow);
+            const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, DialogResponses.learnMore);
             if (result === DialogResponses.learnMore) {
                 await openUrl('https://aka.ms/azurefunction_maven');
             }

--- a/src/utils/mavenUtils.ts
+++ b/src/utils/mavenUtils.ts
@@ -18,10 +18,12 @@ export namespace mavenUtils {
             await cpUtils.executeCommand(undefined, workingDirectory, mvnCommand, '--version');
         } catch (error) {
             const message: string = localize('azFunc.mvnNotFound', 'Failed to find "maven", please ensure that the maven bin directory is in your system path.');
-            const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, DialogResponses.learnMore);
-            if (result === DialogResponses.learnMore) {
-                await openUrl('https://aka.ms/azurefunction_maven');
-            }
+            // don't wait
+            vscode.window.showErrorMessage(message, DialogResponses.learnMore).then(async result => {
+                if (result === DialogResponses.learnMore) {
+                    await openUrl('https://aka.ms/azurefunction_maven');
+                }
+            });
             actionContext.suppressErrorDisplay = true; // Swallow errors in case show two error message
             throw new Error(localize('azFunc.mvnNotFound', 'Failed to find "maven" on path.'));
         }


### PR DESCRIPTION
The button doesn't make sense because maven is required to perform this action. Also don't wait for user to click a button - we want the "Creating New Project..." progress message to go away ASAP

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/987