### PR TITLE
Fix TypeScript scriptPath on Windows

### DIFF
--- a/src/commands/createFunction/scriptSteps/TypeScriptFunctionCreateStep.ts
+++ b/src/commands/createFunction/scriptSteps/TypeScriptFunctionCreateStep.ts
@@ -22,6 +22,6 @@ export class TypeScriptFunctionCreateStep extends ScriptFunctionCreateStep {
             // ignore and use default outDir
         }
 
-        functionJson.scriptFile = path.join('..', outDir, nonNullProp(wizardContext, 'functionName'), 'index.js');
+        functionJson.scriptFile = path.posix.join('..', outDir, nonNullProp(wizardContext, 'functionName'), 'index.js');
     }
 }


### PR DESCRIPTION
`scriptPath` in function.json should always be in posix format

/cc @duncan 