### PR TITLE
Use vscode.env.openExternal

### DIFF
--- a/src/utils/openUrl.ts
+++ b/src/utils/openUrl.ts
@@ -6,5 +6,5 @@
 import * as vscode from 'vscode';
 
 export async function openUrl(url: string): Promise<void> {
-    await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(url));
+    await vscode.env.openExternal(vscode.Uri.parse(url));
 }


### PR DESCRIPTION
More official version of 'vscode.open' that was introduced in VS Code 1.31.0 https://github.com/Microsoft/vscode/issues/66741 (which this extension already relies on)