### PR TITLE
Don't let one bad folder stop provideTasks

### DIFF
--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -28,7 +28,9 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 export async function tryGetFunctionProjectRoot(folderPath: string, suppressPrompt: boolean = false): Promise<string | undefined> {
     let subpath: string | undefined = getWorkspaceSetting(projectSubpathKey, folderPath);
     if (!subpath) {
-        if (await isFunctionProject(folderPath)) {
+        if (!(await fse.pathExists(folderPath))) {
+            return undefined;
+        } else if (await isFunctionProject(folderPath)) {
             return folderPath;
         } else {
             const subpaths: string[] = await fse.readdir(folderPath);

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -65,7 +65,8 @@ export class FuncTaskProvider implements TaskProvider {
                 }
 
                 if (!isNullOrUndefined(lastError)) {
-                    // throw the last error just for the sake of telemetry - shouldn't block providing tasks
+                    // throw the last error just for the sake of telemetry
+                    // (This won't block providing tasks since it's inside callWithTelemetryAndErrorHandling)
                     throw lastError;
                 }
             }

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -41,8 +41,7 @@ export class FuncTaskProvider implements TaskProvider {
             this.suppressTelemetry = true;
 
             if (workspace.workspaceFolders) {
-                // tslint:disable-next-line: no-any
-                let lastError: any;
+                let lastError: unknown;
                 for (const folder of workspace.workspaceFolders) {
                     try {
                         const projectRoot: string | undefined = await tryGetFunctionProjectRoot(folder.uri.fsPath, true /* suppressPrompt */);


### PR DESCRIPTION
I'm seeing errors for `provideTasks` in telemetry where a folder path doesn't exist. Added a few extra checks when providing tasks since this can block debug/deploy if it fails.