### PR TITLE
Write runtime-specific host.json

### DIFF
--- a/src/commands/createNewProject/JavaProjectCreator.ts
+++ b/src/commands/createNewProject/JavaProjectCreator.ts
@@ -27,7 +27,7 @@ export class JavaProjectCreator extends ProjectCreatorBase {
     constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
         super(functionAppPath, actionContext, runtime, language);
         assert.notEqual(runtime, ProjectRuntime.v1, localize('noV1', 'Java does not support runtime "{0}".', ProjectRuntime.v1));
-        this.runtime = ProjectRuntime.v2;
+        this.setRuntime(ProjectRuntime.v2);
     }
 
     public async onCreateNewProject(): Promise<void> {

--- a/src/commands/createNewProject/JavaScriptProjectCreator.ts
+++ b/src/commands/createNewProject/JavaScriptProjectCreator.ts
@@ -3,47 +3,18 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand, ProjectRuntime, TemplateFilter } from "../../constants";
+import { TemplateFilter } from "../../constants";
 import { nodeDebugConfig } from "../../debug/NodeDebugProvider";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
 
 export class JavaScriptProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
-    public readonly deploySubpath: string = '.';
-    // "func extensions install" task creates C# build artifacts that should be hidden
-    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
-    public readonly excludedFiles: string | string[] = ['obj', 'bin'];
-
     public readonly functionsWorkerRuntime: string | undefined = 'node';
 
     public getLaunchJson(): {} {
         return {
             version: '0.2.0',
             configurations: [nodeDebugConfig]
-        };
-    }
-
-    public getTasksJson(): {} {
-        // tslint:disable-next-line:no-any
-        const funcTask: any = {
-            type: func,
-            command: hostStartCommand,
-            problemMatcher: funcWatchProblemMatcher,
-            isBackground: true
-        };
-
-        // tslint:disable-next-line:no-unsafe-any
-        const tasks: {}[] = [funcTask];
-
-        if (this.runtime !== ProjectRuntime.v1) {
-            // tslint:disable-next-line:no-unsafe-any
-            funcTask.dependsOn = extInstallTaskName;
-            this.preDeployTask = extInstallTaskName;
-        }
-
-        return {
-            version: '2.0.0',
-            tasks: tasks
         };
     }
 }

--- a/src/commands/createNewProject/PowerShellProjectCreator.ts
+++ b/src/commands/createNewProject/PowerShellProjectCreator.ts
@@ -5,7 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand, profileps1FileName, ProjectRuntime, TemplateFilter } from "../../constants";
+import { profileps1FileName, TemplateFilter } from "../../constants";
 import { powershellDebugConfig } from "../../debug/PowerShellDebugProvider";
 import { confirmOverwriteFile } from "../../utils/fs";
 import { ScriptProjectCreatorBase } from './ScriptProjectCreatorBase';
