### PR TITLE
Support debugging multiple function apps at once

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -5,61 +5,76 @@
 
 import * as vscode from 'vscode';
 import { IActionContext, registerEvent } from 'vscode-azureextensionui';
-import { hostStartCommand } from '../constants';
 import { localize } from '../localize';
-
-let isFuncHostRunning: boolean = false;
 
 // The name of the task before we started providing it in FuncTaskProvider.ts
 export const oldFuncHostNameRegEx: RegExp = /run\s*functions\s*host/i;
 
-export let stopFuncHostPromise: Promise<void> = Promise.resolve();
+const isFuncHostRunningMap: Map<vscode.WorkspaceFolder | vscode.TaskScope, boolean> = new Map();
+export function isFuncHostRunning(folder: vscode.WorkspaceFolder): boolean {
+    return !!isFuncHostRunningMap.get(folder);
+}
+
+const stopFuncHostPromiseMap: Map<vscode.WorkspaceFolder, Promise<void>> = new Map();
+export async function stopFuncHost(folder: vscode.WorkspaceFolder): Promise<void> {
+    const promise: Promise<void> | undefined = stopFuncHostPromiseMap.get(folder);
+    if (promise) {
+        await promise;
+    }
+}
 
 export function isFuncHostTask(task: vscode.Task): boolean {
-    // task.name resolves to the task's id (deprecated https://github.com/Microsoft/vscode/issues/57707), then label
-    return oldFuncHostNameRegEx.test(task.name) || task.name === hostStartCommand;
+    const commandLine: string | undefined = task.execution && (<vscode.ShellExecution>task.execution).commandLine;
+    // tslint:disable-next-line: strict-boolean-expressions
+    return /func (host )?start/i.test(commandLine || '');
 }
 
 export function registerFuncHostTaskEvents(): void {
     registerEvent('azureFunctions.onDidStartTask', vscode.tasks.onDidStartTask, async function (this: IActionContext, e: vscode.TaskStartEvent): Promise<void> {
         this.suppressErrorDisplay = true;
         this.suppressTelemetry = true;
-        if (isFuncHostTask(e.execution.task)) {
-            isFuncHostRunning = true;
+        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
+            isFuncHostRunningMap.set(e.execution.task.scope, true);
         }
     });
 
     registerEvent('azureFunctions.onDidEndTask', vscode.tasks.onDidEndTask, async function (this: IActionContext, e: vscode.TaskEndEvent): Promise<void> {
         this.suppressErrorDisplay = true;
         this.suppressTelemetry = true;
-        if (isFuncHostTask(e.execution.task)) {
-            isFuncHostRunning = false;
+        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
+            isFuncHostRunningMap.set(e.execution.task.scope, false);
         }
     });
 
     registerEvent('azureFunctions.onDidTerminateDebugSession', vscode.debug.onDidTerminateDebugSession, stopFuncTaskIfRunning);
 }
 
-async function stopFuncTaskIfRunning(this: IActionContext): Promise<void> {
+async function stopFuncTaskIfRunning(this: IActionContext, debugSession: vscode.DebugSession): Promise<void> {
     this.suppressErrorDisplay = true;
     this.suppressTelemetry = true;
 
-    const funcExecution: vscode.TaskExecution | undefined = vscode.tasks.taskExecutions.find((te: vscode.TaskExecution) => isFuncHostTask(te.task));
-    if (funcExecution && isFuncHostRunning) {
-        this.suppressTelemetry = false; // only track telemetry if it's actually the func task
-        stopFuncHostPromise = new Promise((resolve: () => void, reject: (e: Error) => void): void => {
-            const listener: vscode.Disposable = vscode.tasks.onDidEndTask((e: vscode.TaskEndEvent) => {
-                if (isFuncHostTask(e.execution.task)) {
-                    resolve();
-                    listener.dispose();
-                }
-            });
-
-            const timeoutInSeconds: number = 30;
-            const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to stop previous running Functions host within "{0}" seconds. Make sure the task has stopped before you debug again.', timeoutInSeconds));
-            setTimeout(() => { reject(timeoutError); }, timeoutInSeconds * 1000);
+    if (debugSession.workspaceFolder) {
+        const funcExecution: vscode.TaskExecution | undefined = vscode.tasks.taskExecutions.find((te: vscode.TaskExecution) => {
+            return te.task.scope === debugSession.workspaceFolder && isFuncHostTask(te.task);
         });
-        funcExecution.terminate();
-        await stopFuncHostPromise;
+
+        if (funcExecution && isFuncHostRunning(debugSession.workspaceFolder)) {
+            this.suppressTelemetry = false; // only track telemetry if it's actually the func task
+            const stopFuncHostPromise: Promise<void> = new Promise((resolve: () => void, reject: (e: Error) => void): void => {
+                const listener: vscode.Disposable = vscode.tasks.onDidEndTask((e: vscode.TaskEndEvent) => {
+                    if (e.execution === funcExecution) {
+                        resolve();
+                        listener.dispose();
+                    }
+                });
+
+                const timeoutInSeconds: number = 30;
+                const timeoutError: Error = new Error(localize('failedToFindFuncHost', 'Failed to stop previous running Functions host within "{0}" seconds. Make sure the task has stopped before you debug again.', timeoutInSeconds));
+                setTimeout(() => { reject(timeoutError); }, timeoutInSeconds * 1000);
+            });
+            stopFuncHostPromiseMap.set(debugSession.workspaceFolder, stopFuncHostPromise);
+            funcExecution.terminate();
+            await stopFuncHostPromise;
+        }
     }
 }


### PR DESCRIPTION
We generally work with multi-root workspace, but not if you have two function apps open at once. This PR fixes debugging so that you can actually run both at the same time. Here's a sample project: https://github.com/EricJizbaMSFT/MultiFuncApp

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/1081