### PR TITLE
Add runspace: 1

### DIFF
--- a/src/debug/PowerShellDebugProvider.ts
+++ b/src/debug/PowerShellDebugProvider.ts
@@ -15,6 +15,7 @@ export const powershellDebugConfig: DebugConfiguration = {
     type: 'PowerShell',
     request: 'attach',
     customPipeName: defaultCustomPipeName,
+    runspaceId: 1,
     preLaunchTask: hostStartTaskName
 };
 


### PR DESCRIPTION
The default behavior of the 'attach' request changed. This PR keeps the `F5` experience... without this, you'd get a prompt asking which runspace you wanna connect you which is not what we want to show our customers.

The runspace will always be 1 for the PowerShell worker.