### PR TITLE
Make "Init for VS Code" less destructive

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -32,5 +32,8 @@ export * from './src/tree/FunctionAppProvider';
 export * from './src/utils/fs';
 export * from './src/utils/cpUtils';
 export * from './src/utils/venvUtils';
+export * from './src/vsCodeConfig/extensions';
+export * from './src/vsCodeConfig/launch';
+export * from './src/vsCodeConfig/tasks';
 export * from 'vscode-azureappservice';
 export * from 'vscode-azureextensionui';

--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -16,11 +16,11 @@ import { IBindingWizardContext } from "./IBindingWizardContext";
 export async function addBinding(this: IActionContext, data: Uri | LocalBindingsTreeItem | undefined): Promise<void> {
     if (data instanceof Uri) {
         const functionJsonPath: string = data.fsPath;
-        const folder: WorkspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'folder');
-        const workspacePath: string = folder.uri.fsPath;
+        const workspaceFolder: WorkspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'workspaceFolder');
+        const workspacePath: string = workspaceFolder.uri.fsPath;
         const projectPath: string | undefined = await tryGetFunctionProjectRoot(workspacePath) || workspacePath;
 
-        const wizardContext: IBindingWizardContext = { actionContext: this, functionJsonPath: data.fsPath, workspacePath, projectPath };
+        const wizardContext: IBindingWizardContext = { actionContext: this, functionJsonPath: data.fsPath, workspacePath, projectPath, workspaceFolder };
         const wizard: AzureWizard<IBindingWizardContext> = createBindingWizard(wizardContext);
         await wizard.prompt(this);
         await wizard.execute(this);

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -10,6 +10,7 @@ import { NoWorkspaceError } from '../../errors';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
+import { getContainingWorkspace } from '../../utils/workspace';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
 import { verifyAndPromptToCreateProject } from '../createNewProject/verifyIsProject';
 import { FunctionListStep } from './FunctionListStep';
