### PR TITLE
Workaround multi-root workspace bug

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -9,6 +9,11 @@ import { IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import * as fsUtils from './fs';
 
+export function isMultiRootWorkspace(): boolean {
+    return !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
+        && vscode.workspace.name !== vscode.workspace.workspaceFolders[0].name;
+}
+
 export async function selectWorkspaceFolder(ui: IAzureUserInput, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
     return await selectWorkspaceItem(
         ui,

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -11,7 +11,7 @@ import * as fsUtils from './fs';
 
 export function isMultiRootWorkspace(): boolean {
     return !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
-        && vscode.workspace.name !== vscode.workspace.workspaceFolders[0].name;
+        && vscode.workspace.name !== vscode.workspace.workspaceFolders[0].name; // multi-root workspaces always have something like "(Workspace)" appended to their name
 }
 
 export async function selectWorkspaceFolder(ui: IAzureUserInput, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {


### PR DESCRIPTION
If you have a multi-root workspace open when creating a project or initializing for use with VS Code, the tasks and launch config won't be updated. This is likely a bug in VS Code, but would be a regression from the previous release since I added the logic to use VS Code api's here: https://github.com/Microsoft/vscode-azurefunctions/pull/1196

Related: https://github.com/Microsoft/vscode-azurefunctions/issues/1235