### PR TITLE
Use updateWorkspaceSetting to write new project settings

### DIFF
--- a/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
@@ -16,8 +16,6 @@ import { IProjectWizardContext } from '../../createNewProject/IProjectWizardCont
 import { ensureVenv } from '../../createNewProject/ProjectCreateStep/PythonProjectCreateStep';
 import { ScriptInitVSCodeStep } from './ScriptInitVSCodeStep';
 
-const fullPythonVenvSetting: string = `${extensionPrefix}.${pythonVenvSetting}`;
-
 export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
     protected preDeployTask: string = packTaskName;
 
@@ -25,7 +23,7 @@ export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
         const zipPath: string = this.setDeploySubpath(wizardContext, `${path.basename(wizardContext.projectPath)}.zip`);
 
         const venvName: string = await ensureVenv(wizardContext.projectPath);
-        this.otherSettings[fullPythonVenvSetting] = venvName;
+        this.settings.push({ key: pythonVenvSetting, value: venvName });
 
         await ensureVenvInFuncIgnore(wizardContext.projectPath, venvName);
         await ensureGitIgnoreContents(wizardContext.projectPath, venvName, zipPath);
@@ -38,7 +36,7 @@ export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
 
     protected getTasks(): TaskDefinition[] {
         const pipInstallLabel: string = 'pipInstall';
-        const venvSettingReference: string = `\${config:${fullPythonVenvSetting}}`;
+        const venvSettingReference: string = `\${config:${extensionPrefix}.${pythonVenvSetting}}`;
 
         function getPipInstallCommand(platform: NodeJS.Platform): string {
             return venvUtils.convertToVenvPythonCommand('pip install -r requirements.txt', venvSettingReference, platform);

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
@@ -12,10 +12,6 @@ import { InitVSCodeStepBase } from './InitVSCodeStepBase';
  * Base class for all projects based on a simple script (i.e. JavaScript, C# Script, Bash, etc.) that don't require compilation
  */
 export class ScriptInitVSCodeStep extends InitVSCodeStepBase {
-    // "func extensions install" task creates C# build artifacts that should be hidden
-    // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
-    protected readonly excludedFiles: string[] = ['obj', 'bin'];
-
     protected getTasks(runtime: ProjectRuntime): TaskDefinition[] {
         return [
             {
@@ -29,6 +25,10 @@ export class ScriptInitVSCodeStep extends InitVSCodeStepBase {
     }
 
     protected async executeCore(wizardContext: IProjectWizardContext): Promise<void> {
+        // "func extensions install" task creates C# build artifacts that should be hidden
+        // See issue: https://github.com/Microsoft/vscode-azurefunctions/pull/699
+        this.settings.push({ prefix: 'files', key: 'exclude', value: { obj: true, bin: true } });
+
         this.setDeploySubpath(wizardContext, '.');
         if (!this.preDeployTask) {
             if (wizardContext.runtime !== ProjectRuntime.v1) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,6 @@ export const templateFilterSetting: string = 'templateFilter';
 export const deploySubpathSetting: string = 'deploySubpath';
 export const templateVersionSetting: string = 'templateVersion';
 export const preDeployTaskSetting: string = 'preDeployTask';
-export const filesExcludeSetting: string = 'files.exclude';
 export const pythonVenvSetting: string = 'pythonVenv';
 export const projectOpenBehaviorSetting: string = 'projectOpenBehavior';
 


### PR DESCRIPTION
Today we're manually writing the `.vscode/settings.json` file, which is necessary when the folder isn't open in VS Code, but in other cases we should use the normal VS Code APIs to change settings.