### PR TITLE
Use globalStoragePath for storing dotnet templates

### DIFF
--- a/src/templates/executeDotnetTemplateCommand.ts
+++ b/src/templates/executeDotnetTemplateCommand.ts
@@ -26,7 +26,7 @@ export async function executeDotnetTemplateCommand(runtime: ProjectRuntime, work
 
 export function getDotnetTemplatesPath(): string {
     // tslint:disable-next-line:strict-boolean-expressions
-    return ext.context.asAbsolutePath(path.join('resources', 'dotnetTemplates', ext.templateSource || ''));
+    return path.join(ext.context.globalStoragePath, 'dotnetTemplates', ext.templateSource || '');
 }
 
 export function getDotnetItemTemplatePath(runtime: ProjectRuntime): string {


### PR DESCRIPTION
`context.globalStoragePath` was added to VS Code [pretty recently](https://github.com/Microsoft/vscode/issues/66030). We should use that instead of storing directly in our extension folder.

Related: https://github.com/Microsoft/vscode-azurefunctions/issues/659