### PR TITLE
Fix initProjectForVSCode when path passed in isn't workspacePath

### DIFF
--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -15,9 +15,10 @@ import { verifyAndPromptToCreateProject } from '../createNewProject/verifyIsProj
 import { detectProjectLanguage } from './detectProjectLanguage';
 import { InitVSCodeLanguageStep } from './InitVSCodeLanguageStep';
 
-export async function initProjectForVSCode(actionContext: IActionContext, workspacePath?: string, language?: ProjectLanguage): Promise<void> {
+export async function initProjectForVSCode(actionContext: IActionContext, fsPath?: string, language?: ProjectLanguage): Promise<void> {
     let workspaceFolder: WorkspaceFolder | undefined;
-    if (workspacePath === undefined) {
+    let workspacePath: string;
+    if (fsPath === undefined) {
         if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
             throw new NoWorkspaceError();
         } else {
@@ -30,7 +31,8 @@ export async function initProjectForVSCode(actionContext: IActionContext, worksp
             }
         }
     } else {
-        workspaceFolder = getContainingWorkspace(workspacePath);
+        workspaceFolder = getContainingWorkspace(fsPath);
+        workspacePath = workspaceFolder ? workspaceFolder.uri.fsPath : fsPath;
     }
 
     const projectPath: string | undefined = await verifyAndPromptToCreateProject(actionContext, workspacePath);


### PR DESCRIPTION
Found another bug while testing with a pretty easy fix.

Repro steps:
1. Create a folder structure like `jsroot\jssubdir`
1. Open `jssubdir` as your workspace
1. Create a project
1. Open `jsroot` as your workspace
1. Ignore the warning to "Init project for VS Code"
1. Create new function
1. _This time_, when prompted to "Init project for VS Code", select yes

Expected: You get a debuggable project
Actual: The tasks are missing the correct cwd and so debugging fails

The root of the problem is that it's passing in `projectPath` (`jsroot\jsssubdir`) instead of `workspacePath` (`jsroot`). I could fix it to pass in the right thing, but it seems better to assume the path passed in is a random fsPath and to dynamically get the workspacePath