### PR TITLE
Allow custom arguments to provided "func host start" task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9590,9 +9590,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.22.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.22.1.tgz",
-            "integrity": "sha512-5OGIhGQC0SD0V192pbPADmwe53TxS/hYQyUxB+wqciBdbK4O5e7Dt+IgMJv+NX4j68LCGpL6pfi0z5RUJ+02cQ==",
+            "version": "0.22.2",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.22.2.tgz",
+            "integrity": "sha512-j/RfJs/grWHDgGmVCcUhEDSrbSfxGqF0DCdBJk8PZ9e6jLStl1KE6wdxmSrB6TAkieqSg+GbTjGc+e+7z5ha+g==",
             "requires": {
                 "azure-arm-resource": "^3.0.0-preview",
                 "azure-arm-storage": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -891,7 +891,7 @@
         "request-promise": "^4.2.2",
         "semver": "^5.5.0",
         "vscode-azureappservice": "^0.34.1",
-        "vscode-azureextensionui": "^0.22.1",
+        "vscode-azureextensionui": "^0.22.2",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.0.0",
         "websocket": "^1.0.25",

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -29,7 +29,7 @@ export async function pickFuncProcess(this: IActionContext, debugConfig: vscode.
     });
 
     if (!funcTask) {
-        throw new Error(localize('noFuncTask', 'Failed to find "{0}" task.', funcHostStartCommand));
+        throw new Error(localize('noFuncTask', 'Failed to find "{0}" task.', preLaunchTaskName || funcHostStartCommand));
     }
 
     const settingKey: string = 'pickProcessTimeout';

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -15,7 +15,7 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
 
     private readonly _debugPorts: Map<WorkspaceFolder | undefined, number | undefined> = new Map();
 
-    public abstract getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution>;
+    public abstract getShellExecution(folder: WorkspaceFolder, commandLine: string): Promise<ShellExecution>;
 
     public async provideDebugConfigurations(folder: WorkspaceFolder | undefined, _token?: CancellationToken): Promise<DebugConfiguration[]> {
         // tslint:disable-next-line: no-this-assignment

--- a/src/debug/JavaDebugProvider.ts
+++ b/src/debug/JavaDebugProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DebugConfiguration, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
-import { funcHostStartCommand, hostStartTaskName, localhost } from '../constants';
+import { hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 
@@ -23,9 +23,9 @@ export class JavaDebugProvider extends FuncDebugProviderBase {
     protected readonly defaultPortOrPipeName: number = defaultJavaDebugPort;
     protected readonly debugConfig: DebugConfiguration = javaDebugConfig;
 
-    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+    public async getShellExecution(folder: WorkspaceFolder, commandLine: string): Promise<ShellExecution> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
         const options: ShellExecutionOptions = { env: { languageWorkers__java__arguments: `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${port}` } };
-        return new ShellExecution(funcHostStartCommand, options);
+        return new ShellExecution(commandLine, options);
     }
 }

--- a/src/debug/NodeDebugProvider.ts
+++ b/src/debug/NodeDebugProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DebugConfiguration, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
-import { funcHostStartCommand, hostStartTaskName } from '../constants';
+import { hostStartTaskName } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 
@@ -22,9 +22,9 @@ export class NodeDebugProvider extends FuncDebugProviderBase {
     protected readonly defaultPortOrPipeName: number = defaultNodeDebugPort;
     protected readonly debugConfig: DebugConfiguration = nodeDebugConfig;
 
-    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+    public async getShellExecution(folder: WorkspaceFolder, commandLine: string): Promise<ShellExecution> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
         const options: ShellExecutionOptions = { env: { languageWorkers__node__arguments: `--inspect=${port}` } };
-        return new ShellExecution(funcHostStartCommand, options);
+        return new ShellExecution(commandLine, options);
     }
 }

