### PR TITLE
Don't use webpack for local development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,26 @@
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ],
+            "preLaunchTask": "npm: compile",
+            "env": {
+                "AZCODE_IGNORE_BUNDLE": "1",
+                "DEBUGTELEMETRY": "1",
+                "NODE_DEBUG": ""
+            }
+        },
+        {
+            "name": "Launch Extension (webpack)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
             "preLaunchTask": "npm: webpack",
             "env": {
                 "DEBUGTELEMETRY": "1",

--- a/main.js
+++ b/main.js
@@ -16,7 +16,9 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require("./dist/extension.bundle");
+const ignoreBundle = !/^(false|0)?$/i.test(process.env.AZCODE_IGNORE_BUNDLE || '');
+const extensionPath = ignoreBundle ? "./out/src/extension" : "./dist/extension.bundle";
+const extension = require(extensionPath);
 
 async function activate(ctx) {
     return await extension.activateInternal(ctx, perfStats);

--- a/src/utils/getCoreNodeModule.ts
+++ b/src/utils/getCoreNodeModule.ts
@@ -3,31 +3,24 @@
  *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-"use strict";
-
-// Our util/getCoreNodeModule.js file uses a dynamic require that depends on the environment and so has to be excluded
-// from webpack'ing, and we'll just copy it to the distribution folder.
-//
-// Since webpack shouldn't have to depend on npm build to transpile .ts -> .js, we keep this file in .js.
-
-Object.defineProperty(exports, "__esModule", { value: true });
-const vscode = require("vscode");
+import * as vscode from 'vscode';
 
 /**
  * Returns a node module installed with VSCode, or undefined if it fails.
  */
-function getCoreNodeModule(moduleName) {
+export function getCoreNodeModule<T>(moduleName: string): T | undefined {
     try {
         // tslint:disable-next-line:non-literal-require no-unsafe-any
         return require(`${vscode.env.appRoot}/node_modules.asar/${moduleName}`);
+    } catch (err) {
+        // ignore
     }
-    catch (err) { }
+
     try {
         // tslint:disable-next-line:non-literal-require no-unsafe-any
         return require(`${vscode.env.appRoot}/node_modules/${moduleName}`);
+    } catch (err) {
+        // ignore
     }
-    catch (err) { }
     return undefined;
 }
-
-exports.getCoreNodeModule = getCoreNodeModule;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ let config = dev.getDefaultWebpackConfig({
         // Copy files to dist folder where the runtime can find them
         new CopyWebpackPlugin([
             // getCoreNodeModule.js -> dist/node_modules/getCoreNodeModule.js
-            { from: './src/utils/getCoreNodeModule.js', to: 'node_modules' }
+            { from: './out/src/utils/getCoreNodeModule.js', to: 'node_modules' }
         ])
     ]
 });


### PR DESCRIPTION
As discussed offline - getting tired of the delay when we F5 the extension. Main fix was to use an 
 environment variable in main.js

I also had to switch `getCoreNodeModule` back to a *.ts file so that it would work for both webpack and non-webpack. As far as I can tell, we always run `npm build` before webpack, so I don't think this comment applies anymore anyways:
> Since webpack shouldn't have to depend on npm build to transpile .ts -> .js, we keep this file in .js

