### PR TITLE
Remove emulator option for non-windows

### DIFF
--- a/src/commands/appSettings/AzureWebJobsStorageExecuteStep.ts
+++ b/src/commands/appSettings/AzureWebJobsStorageExecuteStep.ts
@@ -14,7 +14,6 @@ export class AzureWebJobsStorageExecuteStep<T extends IAzureWebJobsStorageWizard
 
     public async execute(wizardContext: IAzureWebJobsStorageWizardContext): Promise<void> {
         let value: string;
-        wizardContext.actionContext.properties.azureWebJobsStorageType = wizardContext.azureWebJobsStorageType;
         if (wizardContext.azureWebJobsStorageType === 'emulator') {
             value = localEmulatorConnectionString;
         } else {


### PR DESCRIPTION
The emulator story on non-windows is using Azurite - but that has some limitations (see https://github.com/Microsoft/vscode-azurefunctions/issues/1245) and probably isn't up-to-par quite yet

Since I'm not showing the emulator, I feel like I need to do a "Skip for now" button
![Screen Shot 2019-04-30 at 2 30 16 PM](https://user-images.githubusercontent.com/11282622/56995372-72ddaa80-6b56-11e9-9746-33975c4c22eb.png)

![Screen Shot 2019-04-30 at 2 44 49 PM](https://user-images.githubusercontent.com/11282622/56995397-85f07a80-6b56-11e9-8ee3-5f354c458f83.png)