--- a/src/debug/PowerShellDebugProvider.ts
+++ b/src/debug/PowerShellDebugProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DebugConfiguration, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
-import { funcHostStartCommand, hostStartTaskName } from '../constants';
+import { hostStartTaskName } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 
@@ -23,9 +23,9 @@ export class PowerShellDebugProvider extends FuncDebugProviderBase {
     protected defaultPortOrPipeName: string | number = defaultCustomPipeName;
     protected readonly debugConfig: DebugConfiguration = powershellDebugConfig;
 
-    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
+    public async getShellExecution(folder: WorkspaceFolder, commandLine: string): Promise<ShellExecution> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
         const options: ShellExecutionOptions = { env: { PSWorkerCustomPipeName: `${port}` } };
-        return new ShellExecution(funcHostStartCommand, options);
+        return new ShellExecution(commandLine, options);
     }
 }

--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DebugConfiguration, Extension, extensions, ShellExecution, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
-import { funcHostStartCommand, hostStartTaskName, localhost } from '../constants';
+import { hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
 import { venvUtils } from '../utils/venvUtils';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -23,11 +23,11 @@ export class PythonDebugProvider extends FuncDebugProviderBase {
     protected readonly defaultPortOrPipeName: number = defaultPythonDebugPort;
     protected readonly debugConfig: DebugConfiguration = pythonDebugConfig;
 
-    public async getShellExecution(folder: WorkspaceFolder): Promise<ShellExecution> {
-        const command: string = venvUtils.convertToVenvCommand(funcHostStartCommand, folder.uri.fsPath);
+    public async getShellExecution(folder: WorkspaceFolder, commandLine: string): Promise<ShellExecution> {
+        commandLine = venvUtils.convertToVenvCommand(commandLine, folder.uri.fsPath);
         const port: number = <number>this.getDebugPortOrPipeName(folder);
         const options: ShellExecutionOptions = { env: { languageWorkers__python__arguments: await getPythonCommand(localhost, port) } };
-        return new ShellExecution(command, options);
+        return new ShellExecution(commandLine, options);
     }
 }
 

--- a/src/debug/getFuncTaskCommand.ts
+++ b/src/debug/getFuncTaskCommand.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TaskDefinition, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { func } from '../constants';
+
+interface IFuncTaskDefinition extends TaskDefinition {
+    command?: string;
+}
+
+/**
+ * Gets the exact command line (aka with any user-specified args) to be used in our provided task
+ */
+export function getFuncTaskCommand(folder: WorkspaceFolder, defaultCommand: string, commandsToMatch: RegExp): IFuncTaskCommand {
+    let command: string = defaultCommand;
+    try {
+        const config: WorkspaceConfiguration = workspace.getConfiguration('tasks', folder.uri);
+        // tslint:disable-next-line: strict-boolean-expressions
+        const tasks: IFuncTaskDefinition[] = config.get<IFuncTaskDefinition[]>('tasks') || [];
+        const funcTask: IFuncTaskDefinition | undefined = tasks.find(t => t.type === func && !!t.command && commandsToMatch.test(t.command));
+        if (funcTask && funcTask.command) {
+            command = funcTask.command;
+        }
+    } catch {
+        // ignore and use default
+    }
+    return {
+        taskName: command,
+        commandLine: `func ${command}`
+    };
+}
+
+export interface IFuncTaskCommand {
+    /**
+     * Used to identify the task. It matches the command as defined in the task by the user and is the same as commandLine, except without 'func' at the beginning.
+     */
+    taskName: string;
+
+    /**
+     * The actual command line to run
+     */
+    commandLine: string;
+}


### PR DESCRIPTION
I'm writing the docs for this: https://github.com/Microsoft/vscode-azurefunctions/wiki/Multiple-function-projects and it's much easier if users can continue to use our provided task even if they add a "port" argument. Here is my example commit for a JS multi-root project with these changes: https://github.com/EricJizbaMSFT/FuncMultiRoot/commit/a4733fc727b6da03a6564a376878103d7d432b56. Otherwise they have to define their own shell task and they have to include all the `languageWorkers__node__arguments: "--inspect=9229"` stuff

I could support custom arguments in our other provided tasks, but I figured I would keep it simpler and only do "func host start" since I want to include this in today's release.