### PR TITLE
Fix Java nightly test

### DIFF
--- a/src/commands/initProjectForVSCode/InitVSCodeStep/InitVSCodeStepBase.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/InitVSCodeStepBase.ts
@@ -46,7 +46,7 @@ export abstract class InitVSCodeStepBase extends AzureWizardExecuteStep<IProject
         const gitignorePath: string = path.join(context.workspacePath, gitignoreFileName);
         if (await fse.pathExists(gitignorePath)) {
             let gitignoreContents: string = (await fse.readFile(gitignorePath)).toString();
-            gitignoreContents = gitignoreContents.replace(/^\.vscode\s*$/gm, '');
+            gitignoreContents = gitignoreContents.replace(/^\.vscode(\/|\\)?\s*$/gm, '');
             await fse.writeFile(gitignorePath, gitignoreContents);
         }
     }


### PR DESCRIPTION
The `Create New Project JavaProject` nightly test started failing a bit ago with the error: `The ".vscode" folder is being ignored.`

Somebody must've changed the default gitignore for Java projects (I think that's a part of the maven plugin) and right now it has `.vscode\`. I should probably file an issue on the Java maven template, but I don't know where the source code for that is off the top of my head and it doesn't seem high priority as long as we have this check.

Verified the test passes now: https://dev.azure.com/ms-azuretools/AzCode/_build/results?buildId=7583