### PR TITLE
Add package.json to JavaScript projects

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -11,6 +11,21 @@ import { IProjectWizardContext } from '../IProjectWizardContext';
 import { JavaScriptProjectCreateStep } from './JavaScriptProjectCreateStep';
 
 export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
+    protected packageJsonScripts: { [key: string]: string } = {
+        build: 'tsc',
+        watch: 'tsc -w',
+        prestart: 'npm run build && func extensions install',
+        'start:host': 'func start',
+        start: 'npm run start:host & npm run watch',
+        'build:production': 'npm run prestart && npm prune --production',
+        test: 'echo \"No tests yet...\"'
+    };
+
+    protected packageJsonDevDeps: { [key: string]: string } = {
+        '@azure/functions': '^1.0.2-beta2',
+        typescript: '^3.3.3'
+    };
+
     public async executeCore(wizardContext: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         await super.executeCore(wizardContext, progress);
 
@@ -24,51 +39,6 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
                     rootDir: '.',
                     sourceMap: true,
                     strict: false
-                }
-            });
-        }
-
-        const packagePath: string = path.join(wizardContext.projectPath, 'package.json');
-        if (await confirmOverwriteFile(packagePath)) {
-            await writeFormattedJson(packagePath, {
-                name: path.basename(wizardContext.projectPath),
-                description: '',
-                version: '0.1.0',
-                scripts: {
-                    build: 'tsc',
-                    watch: 'tsc -w',
-                    prestart: 'npm run build && func extensions install',
-                    'start:host': 'func start',
-                    start: 'npm run start:host & npm run watch',
-                    'build:production': 'npm run prestart && npm prune --production',
-                    test: 'echo \"No tests yet...\"'
-                },
-                dependencies: {},
-                devDependencies: {
-                    '@azure/functions': '^1.0.1-beta2',
-                    typescript: '^3.3.3'
-                }
-            });
-
-            const packageLockPath: string = path.join(wizardContext.projectPath, 'package-lock.json');
-            await writeFormattedJson(packageLockPath, {
-                name: path.basename(wizardContext.projectPath),
-                version: '0.1.0',
-                lockfileVersion: 1,
-                requires: true,
-                dependencies: {
-                    '@azure/functions': {
-                        version: '1.0.1-beta2',
-                        resolved: 'https://registry.npmjs.org/@azure/functions/-/functions-1.0.1-beta2.tgz',
-                        integrity: 'sha512-ewVNxU2fqSCLbLuHwwvcL2ExgYNIhaztgHQfBShM9bpCBlAufTrvqlGnsEMfYv2F+BmJrkvhcDWE7E8cDz4X0g==',
-                        dev: true
-                    },
-                    typescript: {
-                        version: '3.3.3',
-                        resolved: 'https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz',
-                        integrity: 'sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==',
-                        dev: true
-                    }
                 }
             });
         }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
@@ -3,12 +3,58 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DebugConfiguration } from "vscode";
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { DebugConfiguration, TaskDefinition } from "vscode";
+import { extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand } from "../../../constants";
 import { nodeDebugConfig } from "../../../debug/NodeDebugProvider";
+import { IProjectWizardContext } from "../../createNewProject/IProjectWizardContext";
 import { ScriptInitVSCodeStep } from './ScriptInitVSCodeStep';
 
+const npmInstallTaskLabel: string = 'npm install';
+const npmPruneTaskLabel: string = 'npm prune';
+
 export class JavaScriptInitVSCodeStep extends ScriptInitVSCodeStep {
+    private hasPackageJson: boolean;
+
+    protected async executeCore(wizardContext: IProjectWizardContext): Promise<void> {
+        await super.executeCore(wizardContext);
+
+        this.hasPackageJson = await fse.pathExists(path.join(wizardContext.projectPath, 'package.json'));
+        if (this.hasPackageJson) {
+            this.preDeployTask = npmPruneTaskLabel;
+        }
+    }
+
     protected getDebugConfiguration(): DebugConfiguration {
         return nodeDebugConfig;
+    }
+
+    protected getTasks(): TaskDefinition[] {
+        if (!this.hasPackageJson) {
+            return super.getTasks();
+        } else {
+            return [
+                {
+                    type: func,
+                    command: hostStartCommand,
+                    problemMatcher: funcWatchProblemMatcher,
+                    isBackground: true,
+                    dependsOn: this.requiresFuncExtensionsInstall ? [extInstallTaskName, npmInstallTaskLabel] : npmInstallTaskLabel
+                },
+                {
+                    type: 'shell',
+                    label: npmInstallTaskLabel,
+                    command: 'npm install'
+                },
+                {
+                    type: 'shell',
+                    label: npmPruneTaskLabel,
+                    command: 'npm prune --production', // This removes dev dependencies, but importantly also installs prod dependencies
+                    dependsOn: this.requiresFuncExtensionsInstall ? extInstallTaskName : undefined,
+                    problemMatcher: []
+                }
+            ];
+        }
     }
 }

