### PR TITLE
Use localized strings when creating functions

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -28,6 +28,7 @@ export * from './src/extensionVariables';
 export * from './src/FunctionConfig';
 export * from './src/ProjectSettings';
 export * from './src/templates/IFunctionTemplate';
+export * from './src/templates/ScriptTemplateRetriever';
 export * from './src/templates/TemplateProvider';
 export * from './src/tree/FunctionAppProvider';
 export * from './src/utils/fs';

--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -98,12 +98,22 @@ export async function getResourcesPath(templatesPath: string, vscodeLang: string
         // Example: "en" for "english"
         const language: string = parts[0];
         // Example: "US" for "United States" (locale is optional)
-        // tslint:disable-next-line: strict-boolean-expressions
-        const locale: string | undefined = parts[1] || '[a-z]*';
+        let locale: string | undefined = parts[1];
 
         const files: string[] = await fse.readdir(folder);
-        const regExp: RegExp = new RegExp(`resources\\.${language}(-${locale})?\\.json`, 'i');
-        const matchingFile: string | undefined = files.find(f => regExp.test(f));
+        let matchingFile: string | undefined;
+        if (!locale) {
+            const regExp: RegExp = new RegExp(`resources\\.${language}\\.json`, 'i');
+            matchingFile = files.find(f => regExp.test(f));
+        }
+
+        if (!matchingFile) {
+            // tslint:disable-next-line: strict-boolean-expressions
+            locale = locale || '[a-z]*';
+            const regExp: RegExp = new RegExp(`resources\\.${language}(-${locale})?\\.json`, 'i');
+            matchingFile = files.find(f => regExp.test(f));
+        }
+
         if (matchingFile) {
             return path.join(folder, matchingFile);
         }

--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -7,6 +7,7 @@ import * as extract from 'extract-zip';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
@@ -77,13 +78,40 @@ export class ScriptTemplateRetriever extends TemplateRetriever {
     }
 
     private async parseTemplates(templatesPath: string): Promise<IFunctionTemplate[]> {
-        // only Resources.json has a capital letter
-        this._rawResources = <object>await fse.readJSON(path.join(templatesPath, 'resources', 'Resources.json'));
+        this._rawResources = <object>await fse.readJSON(await getResourcesPath(templatesPath));
         this._rawTemplates = <object[]>await fse.readJSON(path.join(templatesPath, 'templates', 'templates.json'));
         this._rawConfig = <object>await fse.readJSON(path.join(templatesPath, 'bindings', 'bindings.json'));
 
         return parseScriptTemplates(this._rawResources, this._rawTemplates, this._rawConfig);
     }
+}
+
+/**
+ * Unlike templates.json and bindings.json, Resources.json has a capital letter
+ */
+export async function getResourcesPath(templatesPath: string, vscodeLang: string = vscode.env.language): Promise<string> {
+    const folder: string = path.join(templatesPath, 'resources');
+
+    try {
+        // Example: "en-US"
+        const parts: string[] = vscodeLang.split('-');
+        // Example: "en" for "english"
+        const language: string = parts[0];
+        // Example: "US" for "United States" (locale is optional)
+        // tslint:disable-next-line: strict-boolean-expressions
+        const locale: string | undefined = parts[1] || '[a-z]*';
+
+        const files: string[] = await fse.readdir(folder);
+        const regExp: RegExp = new RegExp(`resources\\.${language}(-${locale})?\\.json`, 'i');
+        const matchingFile: string | undefined = files.find(f => regExp.test(f));
+        if (matchingFile) {
+            return path.join(folder, matchingFile);
+        }
+    } catch {
+        // ignore and fall back to english
+    }
+
+    return path.join(folder, 'Resources.json');
 }
 
 export function getScriptVerifiedTemplateIds(runtime: string): string[] {

--- a/src/templates/TemplateRetriever.ts
+++ b/src/templates/TemplateRetriever.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as vscode from 'vscode';
 import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
@@ -69,8 +70,8 @@ export abstract class TemplateRetriever {
     }
 
     /**
-     * Adds runtime and templateType information to a key to ensure there are no collisions in the cache
-     * For backwards compatability, the original runtime and templateType will not have this information
+     * Adds runtime, templateType, and language information to a key to ensure there are no collisions in the cache
+     * For backwards compatability, the original runtime, templateType, and language will not have this information
      */
     public getCacheKey(key: string, runtime: ProjectRuntime): string {
         if (runtime !== ProjectRuntime.v1) {
@@ -79,6 +80,10 @@ export abstract class TemplateRetriever {
 
         if (this.templateType !== TemplateType.Script) {
             key = `${key}.${this.templateType}`;
+        }
+
+        if (vscode.env.language && !/^en(-us)?$/i.test(vscode.env.language)) {
+            key = `${key}.${vscode.env.language}`;
         }
 
         return key;

--- a/src/templates/parseScriptTemplates.ts
+++ b/src/templates/parseScriptTemplates.ts
@@ -67,7 +67,11 @@ interface IVariables { [name: string]: string; }
 /**
  * Describes script template resources to be used for parsing
  */
-export interface IResources { en: { [key: string]: string }; }
+export interface IResources {
+    lang?: { [key: string]: string };
+    // Every Resources.json file also contains the english strings
+    en: { [key: string]: string };
+}
 
 // tslint:disable-next-line:no-any
 function getVariableValue(resources: IResources, variables: IVariables, data: string): string {
@@ -84,7 +88,16 @@ function getVariableValue(resources: IResources, variables: IVariables, data: st
 
 export function getResourceValue(resources: IResources, data: string): string {
     const matches: RegExpMatchArray | null = data.match(/\$(.*)/);
-    return matches !== null ? resources.en[matches[1]] : data;
+    if (matches === null) {
+        return data;
+    } else {
+        const key: string = matches[1];
+        if (resources.lang && resources.lang[key]) {
+            return resources.lang[key];
+        } else {
+            return resources.en[key];
+        }
+    }
 }
 
 function parseScriptSetting(data: object, resources: IResources, variables: IVariables): IFunctionSetting {

--- a/test/getResourcesPath.test.ts
+++ b/test/getResourcesPath.test.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { ext, getResourcesPath } from '../extension.bundle';
+
+async function verifyLanguage(vscodeLanguage: string, fileName: string): Promise<void> {
+    const templatesPath: string = ext.context.asAbsolutePath(path.join('resources', 'backupScriptTemplates', '~2'));
+    const actual: string = await getResourcesPath(templatesPath, vscodeLanguage);
+    assert.equal(actual, path.join(templatesPath, 'resources', fileName));
+}
+
+suite('getResourcesPath Tests', async () => {
+    // list of VS Code locales: https://code.visualstudio.com/docs/getstarted/locales
+    test('en', async () => { await verifyLanguage('en', 'Resources.json'); });
+    test('zh-CN', async () => { await verifyLanguage('zh-CN', 'Resources.zh-CN.json'); });
+    test('zh-TW', async () => { await verifyLanguage('zh-TW', 'Resources.zh-TW.json'); });
+    test('fr', async () => { await verifyLanguage('fr', 'Resources.fr-FR.json'); });
+    test('de', async () => { await verifyLanguage('de', 'Resources.de-DE.json'); });
+    test('it', async () => { await verifyLanguage('it', 'Resources.it-IT.json'); });
+    test('es', async () => { await verifyLanguage('es', 'Resources.es-ES.json'); });
+    test('ja', async () => { await verifyLanguage('ja', 'Resources.ja-JP.json'); });
+    test('ko', async () => { await verifyLanguage('ko', 'Resources.ko-KR.json'); });
+    test('ru', async () => { await verifyLanguage('ru', 'Resources.ru-RU.json'); });
+    test('bg', async () => { await verifyLanguage('bg', 'Resources.json'); }); // not translated in templates for some reason
+    test('hu', async () => { await verifyLanguage('hu', 'Resources.hu-HU.json'); });
+    test('pt-br', async () => { await verifyLanguage('pt-br', 'Resources.pt-BR.json'); });
+    test('tr', async () => { await verifyLanguage('tr', 'Resources.tr-TR.json'); });
+    test('unknown', async () => { await verifyLanguage('unknown', 'Resources.json'); });
+    test('empty', async () => { await verifyLanguage('', 'Resources.json'); });
+});


### PR DESCRIPTION
The templates already have these strings localized, so might as well use them.

![Screen Shot 2019-03-19 at 11 02 52 AM](https://user-images.githubusercontent.com/11282622/54631829-fc6b6a00-4a39-11e9-8267-bd1bb94f0247.png)

![Screen Shot 2019-03-19 at 11 03 21 AM](https://user-images.githubusercontent.com/11282622/54631835-ff665a80-4a39-11e9-9971-976ba84cdf73.png)
