### PR TITLE
Add feature flag for powershell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5149,11 +5149,6 @@
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
-        "is-wsl": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
-        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6414,14 +6409,6 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "opn": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-            "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-            "requires": {
-                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {
@@ -9203,9 +9190,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.34.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.34.0.tgz",
-            "integrity": "sha512-WB15HPDDwVaMMa8vOVMFhnRIR7PeRxTgVdrgrmrkOjH+5wf1xbexiTX4ADxWpY9OBbbsJ2KEXtPxIktKm//Sfw==",
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.34.1.tgz",
+            "integrity": "sha512-5pqXGIxHxi6A17Q4RcdWSqa7B9ZcbzhR06odtuoTdnfFU49nemXkiVVNB3r7uogRJdU7lYRfIRIRM+5ZyIsLFg==",
             "requires": {
                 "archiver": "^2.0.3",
                 "azure-arm-resource": "^3.0.0-preview",
@@ -9216,12 +9203,11 @@
                 "glob-gitignore": "^1.0.14",
                 "ms-rest": "^2.2.2",
                 "ms-rest-azure": "^2.4.4",
-                "opn": "^5.1.0",
                 "p-retry": "^3.0.0",
                 "request": "^2.83.0",
                 "request-promise": "^4.2.2",
                 "simple-git": "~1.92.0",
-                "vscode-azureextensionui": "^0.22.0",
+                "vscode-azureextensionui": "^0.22.1",
                 "vscode-azurekudu": "^0.1.9",
                 "vscode-nls": "^4.0.0",
                 "websocket": "^1.0.25"

--- a/package.json
+++ b/package.json
@@ -816,6 +816,11 @@
                         "type": "boolean",
                         "description": "%azFunc.advancedCreationDescription%",
                         "default": false
+                    },
+                    "azureFunctions.enablePowerShell": {
+                        "type": "boolean",
+                        "description": "%azFunc.enablePowerShell%",
+                        "default": false
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -885,7 +885,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
-        "vscode-azureappservice": "^0.34.0",
+        "vscode-azureappservice": "^0.34.1",
         "vscode-azureextensionui": "^0.22.1",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.0.0",

--- a/package.nls.json
+++ b/package.nls.json
@@ -64,5 +64,6 @@
     "azFunc.createSlot": "Create Slot...",
     "azFunc.swapSlot": "Swap Slot...",
     "azFunc.advancedCreationDescription": "Enables advanced creation of function apps, which will prompt for several additional values instead of using a default.",
-    "azFunc.toggleAppSettingVisibility": "Toggle App Setting Visibility."
+    "azFunc.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
+    "azFunc.enablePowerShell": "Enable preview support for PowerShell."
 }

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -8,6 +8,7 @@ import { AzureWizardExecuteStep, AzureWizardPromptStep, IWizardOptions } from 'v
 import { ProjectLanguage } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
+import { getFuncExtensionSetting } from '../../ProjectSettings';
 import { nonNullProp } from '../../utils/nonNull';
 import { addFunctionSteps } from '../createFunction/FunctionListStep';
 import { addInitVSCodeStep } from '../initProjectForVSCode/InitVSCodeLanguageStep';
@@ -47,6 +48,10 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.Python, description: previewDescription },
             { label: ProjectLanguage.Java }
         ];
+
+        if (getFuncExtensionSetting('enablePowerShell')) {
+            languagePicks.push({ label: ProjectLanguage.PowerShell, description: previewDescription });
+        }
 
         const options: QuickPickOptions = { placeHolder: localize('selectFuncTemplate', 'Select a language for your function project') };
         wizardContext.language = <ProjectLanguage>(await ext.ui.showQuickPick(languagePicks, options)).label;


### PR DESCRIPTION
cc @TylerLeonhardt I think I might have mentioned "azureFunctions.projectLanguage" as a "feature flag", but I think it would be better to use a separate setting "azureFunctions.enablePowerShell". The first setting only works for "create new project", but we also have a quick pick for "Create new function app in azure" (if you have "azureFunctions.advancedCreation" set to `true`). I added PowerShell to that second quick pick here: https://github.com/Microsoft/vscode-azuretools/pull/460/files#diff-a596426cd9b2e2ac38b0d53eaeb0c3bbR31