### PR TITLE
Be more careful about when to add bundle config

### DIFF
--- a/src/commands/createFunction/FunctionCreateStepBase.ts
+++ b/src/commands/createFunction/FunctionCreateStepBase.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress, Uri, window, workspace } from 'vscode';
 import { AzureWizardExecuteStep, callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'vscode-azureextensionui';
-import { extInstallTaskName, hostFileName, ProjectLanguage, ProjectRuntime, settingsFileName, tasksFileName, vscodeFolderName } from '../../constants';
+import { extInstallCommand, hostFileName, ProjectLanguage, ProjectRuntime, settingsFileName, tasksFileName, vscodeFolderName } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { IHostJsonV2 } from '../../funcConfig/host';
 import { localize } from '../../localize';
@@ -108,7 +108,7 @@ export abstract class FunctionCreateStepBase<T extends IFunctionWizardContext> e
                 const filePath: string = path.join(wizardContext.workspacePath, vscodeFolderName, file);
                 if (await fse.pathExists(filePath)) {
                     const contents: string = (await fse.readFile(filePath)).toString();
-                    if (contents.includes(extInstallTaskName)) {
+                    if (contents.includes(extInstallCommand)) {
                         return false;
                     }
                 }

--- a/src/commands/createFunction/FunctionCreateStepBase.ts
+++ b/src/commands/createFunction/FunctionCreateStepBase.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress, Uri, window, workspace } from 'vscode';
 import { AzureWizardExecuteStep, callWithTelemetryAndErrorHandling, IActionContext, parseError } from 'vscode-azureextensionui';
-import { hostFileName, ProjectRuntime } from '../../constants';
+import { extInstallTaskName, hostFileName, ProjectLanguage, ProjectRuntime, settingsFileName, tasksFileName, vscodeFolderName } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { IHostJsonV2 } from '../../funcConfig/host';
 import { localize } from '../../localize';
@@ -54,7 +54,7 @@ export abstract class FunctionCreateStepBase<T extends IFunctionWizardContext> e
         progress.report({ message: localize('creatingFunction', 'Creating new {0}...', template.name) });
 
         const newFilePath: string = await this.executeCore(wizardContext);
-        if (wizardContext.runtime !== ProjectRuntime.v1 && !template.isHttpTrigger && !template.isTimerTrigger) {
+        if (await this.shouldUseExtensionBundle(wizardContext, template)) {
             await this.verifyExtensionBundle(wizardContext);
         }
 
@@ -89,6 +89,35 @@ export abstract class FunctionCreateStepBase<T extends IFunctionWizardContext> e
 
     public shouldExecute(wizardContext: T): boolean {
         return !!wizardContext.functionTemplate;
+    }
+
+    private async shouldUseExtensionBundle(wizardContext: T, template: IFunctionTemplate): Promise<boolean> {
+        // v1 doesn't support bundles
+        // http and timer triggers don't need a bundle
+        // F# and C# specify extensions as dependencies in their proj file instead of using a bundle
+        if (wizardContext.runtime === ProjectRuntime.v1 ||
+            template.isHttpTrigger || template.isTimerTrigger ||
+            wizardContext.language === ProjectLanguage.CSharp || wizardContext.language === ProjectLanguage.FSharp) {
+            return false;
+        }
+
+        // Old projects setup to use "func extensions install" shouldn't use a bundle because it could lead to duplicate or conflicting binaries
+        try {
+            const filesToCheck: string[] = [tasksFileName, settingsFileName];
+            for (const file of filesToCheck) {
+                const filePath: string = path.join(wizardContext.workspacePath, vscodeFolderName, file);
+                if (await fse.pathExists(filePath)) {
+                    const contents: string = (await fse.readFile(filePath)).toString();
+                    if (contents.includes(extInstallTaskName)) {
+                        return false;
+                    }
+                }
+            }
+        } catch {
+            // ignore and use bundles (the default for new projects)
+        }
+
+        return true;
     }
 }
 

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { DebugConfiguration, TaskDefinition } from 'vscode';
-import { extensionPrefix, extInstallCommand, func, funcWatchProblemMatcher, gitignoreFileName, hostStartCommand, packTaskName, Platform, pythonVenvSetting } from "../../../constants";
+import { extensionPrefix, extInstallCommand, extInstallTaskName, func, funcWatchProblemMatcher, gitignoreFileName, hostStartCommand, packTaskName, Platform, pythonVenvSetting } from "../../../constants";
 import { pythonDebugConfig } from '../../../debug/PythonDebugProvider';
 import { venvUtils } from '../../../utils/venvUtils';
 import { IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
@@ -38,7 +38,7 @@ export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
 
     protected getTasks(): TaskDefinition[] {
         const pipInstallLabel: string = 'pipInstall';
-        const dependsOn: string | undefined = this.requiresFuncExtensionsInstall ? extInstallCommand : this._venvName ? pipInstallLabel : undefined;
+        const dependsOn: string | undefined = this.requiresFuncExtensionsInstall ? extInstallTaskName : this._venvName ? pipInstallLabel : undefined;
         const tasks: TaskDefinition[] = [
             {
                 type: func,


### PR DESCRIPTION
I was testing a Cosmos DB trigger on an old version of the func cli and ran into an issue. The project worked fine locally and successfully deployed, but wasn't actually working in Azure. I dug into the remote logs and found this:
```
2019-05-01T01:06:12.457 [Error] A host error has occurred
System.TypeLoadException : Could not load type 'Microsoft.Azure.Documents.ChangeFeedProcessor.Monitoring.IHealthMonitor' from assembly 'Microsoft.Azure.Documents.ChangeFeedProcessor, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
   at Microsoft.Azure.WebJobs.Extensions.CosmosDB.CosmosDBTriggerListener..ctor(ITriggeredFunctionExecutor executor,DocumentCollectionInfo documentCollectionLocation,DocumentCollectionInfo leaseCollectionLocation,ChangeFeedProcessorOptions processorOptions,ICosmosDBService monitoredCosmosDBService,ICosmosDBService leasesCosmosDBService,ILogger logger)
   at Microsoft.Azure.WebJobs.Extensions.CosmosDB.CosmosDBTriggerBinding.CreateListenerAsync(ListenerFactoryContext context) at C:\azure-webjobs-sdk-extensions\src\WebJobs.Extensions.CosmosDB\Trigger\CosmosDBTriggerBinding.cs : 78
   at Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.TriggerWrapper.CreateListenerAsync(ListenerFactoryContext context) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs : 487
   at async Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.ListenerFactory.CreateAsync(CancellationToken cancellationToken) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs : 426
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Listeners.HostListenerFactory.CreateAsync(CancellationToken cancellationToken) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Listeners\HostListenerFactory.cs : 62
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Listeners.ListenerFactoryListener.StartAsyncCore(CancellationToken cancellationToken) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Listeners\ListenerFactoryListener.cs : 45
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Host.Listeners.ShutdownListener.StartAsync(CancellationToken cancellationToken) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Listeners\ShutdownListener.cs : 29
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.JobHost.StartAsyncCore(CancellationToken cancellationToken) at C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\JobHost.cs : 101
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.ScriptHost.StartAsyncCore(CancellationToken cancellationToken) at C:\azure-webjobs-sdk-script\src\WebJobs.Script\Host\ScriptHost.cs : 260
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.WebHost.WebJobsScriptHostService.StartHostAsync(CancellationToken cancellationToken,Int32 attemptCount,JobHostStartupMode startupMode) at C:\azure-webjobs-sdk-script\src\WebJobs.Script.WebHost\WebJobsScriptHostService.cs : 162
2019-05-01T01:06:12.498 [Information] Stopping JobHost
```

I'm almost certain it was because of conflicting dependencies since I had the bundle config in my host.json _and_ the binaries that were created when I ran `func extensions install` as the preDeployTask. Sure enough the error went away once I removed the bundle config from host.json. I think it's just safer not to mix the two methods of installing extensions.