### PR TITLE
Don't block templates based on verified ids

### DIFF
--- a/src/templates/DotnetTemplateRetriever.ts
+++ b/src/templates/DotnetTemplateRetriever.ts
@@ -21,10 +21,6 @@ export class DotnetTemplateRetriever extends TemplateRetriever {
     private _dotnetTemplatesKey: string = 'DotnetTemplates';
     private _rawTemplates: object[];
 
-    public getVerifiedTemplateIds(runtime: ProjectRuntime): string[] {
-        return getDotnetVerifiedTemplateIds(runtime);
-    }
-
     protected async getTemplatesFromCache(runtime: ProjectRuntime): Promise<IFunctionTemplate[] | undefined> {
         const projectFilePath: string = getDotnetProjectTemplatePath(runtime);
         const itemFilePath: string = getDotnetItemTemplatePath(runtime);

--- a/src/templates/ScriptTemplateRetriever.ts
+++ b/src/templates/ScriptTemplateRetriever.ts
@@ -26,10 +26,6 @@ export class ScriptTemplateRetriever extends TemplateRetriever {
     private _rawTemplates: object[];
     private _rawConfig: object;
 
-    public getVerifiedTemplateIds(runtime: ProjectRuntime): string[] {
-        return getScriptVerifiedTemplateIds(runtime);
-    }
-
     protected async getTemplatesFromCache(runtime: ProjectRuntime): Promise<IFunctionTemplate[] | undefined> {
         const cachedResources: object | undefined = ext.context.globalState.get<object>(this.getCacheKey(this._resourcesKey, runtime));
         const cachedTemplates: object[] | undefined = ext.context.globalState.get<object[]>(this.getCacheKey(this._templatesKey, runtime));


### PR DESCRIPTION
Currently we only use a template version if we can find all verified templates. However, this unnecessarily blocks people from using older versions of templates that might not have all the latest verified templates. This will be more relevant when we add support for bundles (the replacement for extensions.csproj) since a bundle could lock people to a specific version of templates.

We still have unit tests to verify the latest version of the templates has all of the verified templates.