@@ -35,42 +35,12 @@ if ($env:MSI_SECRET -and (Get-Module -ListAvailable Az.Accounts)) {
 
 export class PowerShellProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
-    public readonly deploySubpath: string = '.';
-
-    // "func extensions install" task creates C# build artifacts that should be hidden
-    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
-    public readonly excludedFiles: string | string[] = ['obj', 'bin'];
-
     public readonly functionsWorkerRuntime: string | undefined = 'powershell';
 
     public getLaunchJson(): {} {
         return {
             version: '0.2.0',
             configurations: [powershellDebugConfig]
-        };
-    }
-
-    public getTasksJson(): {} {
-        // tslint:disable-next-line:no-any
-        const funcTask: any = {
-            type: func,
-            command: hostStartCommand,
-            problemMatcher: funcWatchProblemMatcher,
-            isBackground: true
-        };
-
-        // tslint:disable-next-line:no-unsafe-any
-        const tasks: {}[] = [funcTask];
-
-        if (this.runtime !== ProjectRuntime.v1) {
-            // tslint:disable-next-line:no-unsafe-any
-            funcTask.dependsOn = extInstallTaskName;
-            this.preDeployTask = extInstallTaskName;
-        }
-
-        return {
-            version: '2.0.0',
-            tasks: tasks
         };
     }
 

--- a/src/commands/createNewProject/ProjectCreatorBase.ts
+++ b/src/commands/createNewProject/ProjectCreatorBase.ts
@@ -5,6 +5,8 @@
 
 import { IActionContext } from "vscode-azureextensionui";
 import { ProjectRuntime, TemplateFilter } from "../../constants";
+import { tryGetLocalRuntimeVersion } from "../../funcCoreTools/tryGetLocalRuntimeVersion";
+import { promptForProjectRuntime } from "../../ProjectSettings";
 
 export abstract class ProjectCreatorBase {
     public deploySubpath: string = '';
@@ -12,20 +14,30 @@ export abstract class ProjectCreatorBase {
     public excludedFiles: string | string[] = '';
     public otherSettings: { [key: string]: string } = {};
     public abstract templateFilter: TemplateFilter;
-    public runtime: ProjectRuntime | undefined;
     public language: string;
 
     protected readonly functionAppPath: string;
     protected readonly actionContext: IActionContext;
 
+    private _runtime: ProjectRuntime | undefined;
+
     constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
         this.functionAppPath = functionAppPath;
         this.actionContext = actionContext;
-        this.runtime = runtime;
+        this._runtime = runtime;
         this.language = language;
     }
 
-    public getLaunchJson(): {} | undefined {
+    public async getRuntime(): Promise<ProjectRuntime> {
+        if (this._runtime === undefined) {
+            // tslint:disable-next-line: strict-boolean-expressions
+            this._runtime = await tryGetLocalRuntimeVersion() || await promptForProjectRuntime();
+        }
+
+        return this._runtime;
+    }
+
+    public getLaunchJson(_runtime: ProjectRuntime): {} | undefined {
         // By default languages do not support attaching on F5. Each language that supports F5'ing will have to overwrite this method in the subclass
         return undefined;
     }
@@ -40,9 +52,13 @@ export abstract class ProjectCreatorBase {
      */
     public abstract onInitProjectForVSCode(): Promise<void>;
 
-    public abstract getTasksJson(): {};
+    public abstract getTasksJson(runtime: ProjectRuntime): {};
 
     public getRecommendedExtensions(): string[] {
         return ['ms-azuretools.vscode-azurefunctions'];
+    }
+
+    protected setRuntime(value: ProjectRuntime): void {
+        this._runtime = value;
     }
 }

--- a/src/commands/createNewProject/PythonProjectCreator.ts
+++ b/src/commands/createNewProject/PythonProjectCreator.ts
@@ -31,16 +31,13 @@ const minPythonVersionLabel: string = '3.6.x'; // Use invalid semver as the labe
 export class PythonProjectCreator extends ScriptProjectCreatorBase {
     public readonly templateFilter: TemplateFilter = TemplateFilter.Verified;
     public preDeployTask: string = packTaskName;
-    // "func extensions install" task creates C# build artifacts that should be hidden
-    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
-    public readonly excludedFiles: string | string[] = ['obj', 'bin'];
 
     private _venvName: string | undefined;
 
     constructor(functionAppPath: string, actionContext: IActionContext, runtime: ProjectRuntime | undefined, language: string) {
         super(functionAppPath, actionContext, runtime, language);
         assert.notEqual(runtime, ProjectRuntime.v1, localize('noV1', 'Python does not support runtime "{0}".', ProjectRuntime.v1));
-        this.runtime = ProjectRuntime.v2;
+        this.setRuntime(ProjectRuntime.v2);
     }
 
     public getLaunchJson(): {} {

--- a/src/commands/createNewProject/TypeScriptProjectCreator.ts
+++ b/src/commands/createNewProject/TypeScriptProjectCreator.ts
@@ -85,7 +85,7 @@ export class TypeScriptProjectCreator extends JavaScriptProjectCreator {
         }
     }
 
-    public getTasksJson(): {} {
+    public getTasksJson(runtime: ProjectRuntime): {} {
         const npmInstallTaskName: string = 'npm: install';
         const npmBuildTaskName: string = 'npm: build';
         return {
@@ -101,7 +101,7 @@ export class TypeScriptProjectCreator extends JavaScriptProjectCreator {
                 {
                     type: 'npm',
                     script: 'build',
-                    dependsOn: this.runtime === ProjectRuntime.v1 ? npmInstallTaskName : [extInstallTaskName, npmInstallTaskName],
+                    dependsOn: runtime === ProjectRuntime.v1 ? npmInstallTaskName : [extInstallTaskName, npmInstallTaskName],
                     problemMatcher: '$tsc'
                 },
                 {

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -76,7 +76,8 @@ export async function createNewProject(
         }
 
         if (templateId) {
-            await createFunction(actionContext, functionAppPath, templateId, functionName, caseSensitiveFunctionSettings, <ProjectLanguage>language, projectCreator.runtime);
+            const projectRuntime: ProjectRuntime = await projectCreator.getRuntime();
+            await createFunction(actionContext, functionAppPath, templateId, functionName, caseSensitiveFunctionSettings, <ProjectLanguage>language, projectRuntime);
         }
     });
     // don't wait


### PR DESCRIPTION
The "host.json" file that we write should only have `"version": "2.0"` if the runtime is v2. Seems like a simple fix, but I had to refactor when we detect or prompt for runtime in order to do this.

Also moved a few things down into `ScriptProjectCreatorBase.ts` that were copied across Python/TypeScript/PowerShell/JavaScript.

Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/904