@@ -25,8 +26,12 @@ export async function createFunction(
     runtime?: ProjectRuntime): Promise<void> {
     addLocalFuncTelemetry(actionContext);
 
+    let workspaceFolder: WorkspaceFolder | undefined;
     if (workspacePath === undefined) {
-        workspacePath = await getWorkspacePath(actionContext);
+        workspaceFolder = await getWorkspacePath(actionContext);
+        workspacePath = workspaceFolder.uri.fsPath;
+    } else {
+        workspaceFolder = getContainingWorkspace(workspacePath);
     }
 
     const projectPath: string | undefined = await verifyAndPromptToCreateProject(actionContext, workspacePath);
@@ -36,7 +41,7 @@ export async function createFunction(
 
     [language, runtime] = await verifyInitForVSCode(actionContext, projectPath, language, runtime);
 
-    const wizardContext: IFunctionWizardContext = { actionContext, projectPath, workspacePath, runtime, language, functionName };
+    const wizardContext: IFunctionWizardContext = { actionContext, projectPath, workspacePath, workspaceFolder, runtime, language, functionName };
     const wizard: AzureWizard<IFunctionWizardContext> = new AzureWizard(wizardContext, {
         promptSteps: [await FunctionListStep.createFunctionListStep(wizardContext, { templateId, caseSensitiveFunctionSettings, isProjectWizard: false })]
     });
@@ -44,7 +49,7 @@ export async function createFunction(
     await wizard.execute(actionContext);
 }
 
-async function getWorkspacePath(actionContext: IActionContext): Promise<string> {
+async function getWorkspacePath(actionContext: IActionContext): Promise<WorkspaceFolder> {
     let folder: WorkspaceFolder | undefined;
     if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
         const message: string = localize('noWorkspaceWarning', 'You must have a project open to create a function.');
@@ -80,5 +85,5 @@ async function getWorkspacePath(actionContext: IActionContext): Promise<string> 
         }
     }
 
-    return folder.uri.fsPath;
+    return folder;
 }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -28,7 +28,7 @@ export async function createFunction(
 
     let workspaceFolder: WorkspaceFolder | undefined;
     if (workspacePath === undefined) {
-        workspaceFolder = await getWorkspacePath(actionContext);
+        workspaceFolder = await getWorkspaceFolder(actionContext);
         workspacePath = workspaceFolder.uri.fsPath;
     } else {
         workspaceFolder = getContainingWorkspace(workspacePath);
@@ -49,7 +49,7 @@ export async function createFunction(
     await wizard.execute(actionContext);
 }
 
-async function getWorkspacePath(actionContext: IActionContext): Promise<WorkspaceFolder> {
+async function getWorkspaceFolder(actionContext: IActionContext): Promise<WorkspaceFolder> {
     let folder: WorkspaceFolder | undefined;
     if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
         const message: string = localize('noWorkspaceWarning', 'You must have a project open to create a function.');

--- a/src/commands/createNewProject/FolderListStep.ts
+++ b/src/commands/createNewProject/FolderListStep.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { WorkspaceFolder } from 'vscode';
 import { AzureWizardPromptStep } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -15,9 +14,9 @@ export class FolderListStep extends AzureWizardPromptStep<IProjectWizardContext>
 
     public static setProjectPath(wizardContext: Partial<IProjectWizardContext>, projectPath: string): void {
         wizardContext.projectPath = projectPath;
-        const workspaceFolder: WorkspaceFolder | undefined = getContainingWorkspace(projectPath);
-        wizardContext.workspacePath = (workspaceFolder && workspaceFolder.uri.fsPath) || projectPath;
-        if (workspaceFolder) {
+        wizardContext.workspaceFolder = getContainingWorkspace(projectPath);
+        wizardContext.workspacePath = (wizardContext.workspaceFolder && wizardContext.workspaceFolder.uri.fsPath) || projectPath;
+        if (wizardContext.workspaceFolder) {
             wizardContext.openBehavior = 'AlreadyOpen';
         }
     }

--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { WorkspaceFolder } from "vscode";
 import { IActionContext } from "vscode-azureextensionui";
 import { ProjectLanguage, ProjectRuntime } from "../../constants";
 
@@ -10,6 +11,7 @@ export interface IProjectWizardContext {
     actionContext: IActionContext;
     projectPath: string;
     workspacePath: string;
+    workspaceFolder: WorkspaceFolder | undefined;
 
     language?: ProjectLanguage;
     runtime?: ProjectRuntime;

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/InitVSCodeStepBase.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/InitVSCodeStepBase.ts
@@ -8,10 +8,13 @@ import * as path from 'path';
 import { DebugConfiguration, TaskDefinition } from 'vscode';
 import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
 import { deploySubpathSetting, extensionPrefix, gitignoreFileName, launchFileName, preDeployTaskSetting, ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting, settingsFileName, tasksFileName } from '../../../constants';
-import { confirmEditJsonFile, confirmOverwriteFile, isPathEqual, writeFormattedJson } from '../../../utils/fs';
+import { localize } from '../../../localize';
+import { confirmEditJsonFile, isPathEqual, isSubpath } from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
-import { getContainingWorkspace } from '../../../utils/workspace';
+import { IExtensionsJson } from '../../../vsCodeConfig/extensions';
+import { getDebugConfigs, getLaunchVersion, ILaunchJson, isDebugConfigEqual, launchVersion, updateDebugConfigs, updateLaunchVersion } from '../../../vsCodeConfig/launch';
 import { updateWorkspaceSetting } from '../../../vsCodeConfig/settings';
+import { getTasks, getTasksVersion, ITask, ITasksJson, tasksVersion, updateTasks, updateTasksVersion } from '../../../vsCodeConfig/tasks';
 import { IFunctionWizardContext } from '../../createFunction/IFunctionWizardContext';
 import { IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
 
@@ -30,10 +33,12 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
         const language: ProjectLanguage = nonNullProp(wizardContext, 'language');
         wizardContext.actionContext.properties.projectLanguage = language;
 
+        wizardContext.actionContext.properties.isProjectInSubDir = String(isSubpath(wizardContext.workspacePath, wizardContext.projectPath));
+
         const vscodePath: string = path.join(wizardContext.workspacePath, '.vscode');
         await fse.ensureDir(vscodePath);
         await this.writeTasksJson(wizardContext, vscodePath, runtime);
-        await this.writeLaunchJson(vscodePath, runtime);
+        await this.writeLaunchJson(wizardContext, vscodePath, runtime);
         await this.writeSettingsJson(wizardContext, vscodePath, language, runtime);
         await this.writeExtensionsJson(vscodePath, language);
 
@@ -68,34 +73,94 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
     }
 
     private async writeTasksJson(wizardContext: IFunctionWizardContext, vscodePath: string, runtime: ProjectRuntime): Promise<void> {
-        const tasksJsonPath: string = path.join(vscodePath, tasksFileName);
-        if (await confirmOverwriteFile(tasksJsonPath)) {
-            const tasks: TaskDefinition[] = this.getTasks(runtime);
-            for (const task of tasks) {
-                // tslint:disable-next-line: strict-boolean-expressions no-unsafe-any
-                let cwd: string = (task.options && task.options.cwd) || '.';
-                cwd = this.addSubDir(wizardContext, cwd);
-                if (!isPathEqual(cwd, '.')) {
-                    // tslint:disable-next-line: strict-boolean-expressions
-                    task.options = task.options || {};
-                    // always use posix for debug config
-                    // tslint:disable-next-line: no-unsafe-any no-invalid-template-strings
-                    task.options.cwd = path.posix.join('${workspaceFolder}', cwd);
-                }
+        const newTasks: TaskDefinition[] = this.getTasks(runtime);
+        for (const task of newTasks) {
+            // tslint:disable-next-line: strict-boolean-expressions no-unsafe-any
+            let cwd: string = (task.options && task.options.cwd) || '.';
+            cwd = this.addSubDir(wizardContext, cwd);
+            if (!isPathEqual(cwd, '.')) {
+                // tslint:disable-next-line: strict-boolean-expressions
+                task.options = task.options || {};
+                // always use posix for debug config
+                // tslint:disable-next-line: no-unsafe-any no-invalid-template-strings
+                task.options.cwd = path.posix.join('${workspaceFolder}', cwd);
             }
+        }
 
-            await writeFormattedJson(tasksJsonPath, { version: '2.0.0', tasks });
+        const versionMismatchError: Error = new Error(localize('versionMismatchError', 'The version in your {0} must be "{1}" to work with Azure Functions.', tasksFileName, tasksVersion));
+        if (wizardContext.workspaceFolder) { // Use VS Code api to update config if folder is open
+            const currentVersion: string | undefined = getTasksVersion(wizardContext.workspaceFolder);
+            if (!currentVersion) {
+                updateTasksVersion(wizardContext.workspaceFolder, tasksVersion);
+            } else if (currentVersion !== tasksVersion) {
+                throw versionMismatchError;
+            }
+            updateTasks(wizardContext.workspaceFolder, this.insertNewTasks(getTasks(wizardContext.workspaceFolder), newTasks));
+        } else { // otherwise manually edit json
+            const tasksJsonPath: string = path.join(vscodePath, tasksFileName);
+            await confirmEditJsonFile(
+                tasksJsonPath,
+                (data: ITasksJson): ITasksJson => {
+                    if (!data.version) {
+                        data.version = tasksVersion;
+                    } else if (data.version !== tasksVersion) {
+                        throw versionMismatchError;
+                    }
+                    data.tasks = this.insertNewTasks(data.tasks, newTasks);
+                    return data;
+                }
+            );
         }
     }
 
-    private async writeLaunchJson(vscodePath: string, runtime: ProjectRuntime): Promise<void> {
+    private insertNewTasks(existingTasks: ITask[] | undefined, newTasks: ITask[]): ITask[] {
+        // tslint:disable-next-line: strict-boolean-expressions
+        existingTasks = existingTasks || [];
+        // Remove tasks that match the ones we're about to add
+        existingTasks = existingTasks.filter(t1 => newTasks.find(t2 => {
+            return t1.type !== t2.type || t1.label !== t2.label || t1.command !== t2.command;
+        }));
+        existingTasks.push(...newTasks);
+        return existingTasks;
+    }
+
+    private async writeLaunchJson(wizardContext: IFunctionWizardContext, vscodePath: string, runtime: ProjectRuntime): Promise<void> {
         if (this.getDebugConfiguration) {
-            const launchJsonPath: string = path.join(vscodePath, launchFileName);
-            if (await confirmOverwriteFile(launchJsonPath)) {
-                const debugConfig: DebugConfiguration = this.getDebugConfiguration(runtime);
-                await writeFormattedJson(launchJsonPath, { version: '0.2.0', configurations: [debugConfig] });
+            const newDebugConfig: DebugConfiguration = this.getDebugConfiguration(runtime);
+            const versionMismatchError: Error = new Error(localize('versionMismatchError', 'The version in your {0} must be "{1}" to work with Azure Functions.', launchFileName, launchVersion));
+            if (wizardContext.workspaceFolder) { // Use VS Code api to update config if folder is open
+                const currentVersion: string | undefined = getLaunchVersion(wizardContext.workspaceFolder);
+                if (!currentVersion) {
+                    updateLaunchVersion(wizardContext.workspaceFolder, launchVersion);
+                } else if (currentVersion !== launchVersion) {
+                    throw versionMismatchError;
+                }
+                updateDebugConfigs(wizardContext.workspaceFolder, this.insertLaunchConfig(getDebugConfigs(wizardContext.workspaceFolder), newDebugConfig));
+            } else { // otherwise manually edit json
+                const launchJsonPath: string = path.join(vscodePath, launchFileName);
+                await confirmEditJsonFile(
+                    launchJsonPath,
+                    (data: ILaunchJson): ILaunchJson => {
+                        if (!data.version) {
+                            data.version = launchVersion;
+                        } else if (data.version !== launchVersion) {
+                            throw versionMismatchError;
+                        }
+                        data.configurations = this.insertLaunchConfig(data.configurations, newDebugConfig);
+                        return data;
+                    }
+                );
             }
         }
+    }
+
+    private insertLaunchConfig(existingConfigs: DebugConfiguration[] | undefined, newConfig: DebugConfiguration): DebugConfiguration[] {
+        // tslint:disable-next-line: strict-boolean-expressions
+        existingConfigs = existingConfigs || [];
+        // Remove configs that match the one we're about to add
+        existingConfigs = existingConfigs.filter(l1 => !isDebugConfigEqual(l1, newConfig));
+        existingConfigs.push(newConfig);
+        return existingConfigs;
     }
 
     private async writeSettingsJson(wizardContext: IFunctionWizardContext, vscodePath: string, language: string, runtime: ProjectRuntime): Promise<void> {
@@ -110,11 +175,11 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
             settings.push({ key: preDeployTaskSetting, value: this.preDeployTask });
         }
 
-        if (getContainingWorkspace(wizardContext.projectPath)) {
+        if (wizardContext.workspaceFolder) { // Use VS Code api to update config if folder is open
             for (const setting of settings) {
                 await updateWorkspaceSetting(setting.key, setting.value, wizardContext.workspacePath, setting.prefix);
             }
-        } else {
+        } else { // otherwise manually edit json
             const settingsJsonPath: string = path.join(vscodePath, settingsFileName);
             await confirmEditJsonFile(
                 settingsJsonPath,
@@ -133,7 +198,7 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
         const extensionsJsonPath: string = path.join(vscodePath, 'extensions.json');
         await confirmEditJsonFile(
             extensionsJsonPath,
-            (data: IRecommendations): {} => {
+            (data: IExtensionsJson): {} => {
                 const recommendations: string[] = ['ms-azuretools.vscode-azurefunctions'];
                 if (this.getRecommendedExtensions) {
                     recommendations.push(...this.getRecommendedExtensions(language));
@@ -149,10 +214,6 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
             }
         );
     }
-}
-
-interface IRecommendations {
-    recommendations?: string[];
 }
 
 interface ISettingToAdd {

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -8,6 +8,7 @@ import { AzureWizard, IActionContext, UserCancelledError } from 'vscode-azureext
 import { ProjectLanguage, projectLanguageSetting } from '../../constants';
 import { NoWorkspaceError } from '../../errors';
 import { localize } from '../../localize';
+import { getContainingWorkspace } from '../../utils/workspace';
 import { getGlobalSetting } from '../../vsCodeConfig/settings';
 import { IProjectWizardContext } from '../createNewProject/IProjectWizardContext';
 import { verifyAndPromptToCreateProject } from '../createNewProject/verifyIsProject';
@@ -15,18 +16,21 @@ import { detectProjectLanguage } from './detectProjectLanguage';
 import { InitVSCodeLanguageStep } from './InitVSCodeLanguageStep';
 
 export async function initProjectForVSCode(actionContext: IActionContext, workspacePath?: string, language?: ProjectLanguage): Promise<void> {
+    let workspaceFolder: WorkspaceFolder | undefined;
     if (workspacePath === undefined) {
         if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
             throw new NoWorkspaceError();
         } else {
             const placeHolder: string = localize('selectFunctionAppFolderNew', 'Select the folder to initialize for use with VS Code');
-            const folder: WorkspaceFolder | undefined = await window.showWorkspaceFolderPick({ placeHolder });
-            if (!folder) {
+            workspaceFolder = await window.showWorkspaceFolderPick({ placeHolder });
+            if (!workspaceFolder) {
                 throw new UserCancelledError();
             } else {
-                workspacePath = folder.uri.fsPath;
+                workspacePath = workspaceFolder.uri.fsPath;
             }
         }
+    } else {
+        workspaceFolder = getContainingWorkspace(workspacePath);
     }
 
     const projectPath: string | undefined = await verifyAndPromptToCreateProject(actionContext, workspacePath);
@@ -37,7 +41,7 @@ export async function initProjectForVSCode(actionContext: IActionContext, worksp
     // tslint:disable-next-line: strict-boolean-expressions
     language = language || getGlobalSetting(projectLanguageSetting) || await detectProjectLanguage(projectPath);
 
-    const wizardContext: IProjectWizardContext = { projectPath, workspacePath, actionContext, language };
+    const wizardContext: IProjectWizardContext = { projectPath, workspacePath, actionContext, language, workspaceFolder };
     const wizard: AzureWizard<IProjectWizardContext> = new AzureWizard(wizardContext, { promptSteps: [new InitVSCodeLanguageStep()] });
     await wizard.prompt(actionContext);
     await wizard.execute(actionContext);

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -11,6 +11,7 @@ import { isFuncHostTask, stopFuncHost } from '../funcCoreTools/funcHostTask';
 import { validateFuncCoreToolsInstalled } from '../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../localize';
 import { getWindowsProcessTree, IProcessTreeNode, IWindowsProcessTree } from '../utils/windowsProcessTree';
+import { getDebugConfigs, isDebugConfigEqual } from '../vsCodeConfig/launch';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 
 export async function pickFuncProcess(this: IActionContext, debugConfig: vscode.DebugConfiguration): Promise<string | undefined> {
@@ -49,10 +50,8 @@ function getMatchingWorkspace(debugConfig: vscode.DebugConfiguration): vscode.Wo
     if (vscode.workspace.workspaceFolders) {
         for (const workspace of vscode.workspace.workspaceFolders) {
             try {
-                const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('launch', workspace.uri);
-                // tslint:disable-next-line: strict-boolean-expressions
-                const configs: vscode.DebugConfiguration[] = config.get<vscode.DebugConfiguration[]>('configurations') || [];
-                if (configs.some(c => c.name === debugConfig.name && c.request === debugConfig.request && c.type === debugConfig.type)) {
+                const configs: vscode.DebugConfiguration[] = getDebugConfigs(workspace);
+                if (configs.some(c => isDebugConfigEqual(c, debugConfig))) {
                     return workspace;
                 }
             } catch {

--- a/src/debug/getFuncTaskCommand.ts
+++ b/src/debug/getFuncTaskCommand.ts
@@ -3,12 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TaskDefinition, workspace, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
+import { WorkspaceFolder } from 'vscode';
 import { func } from '../constants';
-
-interface IFuncTaskDefinition extends TaskDefinition {
-    command?: string;
-}
+import { getTasks, ITask } from '../vsCodeConfig/tasks';
 
 /**
  * Gets the exact command line (aka with any user-specified args) to be used in our provided task
@@ -16,10 +13,8 @@ interface IFuncTaskDefinition extends TaskDefinition {
 export function getFuncTaskCommand(folder: WorkspaceFolder, defaultCommand: string, commandsToMatch: RegExp): IFuncTaskCommand {
     let command: string = defaultCommand;
     try {
-        const config: WorkspaceConfiguration = workspace.getConfiguration('tasks', folder.uri);
-        // tslint:disable-next-line: strict-boolean-expressions
-        const tasks: IFuncTaskDefinition[] = config.get<IFuncTaskDefinition[]>('tasks') || [];
-        const funcTask: IFuncTaskDefinition | undefined = tasks.find(t => t.type === func && !!t.command && commandsToMatch.test(t.command));
+        const tasks: ITask[] = getTasks(folder);
+        const funcTask: ITask | undefined = tasks.find(t => t.type === func && !!t.command && commandsToMatch.test(t.command));
         if (funcTask && funcTask.command) {
             command = funcTask.command;
         }

--- a/src/tree/localProject/IProjectRoot.ts
+++ b/src/tree/localProject/IProjectRoot.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { WorkspaceFolder } from "vscode";
 import { ISubscriptionRoot } from "vscode-azureextensionui";
 
 export interface IProjectRoot extends ISubscriptionRoot {
     projectPath: string;
     workspacePath: string;
+    workspaceFolder: WorkspaceFolder;
 }

--- a/src/tree/localProject/LocalBindingsTreeItem.ts
+++ b/src/tree/localProject/LocalBindingsTreeItem.ts
@@ -52,7 +52,8 @@ export class LocalBindingsTreeItem extends AzureParentTreeItem<IProjectRoot> {
             actionContext,
             functionJsonPath: this.functionJsonPath,
             workspacePath: this.root.workspacePath,
-            projectPath: this.root.projectPath
+            projectPath: this.root.projectPath,
+            workspaceFolder: this.root.workspaceFolder
         };
 
         const wizard: AzureWizard<IBindingWizardContext> = createBindingWizard(wizardContext);

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import { Disposable, FileSystemWatcher, Uri, workspace } from 'vscode';
+import { Disposable, FileSystemWatcher, Uri, workspace, WorkspaceFolder } from 'vscode';
 import { AzureTreeItem, RootTreeItem } from 'vscode-azureextensionui';
 import { functionJsonFileName } from '../../constants';
 import { localize } from '../../localize';
@@ -21,8 +21,8 @@ export class LocalProjectTreeItem extends RootTreeItem<IProjectRoot> implements 
     private _disposables: Disposable[] = [];
     private _localFunctionsTreeItem: LocalFunctionsTreeItem;
 
-    public constructor(projectPath: string, workspacePath: string) {
-        super(<IProjectRoot>{ projectPath, workspacePath });
+    public constructor(projectPath: string, workspacePath: string, workspaceFolder: WorkspaceFolder) {
+        super(<IProjectRoot>{ projectPath, workspacePath, workspaceFolder });
 
         this.projectName = path.basename(projectPath);
 

--- a/src/tree/localProject/getProjectTreeItems.ts
+++ b/src/tree/localProject/getProjectTreeItems.ts
@@ -21,7 +21,7 @@ export async function getProjectTreeItems(context: ExtensionContext): Promise<Az
         for (const folder of folders) {
             const projectPath: string | undefined = await tryGetFunctionProjectRoot(folder.uri.fsPath, true /* suppressPrompt */);
             if (projectPath) {
-                const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(projectPath, folder.uri.fsPath);
+                const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(projectPath, folder.uri.fsPath, folder);
                 context.subscriptions.push(treeItem);
                 // tslint:disable-next-line: no-any
                 result.push(treeItem);

--- a/src/vsCodeConfig/extensions.ts
+++ b/src/vsCodeConfig/extensions.ts
@@ -3,16 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TaskDefinition } from "vscode";
-
-export interface ITask extends TaskDefinition {
-    label?: string;
-    options?: ITaskOptions;
-}
-
-export interface ITaskOptions {
-    cwd?: string;
-    env?: {
-        [key: string]: string;
-    };
+export interface IExtensionsJson {
+    recommendations?: string[];
 }

--- a/src/vsCodeConfig/launch.ts
+++ b/src/vsCodeConfig/launch.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DebugConfiguration, workspace, WorkspaceConfiguration, WorkspaceFolder } from "vscode";
+
+const configurationsKey: string = 'configurations';
+const launchKey: string = 'launch';
+const versionKey: string = 'version';
+export const launchVersion: string = '0.2.0';
+
+export function getDebugConfigs(folder: WorkspaceFolder): DebugConfiguration[] {
+    // tslint:disable-next-line: strict-boolean-expressions
+    return getLaunchConfig(folder).get<DebugConfiguration[]>(configurationsKey) || [];
+}
+
+export function updateDebugConfigs(folder: WorkspaceFolder, configs: DebugConfiguration[]): void {
+    getLaunchConfig(folder).update(configurationsKey, configs);
+}
+
+export function getLaunchVersion(folder: WorkspaceFolder): string | undefined {
+    return getLaunchConfig(folder).get<string>(versionKey);
+}
+
+export function updateLaunchVersion(folder: WorkspaceFolder, version: string): void {
+    getLaunchConfig(folder).update(versionKey, version);
+}
+
+export function isDebugConfigEqual(c1: DebugConfiguration, c2: DebugConfiguration): boolean {
+    return c1.name === c2.name && c1.request === c2.request && c1.type === c2.type;
+}
+
+function getLaunchConfig(folder: WorkspaceFolder): WorkspaceConfiguration {
+    return workspace.getConfiguration(launchKey, folder.uri);
+}
+
+export interface ILaunchJson {
+    version: string;
+    configurations?: DebugConfiguration[];
+}

--- a/src/vsCodeConfig/tasks.ts
+++ b/src/vsCodeConfig/tasks.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TaskDefinition, workspace, WorkspaceConfiguration, WorkspaceFolder } from "vscode";
+
+const tasksKey: string = 'tasks';
+const versionKey: string = 'version';
+export const tasksVersion: string = '2.0.0';
+
+export function getTasks(folder: WorkspaceFolder): ITask[] {
+    // tslint:disable-next-line: strict-boolean-expressions
+    return getTasksConfig(folder).get<ITask[]>(tasksKey) || [];
+}
+
+export function updateTasks(folder: WorkspaceFolder, tasks: ITask[]): void {
+    getTasksConfig(folder).update(tasksKey, tasks);
+}
+
+export function getTasksVersion(folder: WorkspaceFolder): string | undefined {
+    return getTasksConfig(folder).get<string>(versionKey);
+}
+
+export function updateTasksVersion(folder: WorkspaceFolder, version: string): void {
+    getTasksConfig(folder).update(versionKey, version);
+}
+
+function getTasksConfig(folder: WorkspaceFolder): WorkspaceConfiguration {
+    return workspace.getConfiguration(tasksKey, folder.uri);
+}
+
+export interface ITasksJson {
+    version: string;
+    tasks?: ITask[];
+}
+
+export interface ITask extends TaskDefinition {
+    label?: string;
+    command?: string;
+    options?: ITaskOptions;
+}
+
+export interface ITaskOptions {
+    cwd?: string;
+    env?: {
+        [key: string]: string;
+    };
+}

--- a/src/vsCodeConfig/verifyJSDebugConfigIsValid.ts
+++ b/src/vsCodeConfig/verifyJSDebugConfigIsValid.ts
@@ -11,8 +11,8 @@ import { ProjectLanguage, ProjectRuntime, tasksFileName, vscodeFolderName } from
 import { oldFuncHostNameRegEx } from "../funcCoreTools/funcHostTask";
 import { tryGetLocalRuntimeVersion } from '../funcCoreTools/tryGetLocalRuntimeVersion';
 import { localize } from '../localize';
-import { ITask } from './ITask';
 import { promptToReinitializeProject } from './promptToReinitializeProject';
+import { ITask, ITasksJson } from './tasks';
 
 /**
  * JavaScript debugging in the func cli had breaking changes in v2.0.1-beta.30 (~6/2018). This verifies users are up-to-date with the latest working debug config.
@@ -31,7 +31,7 @@ export async function verifyJSDebugConfigIsValid(projectLanguage: ProjectLanguag
 
             // NOTE: Only checking against oldFuncHostNameRegEx (where label looks like "runFunctionsHost")
             // If they're using the tasks our extension provides (where label looks like "func: host start"), they are already good-to-go
-            const funcTask: ITask | undefined = tasksContent.tasks.find((t: ITask) => !!t.label && oldFuncHostNameRegEx.test(t.label));
+            const funcTask: ITask | undefined = tasksContent.tasks && tasksContent.tasks.find((t: ITask) => !!t.label && oldFuncHostNameRegEx.test(t.label));
             if (funcTask) {
                 actionContext.properties.verifyConfigPrompt = 'updateJSDebugConfig';
 
@@ -45,8 +45,4 @@ export async function verifyJSDebugConfigIsValid(projectLanguage: ProjectLanguag
             }
         }
     }
-}
-
-interface ITasksJson {
-    tasks: ITask[];
 }

--- a/src/vsCodeConfig/verifyTargetFramework.ts
+++ b/src/vsCodeConfig/verifyTargetFramework.ts
@@ -10,10 +10,10 @@ import { tryGetCsprojFile, tryGetFsprojFile, tryGetTargetFramework } from '../co
 import { deploySubpathSetting, ProjectLanguage } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { ITask } from './ITask';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './settings';
+import { getTasks, ITask, updateTasks } from './tasks';
 
-export async function verifyTargetFramework(projectLanguage: ProjectLanguage, workspacePath: string, projectPath: string, actionContext: IActionContext): Promise<void> {
+export async function verifyTargetFramework(projectLanguage: ProjectLanguage, folder: vscode.WorkspaceFolder, projectPath: string, actionContext: IActionContext): Promise<void> {
     const settingKey: string = 'showTargetFrameworkWarning';
     if (getWorkspaceSetting<boolean>(settingKey)) {
 
@@ -23,8 +23,8 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, wo
             const targetFramework: string | undefined = await tryGetTargetFramework(path.join(projectPath, projFileName));
             if (targetFramework) {
 
-                const tasksResult: IVerifyFrameworkResult | undefined = verifyTasksFramework(workspacePath, targetFramework);
-                const settingsResult: IVerifyFrameworkResult | undefined = verifySettingsFramework(workspacePath, targetFramework);
+                const tasksResult: IVerifyFrameworkResult | undefined = verifyTasksFramework(folder, targetFramework);
+                const settingsResult: IVerifyFrameworkResult | undefined = verifySettingsFramework(folder.uri.fsPath, targetFramework);
 
                 const mismatchTargetFramework: string | undefined = (tasksResult && tasksResult.mismatchTargetFramework) || (settingsResult && settingsResult.mismatchTargetFramework);
                 if (mismatchTargetFramework) {
@@ -37,7 +37,7 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, wo
                     const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, update, DialogResponses.dontWarnAgain);
                     if (result === DialogResponses.dontWarnAgain) {
                         actionContext.properties.verifyConfigResult = 'dontWarnAgain';
-                        await updateWorkspaceSetting(settingKey, false, workspacePath);
+                        await updateWorkspaceSetting(settingKey, false, folder.uri.fsPath);
                     } else if (result === update) {
                         actionContext.properties.verifyConfigResult = 'update';
                         if (tasksResult) {
@@ -64,31 +64,28 @@ interface IVerifyFrameworkResult {
 // https://docs.microsoft.com/dotnet/standard/frameworks
 const targetFrameworkRegExp: RegExp = /net(standard|coreapp)?[0-9.]+/i;
 
-function verifyTasksFramework(workspacePath: string, projTargetFramework: string): IVerifyFrameworkResult | undefined {
-    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('tasks', vscode.Uri.file(workspacePath));
-    const tasks: ITask[] | undefined = config.get<ITask[]>('tasks');
-    if (tasks) {
-        let mismatchTargetFramework: string | undefined;
+function verifyTasksFramework(folder: vscode.WorkspaceFolder, projTargetFramework: string): IVerifyFrameworkResult | undefined {
+    let mismatchTargetFramework: string | undefined;
 
-        for (const task of tasks) {
-            if (task.options && task.options.cwd) {
-                const matches: RegExpMatchArray | null = task.options.cwd.match(targetFrameworkRegExp);
-                const targetFramework: string | null = matches && matches[0];
-                if (targetFramework && targetFramework.toLowerCase() !== projTargetFramework.toLowerCase()) {
-                    mismatchTargetFramework = targetFramework;
-                    task.options.cwd = task.options.cwd.replace(targetFramework, projTargetFramework);
-                }
+    const tasks: ITask[] = getTasks(folder);
+    for (const task of tasks) {
+        if (task.options && task.options.cwd) {
+            const matches: RegExpMatchArray | null = task.options.cwd.match(targetFrameworkRegExp);
+            const targetFramework: string | null = matches && matches[0];
+            if (targetFramework && targetFramework.toLowerCase() !== projTargetFramework.toLowerCase()) {
+                mismatchTargetFramework = targetFramework;
+                task.options.cwd = task.options.cwd.replace(targetFramework, projTargetFramework);
             }
         }
+    }
 
-        if (mismatchTargetFramework) {
-            return {
-                mismatchTargetFramework,
-                update: async (): Promise<void> => {
-                    config.update('tasks', tasks);
-                }
-            };
-        }
+    if (mismatchTargetFramework) {
+        return {
+            mismatchTargetFramework,
+            update: async (): Promise<void> => {
+                updateTasks(folder, tasks);
+            }
+        };
     }
 
     return undefined;

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -44,7 +44,7 @@ export async function verifyVSCodeConfigOnActivate(actionContext: IActionContext
                             break;
                         case ProjectLanguage.CSharp:
                         case ProjectLanguage.FSharp:
-                            await verifyTargetFramework(projectLanguage, workspacePath, projectPath, actionContext);
+                            await verifyTargetFramework(projectLanguage, folder, projectPath, actionContext);
                             break;
                         default:
                     }

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -182,6 +182,147 @@ suite('Init Project For VS Code Tests', async function (this: ISuiteCallbackCont
         await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
+    const goodTasksFile: string = 'Existing Tasks File';
+    test(goodTasksFile, async () => {
+        const projectPath: string = path.join(testFolderPath, goodTasksFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'tasks.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "2.0.0",
+            tasks: [
+                {
+                    label: "hello world",
+                    command: "echo 'hello world'",
+                    type: "shell"
+                }
+            ]
+        });
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
+        const options: IValidateProjectOptions = getJavaScriptValidateOptions();
+        options.expectedTasks.push('hello world');
+        await validateProject(projectPath, options);
+    });
+
+    const badTasksFile: string = 'Poorly Formed Tasks File';
+    test(badTasksFile, async () => {
+        const projectPath: string = path.join(testFolderPath, badTasksFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'tasks.json');
+        await fse.ensureFile(filePath);
+        await fse.writeFile(filePath, '{');
+        // This should simply prompt the user to overwrite the file since we can't parse it
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const overwriteTask: string = 'Overwrite Existing Task';
+    test(overwriteTask, async () => {
+        const projectPath: string = path.join(testFolderPath, overwriteTask);
+        const filePath: string = path.join(projectPath, '.vscode', 'tasks.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "2.0.0",
+            tasks: [
+                {
+                    type: "func",
+                    command: "host start"
+                }
+            ]
+        });
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const oldTasksFile: string = 'Old Tasks File';
+    test(oldTasksFile, async () => {
+        const projectPath: string = path.join(testFolderPath, oldTasksFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'tasks.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "1.0.0",
+            tasks: [
+                {
+                    label: "hello world",
+                    command: "echo 'hello world'",
+                    type: "shell"
+                }
+            ]
+        });
+        // This should simply prompt the user to overwrite the file since the version is old
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const goodLaunchFile: string = 'Existing Launch File';
+    test(goodLaunchFile, async () => {
+        const projectPath: string = path.join(testFolderPath, goodLaunchFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'launch.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "0.2.0",
+            configurations: [
+                {
+                    name: "Launch 1",
+                    request: "attach",
+                    type: "node"
+                }
+            ]
+        });
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
+        const options: IValidateProjectOptions = getJavaScriptValidateOptions();
+        options.expectedDebugConfigs.push('Launch 1');
+        await validateProject(projectPath, options);
+    });
+
+    const badLaunchFile: string = 'Poorly Formed Launch File';
+    test(badLaunchFile, async () => {
+        const projectPath: string = path.join(testFolderPath, badLaunchFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'launch.json');
+        await fse.ensureFile(filePath);
+        await fse.writeFile(filePath, '{');
+        // This should simply prompt the user to overwrite the file since we can't parse it
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const overwriteConfig: string = 'Overwrite Existing Debug Config';
+    test(overwriteConfig, async () => {
+        const projectPath: string = path.join(testFolderPath, overwriteConfig);
+        const filePath: string = path.join(projectPath, '.vscode', 'launch.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "0.2.0",
+            configurations: [
+                {
+                    name: "Attach to Node Functions",
+                    type: "node",
+                    request: "attach"
+                }
+            ]
+        });
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const oldLaunchFile: string = 'Old Launch File';
+    test(oldLaunchFile, async () => {
+        const projectPath: string = path.join(testFolderPath, oldLaunchFile);
+        const filePath: string = path.join(projectPath, '.vscode', 'launch.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "0.1.0",
+            configurations: [
+                {
+                    name: "Launch 1",
+                    request: "attach",
+                    type: "node"
+                }
+            ]
+        });
+        // This should simply prompt the user to overwrite the file since the version is old
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript, DialogResponses.yes.title);
+        await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
     const badGitignoreFile: string = 'Bad gitignore File';
     test(badGitignoreFile, async () => {
         const projectPath: string = path.join(testFolderPath, badGitignoreFile);

--- a/test/tslint.json
+++ b/test/tslint.json
@@ -17,6 +17,7 @@
             "member-variable-declaration"
             // "object-destructuring",
             // "array-destructuring"
-        ]
+        ],
+        "no-unexternalized-strings": false
     }
 }


### PR DESCRIPTION
As opposed to overwriting the "tasks.json" and "launch.json" files if they already exist, we will just add our config to those files. I think this is especially necessary when users have their Functions project in a sub directory because that means they could have existing debug configs for other projects in other sub directories.