### PR TITLE
Unblock F# function creation

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -85,6 +85,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                     executeSteps.push(await JavaFunctionCreateStep.createStep(wizardContext.actionContext));
                     break;
                 case ProjectLanguage.CSharp:
+                case ProjectLanguage.FSharp:
                     executeSteps.push(await DotnetFunctionCreateStep.createStep(wizardContext.actionContext));
                     break;
                 case ProjectLanguage.TypeScript:

--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
@@ -12,7 +12,7 @@ import { cpUtils } from '../../../utils/cpUtils';
 import { dotnetUtils } from '../../../utils/dotnetUtils';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionCreateStepBase } from '../FunctionCreateStepBase';
-import { IDotnetFunctionWizardContext } from './IDotnetFunctionWizardContext';
+import { getFileExtension, IDotnetFunctionWizardContext } from './IDotnetFunctionWizardContext';
 
 export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunctionWizardContext> {
     private constructor() {
@@ -27,9 +27,10 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
     public async executeCore(wizardContext: IDotnetFunctionWizardContext): Promise<string> {
         const template: IFunctionTemplate = nonNullProp(wizardContext, 'functionTemplate');
 
+        const functionName: string = nonNullProp(wizardContext, 'functionName');
         const args: string[] = [];
         args.push('--arg:name');
-        args.push(cpUtils.wrapArgInQuotes(nonNullProp(wizardContext, 'functionName')));
+        args.push(cpUtils.wrapArgInQuotes(functionName));
 
         args.push('--arg:namespace');
         args.push(cpUtils.wrapArgInQuotes(nonNullProp(wizardContext, 'namespace')));
@@ -43,6 +44,6 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
         const runtime: ProjectRuntime = nonNullProp(wizardContext, 'runtime');
         await executeDotnetTemplateCommand(runtime, wizardContext.projectPath, 'create', '--identity', template.id, ...args);
 
-        return path.join(wizardContext.projectPath, `${wizardContext.functionName}.cs`);
+        return path.join(wizardContext.projectPath, functionName + getFileExtension(wizardContext));
     }
 }

--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionNameStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionNameStep.ts
@@ -10,16 +10,16 @@ import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
 import * as fsUtil from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionNameStepBase } from '../FunctionNameStepBase';
-import { IDotnetFunctionWizardContext } from './IDotnetFunctionWizardContext';
+import { getFileExtension, IDotnetFunctionWizardContext } from './IDotnetFunctionWizardContext';
 
 export class DotnetFunctionNameStep extends FunctionNameStepBase<IDotnetFunctionWizardContext> {
     protected async getUniqueFunctionName(wizardContext: IDotnetFunctionWizardContext): Promise<string | undefined> {
         const template: IFunctionTemplate = nonNullProp(wizardContext, 'functionTemplate');
-        return await fsUtil.getUniqueFsPath(wizardContext.projectPath, template.defaultFunctionName, '.cs');
+        return await fsUtil.getUniqueFsPath(wizardContext.projectPath, template.defaultFunctionName, getFileExtension(wizardContext));
     }
 
     protected async validateFunctionNameCore(wizardContext: IDotnetFunctionWizardContext, name: string): Promise<string | undefined> {
-        if (await fse.pathExists(path.join(wizardContext.projectPath, `${name}.cs`))) {
+        if (await fse.pathExists(path.join(wizardContext.projectPath, name + getFileExtension(wizardContext)))) {
             return localize('existingFile', 'A file with the name "{0}" already exists.', name);
         } else {
             return undefined;

--- a/src/commands/createFunction/dotnetSteps/IDotnetFunctionWizardContext.ts
+++ b/src/commands/createFunction/dotnetSteps/IDotnetFunctionWizardContext.ts
@@ -3,8 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ProjectLanguage } from '../../../constants';
 import { IFunctionWizardContext } from '../IFunctionWizardContext';
 
 export interface IDotnetFunctionWizardContext extends IFunctionWizardContext {
     namespace?: string;
+}
+
+export function getFileExtension(wizardContext: IDotnetFunctionWizardContext): string {
+    return wizardContext.language === ProjectLanguage.FSharp ? '.fs' : '.cs';
 }

--- a/src/templates/parseDotnetTemplates.ts
+++ b/src/templates/parseDotnetTemplates.ts
@@ -58,7 +58,7 @@ function parseDotnetTemplate(rawTemplate: IRawTemplate): IFunctionTemplate {
         id: rawTemplate.Identity,
         name: rawTemplate.Name,
         defaultFunctionName: rawTemplate.DefaultName,
-        language: ProjectLanguage.CSharp,
+        language: /FSharp/i.test(rawTemplate.Identity) ? ProjectLanguage.FSharp : ProjectLanguage.CSharp,
         userPromptedSettings: userPromptedSettings,
         categories: [TemplateCategory.Core] // Dotnet templates do not have category information, so display all templates as if they are in the 'core' category
     };
@@ -73,7 +73,7 @@ export function parseDotnetTemplates(rawTemplates: object[], runtime: ProjectRun
     for (const rawTemplate of rawTemplates) {
         try {
             const template: IFunctionTemplate = parseDotnetTemplate(<IRawTemplate>rawTemplate);
-            if (template.id.startsWith('Azure.Function.CSharp.') &&
+            if (/^Azure\.Function\.(F|C)Sharp\./i.test(template.id) &&
                 ((runtime === ProjectRuntime.v1 && template.id.includes('1')) || (runtime === ProjectRuntime.v2 && template.id.includes('2')))) {
                 templates.push(template);
             }


### PR DESCRIPTION
One of the last pieces of https://github.com/Microsoft/vscode-azurefunctions/issues/315. The [recently added](https://github.com/Azure/azure-functions-templates/issues/627#issuecomment-485029965) templates should show up when the template filter is set to "All".

Only remaining work is to add templates to "Verified" category, make sure tests are up-to-par with other languages, and finally show F# in the "New Project" quick pick. Will likely do that after build conference.