### PR TITLE
Additional validation in verifyInitForVSCode

### DIFF
--- a/src/utils/nonNull.ts
+++ b/src/utils/nonNull.ts
@@ -17,12 +17,25 @@ export function nonNullProp<TSource, TKey extends keyof TSource>(source: TSource
 /**
  * Validates that a given value is not null and not undefined.
  */
-// tslint:disable-next-line:no-any
 export function nonNullValue<T>(value: T | undefined, propertyNameOrMessage?: string): T {
     if (isNullOrUndefined(value)) {
         throw new Error(
             // tslint:disable-next-line:prefer-template
             'Internal error: Expected value to be neither null nor undefined'
+            + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
+    }
+
+    return value;
+}
+
+/**
+ * Validates that a given string is not null, undefined, nor empty
+ */
+export function nonNullOrEmptyValue(value: string | undefined, propertyNameOrMessage?: string): string {
+    if (!value) {
+        throw new Error(
+            // tslint:disable-next-line:prefer-template
+            'Internal error: Expected value to be neither null, undefined, nor empty'
             + (propertyNameOrMessage ? `: ${propertyNameOrMessage}` : ''));
     }
 

--- a/src/vsCodeConfig/verifyInitForVSCode.ts
+++ b/src/vsCodeConfig/verifyInitForVSCode.ts
@@ -8,7 +8,7 @@ import { initProjectForVSCode } from '../commands/initProjectForVSCode/initProje
 import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { nonNullValue } from '../utils/nonNull';
+import { nonNullOrEmptyValue } from '../utils/nonNull';
 import { convertStringToRuntime, getWorkspaceSetting } from './settings';
 
 /**
@@ -23,8 +23,8 @@ export async function verifyInitForVSCode(actionContext: IActionContext, fsPath:
         // No need to check result - cancel will throw a UserCancelledError
         await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes);
         await initProjectForVSCode(actionContext, fsPath);
-        language = nonNullValue(getWorkspaceSetting(projectLanguageSetting, fsPath));
-        runtime = nonNullValue(getWorkspaceSetting(projectRuntimeSetting, fsPath));
+        language = nonNullOrEmptyValue(getWorkspaceSetting(projectLanguageSetting, fsPath));
+        runtime = nonNullOrEmptyValue(convertStringToRuntime(getWorkspaceSetting(projectRuntimeSetting, fsPath)));
     }
 
     return [<ProjectLanguage>language, <ProjectRuntime>runtime];

--- a/src/vsCodeConfig/verifyInitForVSCode.ts
+++ b/src/vsCodeConfig/verifyInitForVSCode.ts
@@ -23,8 +23,8 @@ export async function verifyInitForVSCode(actionContext: IActionContext, fsPath:
         // No need to check result - cancel will throw a UserCancelledError
         await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes);
         await initProjectForVSCode(actionContext, fsPath);
-        language = nonNullOrEmptyValue(getWorkspaceSetting(projectLanguageSetting, fsPath));
-        runtime = nonNullOrEmptyValue(convertStringToRuntime(getWorkspaceSetting(projectRuntimeSetting, fsPath)));
+        language = nonNullOrEmptyValue(getWorkspaceSetting(projectLanguageSetting, fsPath), projectLanguageSetting);
+        runtime = nonNullOrEmptyValue(convertStringToRuntime(getWorkspaceSetting(projectRuntimeSetting, fsPath)), projectRuntimeSetting);
     }
 
     return [<ProjectLanguage>language, <ProjectRuntime>runtime];


### PR DESCRIPTION
Before this PR: https://github.com/Microsoft/vscode-azurefunctions/pull/1183, there was a bug where the newly added settings were not returned properly in `verifyInitForVSCode`. However, that bug was hard to diagnose/solve because `nonNullValue` was not throwing an error for an empty string. If for some reason my above PR didn't fix all cases, at least now we'll get more accurate error message/call stack.