--- a/test/createNewProject.test.ts
+++ b/test/createNewProject.test.ts
@@ -53,7 +53,7 @@ suite('Create New Project', async function (this: ISuiteCallbackContext): Promis
     test(javaScriptProject, async () => {
         const projectPath: string = path.join(testFolderPath, javaScriptProject);
         await testCreateNewProject(projectPath, ProjectLanguage.JavaScript);
-        await validateProject(projectPath, getJavaScriptValidateOptions());
+        await validateProject(projectPath, getJavaScriptValidateOptions(true /* hasPackageJson */));
     });
 
     const csharpProject: string = 'CSharpProject';
@@ -142,7 +142,7 @@ suite('Create New Project', async function (this: ISuiteCallbackContext): Promis
         const projectPath: string = path.join(testFolderPath, 'createNewProjectApi');
         ext.ui = new TestUserInput([/skip for now/i]);
         await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'JavaScript', '~2', false /* openFolder */);
-        await validateProject(projectPath, getJavaScriptValidateOptions());
+        await validateProject(projectPath, getJavaScriptValidateOptions(true /* hasPackageJson */));
     });
 
     // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-new-project

--- a/test/initProjectForVSCode.test.ts
+++ b/test/initProjectForVSCode.test.ts
@@ -24,6 +24,15 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
         await validateProject(projectPath, getJavaScriptValidateOptions());
     });
 
+    const javaScriptProjectWithPackageJson: string = 'AutoDetectJavaScriptProjectWithPackageJson';
+    test(javaScriptProjectWithPackageJson, async () => {
+        const projectPath: string = path.join(testFolderPath, javaScriptProjectWithPackageJson);
+        await fse.ensureFile(path.join(projectPath, 'HttpTriggerJS', 'index.js'));
+        await fse.ensureFile(path.join(projectPath, 'package.json'));
+        await testInitProjectForVSCode(projectPath);
+        await validateProject(projectPath, getJavaScriptValidateOptions(true /* hasPackageJson */));
+    });
+
     const javaScriptProjectWithExtensions: string = 'AutoDetectJavaScriptProjectWithExtensions';
     test(javaScriptProjectWithExtensions, async () => {
         const projectPath: string = path.join(testFolderPath, javaScriptProjectWithExtensions);
@@ -230,6 +239,30 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
         });
         await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
         await validateProject(projectPath, getJavaScriptValidateOptions());
+    });
+
+    const overwriteMultipleTasks: string = 'Overwrite Multiple Existing Tasks';
+    test(overwriteMultipleTasks, async () => {
+        const projectPath: string = path.join(testFolderPath, overwriteMultipleTasks);
+        await fse.ensureFile(path.join(projectPath, 'package.json'));
+        const filePath: string = path.join(projectPath, '.vscode', 'tasks.json');
+        await fse.ensureFile(filePath);
+        await fse.writeJSON(filePath, {
+            version: "2.0.0",
+            tasks: [
+                {
+                    type: "func",
+                    command: "host start"
+                },
+                {
+                    type: "shell",
+                    label: "npm install",
+                    command: "whoops"
+                }
+            ]
+        });
+        await testInitProjectForVSCode(projectPath, ProjectLanguage.JavaScript);
+        await validateProject(projectPath, getJavaScriptValidateOptions(true /* hasPackageJson */));
     });
 
     const oldTasksFile: string = 'Old Tasks File';

--- a/test/validateProject.ts
+++ b/test/validateProject.ts
@@ -8,23 +8,30 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { extensionPrefix, IExtensionsJson, ILaunchJson, ITasksJson, ProjectLanguage, ProjectRuntime } from '../extension.bundle';
 
-export function getJavaScriptValidateOptions(): IValidateProjectOptions {
+export function getJavaScriptValidateOptions(hasPackageJson: boolean = false): IValidateProjectOptions {
+    const expectedSettings: { [key: string]: string } = {
+        projectLanguage: ProjectLanguage.JavaScript,
+        projectRuntime: ProjectRuntime.v2,
+        deploySubpath: '.'
+    };
+    const expectedPaths: string[] = [];
+    const expectedTasks: string[] = ['host start'];
+
+    if (hasPackageJson) {
+        expectedSettings.preDeployTask = 'npm prune';
+        expectedPaths.push('package.json');
+        expectedTasks.push('npm install', 'npm prune');
+    }
+
     return {
-        expectedSettings: {
-            projectLanguage: ProjectLanguage.JavaScript,
-            projectRuntime: ProjectRuntime.v2,
-            deploySubpath: '.'
-        },
-        expectedPaths: [
-        ],
+        expectedSettings,
+        expectedPaths,
         expectedExtensionRecs: [
         ],
         expectedDebugConfigs: [
             'Attach to Node Functions'
         ],
-        expectedTasks: [
-            'host start'
-        ]
+        expectedTasks
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vscode-azurefunctions/issues/1155

As part of this change, I also stopped writing down package-lock.json in the typescript scenario. I just don't think it's worth it. There's a lot of different versions of npm so it would change immediately for a lot of users anyways. The only previous concern was that people might get stuck in a bad situation if the latest version of `typescript` or `@azure/functions` has problems, but the user could easily change the version in their package.json - plus Microsoft owns both of those packages so I guess I'm fine taking that minimal risk.