### PR TITLE
Clean up tree naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "onCommand:azureFunctions.setAzureWebJobsStorage",
         "workspaceContains:host.json",
         "workspaceContains:*/host.json",
-        "onView:azureFunctionsExplorer",
+        "onView:azFuncTree",
         "onDebugInitialConfigurations"
     ],
     "main": "./main.js",
@@ -334,7 +334,7 @@
         "views": {
             "azure": [
                 {
-                    "id": "azureFunctionsExplorer",
+                    "id": "azFuncTree",
                     "name": "Functions",
                     "when": "config.azureFunctions.showExplorer == true"
                 }
@@ -344,234 +344,234 @@
             "view/title": [
                 {
                     "command": "azureFunctions.createNewProject",
-                    "when": "view == azureFunctionsExplorer",
+                    "when": "view == azFuncTree",
                     "group": "navigation@1"
                 },
                 {
                     "command": "azureFunctions.createFunction",
-                    "when": "view == azureFunctionsExplorer",
+                    "when": "view == azFuncTree",
                     "group": "navigation@2"
                 },
                 {
                     "command": "azureFunctions.deploy",
-                    "when": "view == azureFunctionsExplorer",
+                    "when": "view == azFuncTree",
                     "group": "navigation@3"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer",
+                    "when": "view == azFuncTree",
                     "group": "navigation@3"
                 }
             ],
             "view/item/context": [
                 {
                     "command": "azureFunctions.selectSubscriptions",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
+                    "when": "view == azFuncTree && viewItem == azureextensionui.azureSubscription",
                     "group": "inline"
                 },
                 {
                     "command": "azureFunctions.createFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
+                    "when": "view == azFuncTree && viewItem == azureextensionui.azureSubscription",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.openInPortal",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
+                    "when": "view == azFuncTree && viewItem == azureextensionui.azureSubscription",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == azureextensionui.azureSubscription",
+                    "when": "view == azFuncTree && viewItem == azureextensionui.azureSubscription",
                     "group": "3@1"
                 },
                 {
                     "command": "azureFunctions.openInPortal",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncProductionSlot",
+                    "when": "view == azFuncTree && viewItem == azFuncProductionSlot",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.startFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.stopFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "2@2"
                 },
                 {
                     "command": "azureFunctions.restartFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "2@3"
                 },
                 {
                     "command": "azureFunctions.swapSlot",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncSlot",
+                    "when": "view == azFuncTree && viewItem == azFuncSlot",
                     "group": "2@4"
                 },
                 {
                     "command": "azureFunctions.deleteFunctionApp",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "2@5"
                 },
                 {
                     "command": "azureFunctions.deploy",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "3@1"
                 },
                 {
                     "command": "azureFunctions.configureDeploymentSource",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "3@2"
                 },
                 {
                     "command": "azureFunctions.startStreamingLogs",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "4@1"
                 },
                 {
                     "command": "azureFunctions.stopStreamingLogs",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "4@2"
                 },
                 {
                     "command": "azureFunctions.debugFunctionAppOnAzure",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/ && config.azureFunctions.enableRemoteDebugging == true",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/ && config.azureFunctions.enableRemoteDebugging == true",
                     "group": "5@1"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFunc(Production|)Slot$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFunc(Production|)Slot$/",
                     "group": "6@1"
                 },
                 {
                     "command": "azureFunctions.createSlot",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncSlots",
+                    "when": "view == azFuncTree && viewItem == azFuncSlots",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncSlots",
+                    "when": "view == azFuncTree && viewItem == azFuncSlots",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncFunctions",
+                    "when": "view == azFuncTree && viewItem == azFuncFunctions",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.copyFunctionUrl",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFuncFunctionHttp(ReadOnly|)$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFuncFunctionHttp(ReadOnly|)$/",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.executeFunction",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFuncFunctionTimer(ReadOnly|)$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFuncFunctionTimer(ReadOnly|)$/",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.deleteFunction",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFuncFunction(Http|Timer|)$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFuncFunction(Http|Timer|)$/",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.startStreamingLogs",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFuncFunction(Http|Timer|)(ReadOnly|)$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFuncFunction(Http|Timer|)(ReadOnly|)$/",
                     "group": "3@1"
                 },
                 {
                     "command": "azureFunctions.stopStreamingLogs",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^azFuncFunction(Http|Timer|)(ReadOnly|)$/",
+                    "when": "view == azFuncTree && viewItem =~ /^azFuncFunction(Http|Timer|)(ReadOnly|)$/",
                     "group": "3@2"
                 },
                 {
                     "command": "azureFunctions.appSettings.add",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettings",
+                    "when": "view == azFuncTree && viewItem == applicationSettings",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.appSettings.download",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettings",
+                    "when": "view == azFuncTree && viewItem == applicationSettings",
                     "group": "1@2"
                 },
                 {
                     "command": "azureFunctions.appSettings.upload",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettings",
+                    "when": "view == azFuncTree && viewItem == applicationSettings",
                     "group": "1@3"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettings",
+                    "when": "view == azFuncTree && viewItem == applicationSettings",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.appSettings.edit",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettingItem",
+                    "when": "view == azFuncTree && viewItem == applicationSettingItem",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.appSettings.rename",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettingItem",
+                    "when": "view == azFuncTree && viewItem == applicationSettingItem",
                     "group": "1@2"
                 },
                 {
                     "command": "azureFunctions.appSettings.delete",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettingItem",
+                    "when": "view == azFuncTree && viewItem == applicationSettingItem",
                     "group": "1@3"
                 },
                 {
                     "command": "azureFunctions.appSettings.toggleSlotSetting",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettingItem && config.azureFunctions.enableSlots == true",
+                    "when": "view == azFuncTree && viewItem == applicationSettingItem && config.azureFunctions.enableSlots == true",
                     "group": "1@4"
                 },
                 {
                     "command": "azureFunctions.toggleAppSettingVisibility",
-                    "when": "view == azureFunctionsExplorer && viewItem == applicationSettingItem",
+                    "when": "view == azFuncTree && viewItem == applicationSettingItem",
                     "group": "inline"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncProxies",
+                    "when": "view == azFuncTree && viewItem == azFuncProxies",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.deleteProxy",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncProxy",
+                    "when": "view == azFuncTree && viewItem == azFuncProxy",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.disconnectRepo",
-                    "when": "view == azureFunctionsExplorer && viewItem == deploymentsConnected",
+                    "when": "view == azFuncTree && viewItem == deploymentsConnected",
                     "group": "1@2"
                 },
                 {
                     "command": "azureFunctions.refresh",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^deployments(C|Unc)onnected$/",
+                    "when": "view == azFuncTree && viewItem =~ /^deployments(C|Unc)onnected$/",
                     "group": "2@1"
                 },
                 {
                     "command": "azureFunctions.redeploy",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^deployment//",
+                    "when": "view == azFuncTree && viewItem =~ /^deployment//",
                     "group": "1@1"
                 },
                 {
                     "command": "azureFunctions.openInPortal",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^deployment//",
+                    "when": "view == azFuncTree && viewItem =~ /^deployment//",
                     "group": "1@2"
                 },
                 {
                     "command": "azureFunctions.viewCommitInGitHub",
-                    "when": "view == azureFunctionsExplorer && viewItem == deployment/github",
+                    "when": "view == azFuncTree && viewItem == deployment/github",
                     "group": "1@3"
                 },
                 {
                     "command": "azureFunctions.viewDeploymentLogs",
-                    "when": "view == azureFunctionsExplorer && viewItem =~ /^deployment//",
+                    "when": "view == azFuncTree && viewItem =~ /^deployment//",
                     "group": "inline"
                 },
                 {
                     "command": "azureFunctions.addBinding",
-                    "when": "view == azureFunctionsExplorer && viewItem == azFuncLocalBindings"
+                    "when": "view == azFuncTree && viewItem == azFuncLocalBindings"
                 }
             ],
             "explorer/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         ext.azureAccountTreeItem = new AzureAccountTreeItemWithProjects();
         context.subscriptions.push(ext.azureAccountTreeItem);
         ext.tree = new AzExtTreeDataProvider(ext.azureAccountTreeItem, 'azureFunctions.loadMore');
-        context.subscriptions.push(vscode.window.createTreeView('azureFunctionsExplorer', { treeDataProvider: ext.tree }));
+        context.subscriptions.push(vscode.window.createTreeView('azFuncTree', { treeDataProvider: ext.tree }));
 
         const validateEventId: string = 'azureFunctions.validateFunctionProjects';
         // tslint:disable-next-line:no-floating-promises

--- a/src/tree/FunctionTreeItem.ts
+++ b/src/tree/FunctionTreeItem.ts
@@ -12,8 +12,8 @@ import { ProjectRuntime } from '../constants';
 import { ext } from '../extensionVariables';
 import { HttpAuthLevel, ParsedFunctionJson } from '../funcConfig/function';
 import { localize } from '../localize';
-import { nodeUtils } from '../utils/nodeUtils';
 import { nonNullProp } from '../utils/nonNull';
+import { treeUtils } from '../utils/treeUtils';
 import { FunctionsTreeItem } from './FunctionsTreeItem';
 
 export class FunctionTreeItem extends AzureTreeItem<ISiteTreeRoot> {
@@ -78,7 +78,7 @@ export class FunctionTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     }
 
     public get iconPath(): string {
-        return nodeUtils.getIconPath(FunctionTreeItem.contextValueBase);
+        return treeUtils.getIconPath(FunctionTreeItem.contextValueBase);
     }
 
     public get triggerUrl(): string | undefined {

--- a/src/tree/FunctionsTreeItem.ts
+++ b/src/tree/FunctionsTreeItem.ts
@@ -8,7 +8,7 @@ import { isArray } from 'util';
 import { ISiteTreeRoot } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
-import { nodeUtils } from '../utils/nodeUtils';
+import { treeUtils } from '../utils/treeUtils';
 import { FunctionTreeItem, getFunctionNameFromId } from './FunctionTreeItem';
 import { SlotTreeItemBase } from './SlotTreeItemBase';
 
@@ -41,8 +41,8 @@ export class FunctionsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         return 'functions';
     }
 
-    public get iconPath(): nodeUtils.IThemedIconPath {
-        return nodeUtils.getThemedIconPath('BulletList');
+    public get iconPath(): treeUtils.IThemedIconPath {
+        return treeUtils.getThemedIconPath('BulletList');
     }
 
     public get readOnly(): boolean {

--- a/src/tree/ProxiesTreeItem.ts
+++ b/src/tree/ProxiesTreeItem.ts
@@ -7,7 +7,7 @@ import { getFile, IFileResult, ISiteTreeRoot, putFile } from 'vscode-azureappser
 import { AzureParentTreeItem, AzureTreeItem, DialogResponses, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { nodeUtils } from '../utils/nodeUtils';
+import { treeUtils } from '../utils/treeUtils';
 import { ProxyTreeItem } from './ProxyTreeItem';
 import { SlotTreeItemBase } from './SlotTreeItemBase';
 
@@ -43,8 +43,8 @@ export class ProxiesTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
         return this._readOnly ? localize('readOnly', 'Read only') : '';
     }
 
-    public get iconPath(): nodeUtils.IThemedIconPath {
-        return nodeUtils.getThemedIconPath('BulletList');
+    public get iconPath(): treeUtils.IThemedIconPath {
+        return treeUtils.getThemedIconPath('BulletList');
     }
 
     public get readOnly(): boolean {

--- a/src/tree/ProxyTreeItem.ts
+++ b/src/tree/ProxyTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { ISiteTreeRoot } from 'vscode-azureappservice';
 import { AzureTreeItem } from 'vscode-azureextensionui';
-import { nodeUtils } from '../utils/nodeUtils';
+import { treeUtils } from '../utils/treeUtils';
 import { ProxiesTreeItem } from './ProxiesTreeItem';
 
 export class ProxyTreeItem extends AzureTreeItem<ISiteTreeRoot> {
@@ -28,7 +28,7 @@ export class ProxyTreeItem extends AzureTreeItem<ISiteTreeRoot> {
     }
 
     public get iconPath(): string {
-        return nodeUtils.getIconPath(ProxyTreeItem.contextValue);
+        return treeUtils.getIconPath(ProxyTreeItem.contextValue);
     }
 
     public async deleteTreeItemImpl(): Promise<void> {

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -9,7 +9,7 @@ import { AzureParentTreeItem, AzureTreeItem } from 'vscode-azureextensionui';
 import { ProjectRuntime } from '../constants';
 import { IParsedHostJson, parseHostJson } from '../funcConfig/host';
 import { localize } from '../localize';
-import { nodeUtils } from '../utils/nodeUtils';
+import { treeUtils } from '../utils/treeUtils';
 import { convertStringToRuntime } from '../vsCodeConfig/settings';
 import { FunctionsTreeItem } from './FunctionsTreeItem';
 import { FunctionTreeItem } from './FunctionTreeItem';
@@ -66,7 +66,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
     }
 
     public get iconPath(): string {
-        return nodeUtils.getIconPath(this.contextValue);
+        return treeUtils.getIconPath(this.contextValue);
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/tree/SlotsTreeItem.ts
+++ b/src/tree/SlotsTreeItem.ts
@@ -7,7 +7,7 @@ import { WebSiteManagementClient, WebSiteManagementModels } from 'azure-arm-webs
 import { createSlot, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, createAzureClient, ICreateChildImplContext } from 'vscode-azureextensionui';
 import { localize } from '../localize';
-import { nodeUtils } from '../utils/nodeUtils';
+import { treeUtils } from '../utils/treeUtils';
 import { ProductionSlotTreeItem } from './ProductionSlotTreeItem';
 import { SlotTreeItem } from './SlotTreeItem';
 
@@ -30,7 +30,7 @@ export class SlotsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     }
 
     public get iconPath(): string {
-        return nodeUtils.getIconPath(this.contextValue);
+        return treeUtils.getIconPath(this.contextValue);
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/tree/localProject/LocalBindingsTreeItem.ts
+++ b/src/tree/localProject/LocalBindingsTreeItem.ts
@@ -8,8 +8,8 @@ import { createBindingWizard } from '../../commands/addBinding/createBindingWiza
 import { IBindingWizardContext } from '../../commands/addBinding/IBindingWizardContext';
 import { ParsedFunctionJson } from '../../funcConfig/function';
 import { localize } from '../../localize';
-import { nodeUtils } from '../../utils/nodeUtils';
 import { nonNullProp } from '../../utils/nonNull';
+import { treeUtils } from '../../utils/treeUtils';
 import { LocalBindingTreeItem } from './LocalBindingTreeItem';
 import { LocalFunctionTreeItem } from './LocalFunctionTreeItem';
 import { LocalParentTreeItem } from './LocalTreeItem';
@@ -33,8 +33,8 @@ export class LocalBindingsTreeItem extends LocalParentTreeItem {
         return 'bindings';
     }
 
-    public get iconPath(): nodeUtils.IThemedIconPath {
-        return nodeUtils.getThemedIconPath('BulletList');
+    public get iconPath(): treeUtils.IThemedIconPath {
+        return treeUtils.getThemedIconPath('BulletList');
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/tree/localProject/LocalFunctionTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ParsedFunctionJson } from '../../funcConfig/function';
-import { nodeUtils } from '../../utils/nodeUtils';
+import { treeUtils } from '../../utils/treeUtils';
 import { FunctionTreeItem } from '../FunctionTreeItem';
 import { LocalBindingsTreeItem } from './LocalBindingsTreeItem';
 import { LocalFunctionsTreeItem } from './LocalFunctionsTreeItem';
@@ -31,7 +31,7 @@ export class LocalFunctionTreeItem extends LocalParentTreeItem {
     }
 
     public get iconPath(): string {
-        return nodeUtils.getIconPath(FunctionTreeItem.contextValueBase);
+        return treeUtils.getIconPath(FunctionTreeItem.contextValueBase);
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/tree/localProject/LocalFunctionsTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionsTreeItem.ts
@@ -9,7 +9,7 @@ import { AzExtTreeItem } from 'vscode-azureextensionui';
 import { functionJsonFileName } from '../../constants';
 import { ParsedFunctionJson } from '../../funcConfig/function';
 import { localize } from '../../localize';
-import { nodeUtils } from '../../utils/nodeUtils';
+import { treeUtils } from '../../utils/treeUtils';
 import { LocalFunctionTreeItem } from './LocalFunctionTreeItem';
 import { LocalParentTreeItem } from './LocalTreeItem';
 
@@ -23,8 +23,8 @@ export class LocalFunctionsTreeItem extends LocalParentTreeItem {
         return 'functions';
     }
 
-    public get iconPath(): nodeUtils.IThemedIconPath {
-        return nodeUtils.getThemedIconPath('BulletList');
+    public get iconPath(): treeUtils.IThemedIconPath {
+        return treeUtils.getThemedIconPath('BulletList');
     }
 
     public hasMoreChildrenImpl(): boolean {

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -8,7 +8,7 @@ import { Disposable, WorkspaceFolder } from 'vscode';
 import { AzExtParentTreeItem, AzExtTreeItem } from 'vscode-azureextensionui';
 import { functionJsonFileName } from '../../constants';
 import { localize } from '../../localize';
-import { nodeUtils } from '../../utils/nodeUtils';
+import { treeUtils } from '../../utils/treeUtils';
 import { createRefreshFileWatcher } from './createRefreshFileWatcher';
 import { LocalFunctionsTreeItem } from './LocalFunctionsTreeItem';
 import { IProjectRoot, isLocalTreeItem, LocalParentTreeItem } from './LocalTreeItem';
@@ -38,8 +38,8 @@ export class LocalProjectTreeItem extends LocalParentTreeItem implements Disposa
         return this._root;
     }
 
-    public get iconPath(): nodeUtils.IThemedIconPath {
-        return nodeUtils.getThemedIconPath('CreateNewProject');
+    public get iconPath(): treeUtils.IThemedIconPath {
+        return treeUtils.getThemedIconPath('CreateNewProject');
     }
 
     public get id(): string {

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import { ext } from '../extensionVariables';
 
-export namespace nodeUtils {
+export namespace treeUtils {
     export interface IThemedIconPath {
         light: string;
         dark: string;


### PR DESCRIPTION
- Rename `nodeUtils` to `treeUtils` because "node" could mean either "TreeItem" or "node.js"
- Rename `azureFunctionsExplorer` to `azFuncTree` because it's shorter and more consistent with contextValue names (which all start with `azFunc`)