### PR TITLE
No longer recommend preDeployTask

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -80,7 +80,7 @@ export async function deploy(this: IActionContext, target?: vscode.Uri | string 
         this.properties.cancelStep = '';
     }
 
-    await runPreDeployTask(this, deployFsPath, siteConfig.scmType, language, runtime);
+    await runPreDeployTask(this, deployFsPath, siteConfig.scmType);
 
     if (siteConfig.scmType === ScmType.LocalGit) {
         // preDeploy tasks are not required for LocalGit so subpath may not exist

--- a/src/commands/deploy/runPreDeployTask.ts
+++ b/src/commands/deploy/runPreDeployTask.ts
@@ -3,18 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as os from 'os';
 import * as vscode from 'vscode';
 import { handleFailedPreDeployTask, IPreDeployTaskResult, tryRunPreDeployTask } from 'vscode-azureappservice';
 import { DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
-import { dotnetPublishTaskLabel, extensionPrefix, extInstallTaskName, javaPackageTaskLabel, packTaskName, preDeployTaskSetting, ProjectLanguage, ProjectRuntime } from '../../constants';
-import { ext } from '../../extensionVariables';
+import { extensionPrefix, packTaskName, preDeployTaskSetting, tasksFileName } from '../../constants';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
 import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 
-export async function runPreDeployTask(actionContext: IActionContext, deployFsPath: string, scmType: string | undefined, language: ProjectLanguage, runtime: ProjectRuntime): Promise<void> {
+export async function runPreDeployTask(actionContext: IActionContext, deployFsPath: string, scmType: string | undefined): Promise<void> {
     const preDeployTask: string | undefined = getWorkspaceSetting(preDeployTaskSetting, deployFsPath);
     if (preDeployTask && preDeployTask.startsWith('func:')) {
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to run preDeployTask "{0}".', preDeployTask);
@@ -30,46 +28,10 @@ export async function runPreDeployTask(actionContext: IActionContext, deployFsPa
         result = await promptToBuildNativeDeps(actionContext, deployFsPath, scmType);
     }
 
-    const messageLines: string[] = [];
-    if (!result.taskName) {
-        const recommendedTaskName: string | undefined = getRecommendedTaskName(language, runtime);
-        if (recommendedTaskName) {
-            messageLines.push(localize('noPreDeployTaskWarning', 'WARNING: Did not find recommended preDeploy task "{0}". The deployment will continue, but the selected folder may not reflect your latest changes.', recommendedTaskName));
-            messageLines.push(localize('howToAddPreDeploy', 'In order to ensure that you always deploy your latest changes, add a preDeploy task with the following steps:'));
-            const fullMessage: string = getFullPreDeployMessage(messageLines);
-            ext.outputChannel.show(true);
-            ext.outputChannel.appendLine(fullMessage);
-        }
-    } else if (result.failedToFindTask) {
-        messageLines.push(localize('noPreDeployTaskError', 'Did not find preDeploy task "{0}". Change the "{1}.{2}" setting, manually edit your task.json, or re-initialize your VS Code config with the following steps:', result.taskName, extensionPrefix, preDeployTaskSetting));
-        const fullMessage: string = getFullPreDeployMessage(messageLines);
-        throw new Error(fullMessage);
+    if (result.failedToFindTask) {
+        throw new Error(localize('noPreDeployTaskError', 'Failed to find preDeploy task "{0}". Modify the setting "{1}.{2}" or add that task to {3}.', result.taskName, extensionPrefix, preDeployTaskSetting, tasksFileName));
     } else if (result.exitCode !== undefined && result.exitCode !== 0) {
         await handleFailedPreDeployTask(actionContext, result);
-    }
-}
-
-function getFullPreDeployMessage(messageLines: string[]): string {
-    messageLines.push(localize('howToAddPreDeploy1', '1. Open Command Palette (View -> Command Palette...)'));
-    messageLines.push(localize('howToAddPreDeploy2', '2. Search for "Azure Functions" and run command "Initialize Project for Use with VS Code"'));
-    messageLines.push(localize('howToAddPreDeploy3', '3. Select "Yes" to overwrite your tasks.json file when prompted'));
-    return messageLines.join(os.EOL);
-}
-
-function getRecommendedTaskName(language: ProjectLanguage, runtime: ProjectRuntime): string | undefined {
-    switch (language) {
-        case ProjectLanguage.CSharp:
-        case ProjectLanguage.FSharp:
-            return dotnetPublishTaskLabel;
-        case ProjectLanguage.JavaScript:
-            // "func extensions install" is only supported on v2
-            return runtime === ProjectRuntime.v1 ? undefined : extInstallTaskName;
-        case ProjectLanguage.Python:
-            return packTaskName;
-        case ProjectLanguage.Java:
-            return javaPackageTaskLabel;
-        default:
-            return undefined; // preDeployTask not needed
     }
 }
 


### PR DESCRIPTION
We originally added this logic specifically for `func extensions install` because it was not an obvious task and because it was added after many users had already created projects without it. Now - that task isn't required. I don't think it's worth keeping the logic for the other tasks, since those are language-specific, pretty obvious, and the vast majority of projects have them by default anyways.

![Screen Shot 2019-04-19 at 10 11 28 AM](https://user-images.githubusercontent.com/11282622/56435150-4e4b1e00-628c-11e9-9fa6-33aa19d953b3.png)
