### PR TITLE
Improve AzureWebJobsStorage experience

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -5,6 +5,7 @@
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IAzureQuickPickOptions, IWizardOptions } from 'vscode-azureextensionui';
 import { ProjectLanguage, ProjectRuntime, TemplateFilter, templateFilterSetting } from '../../constants';
+import { canValidateAzureWebJobStorageOnDebug } from '../../debug/validatePreDebug';
 import { ext } from '../../extensionVariables';
 import { getAzureWebJobsStorage } from '../../funcConfig/local.settings';
 import { localize } from '../../localize';
@@ -97,7 +98,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                     break;
             }
 
-            if (!template.isHttpTrigger && !await getAzureWebJobsStorage(context.projectPath)) {
+            if (!template.isHttpTrigger && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context.projectPath)) {
                 promptSteps.push(new AzureWebJobsStoragePromptStep());
                 executeSteps.push(new AzureWebJobsStorageExecuteStep());
             }

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -15,7 +15,7 @@ import { getWindowsProcessTree, IProcessTreeNode, IWindowsProcessTree } from '..
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 
 export async function pickFuncProcess(context: IActionContext, debugConfig: vscode.DebugConfiguration): Promise<string | undefined> {
-    const result: IPreDebugValidateResult = await preDebugValidate(debugConfig);
+    const result: IPreDebugValidateResult = await preDebugValidate(context, debugConfig);
     if (!result.shouldContinue) {
         throw new UserCancelledError();
     }

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -43,11 +43,10 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
         await callWithTelemetryAndErrorHandling('resolveDebugConfiguration', async (context: IActionContext) => {
             context.telemetry.properties.isActivationEvent = 'true';
             context.errorHandling.suppressDisplay = true;
-            context.telemetry.suppressIfSuccessful = true;
 
             this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
             if (debugConfiguration.preLaunchTask === hostStartTaskName) {
-                const preDebugResult: IPreDebugValidateResult = await preDebugValidate(debugConfiguration);
+                const preDebugResult: IPreDebugValidateResult = await preDebugValidate(context, debugConfiguration);
                 if (!preDebugResult.shouldContinue) {
                     // Stop debugging only in this case
                     result = undefined;

--- a/src/tree/localProject/LocalFunctionsTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionsTreeItem.ts
@@ -25,15 +25,7 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        const subpaths: string[] = await fse.readdir(this.parent.projectPath);
-
-        const functions: string[] = [];
-        await Promise.all(subpaths.map(async s => {
-            if (await fse.pathExists(path.join(this.parent.projectPath, s, functionJsonFileName))) {
-                functions.push(s);
-            }
-        }));
-
+        const functions: string[] = await getFunctionFolders(this.parent.projectPath);
         return await this.createTreeItemsWithErrorHandling(
             functions,
             'azFuncInvalidLocalFunction',
@@ -45,4 +37,15 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
             (func: string) => func
         );
     }
+}
+
+export async function getFunctionFolders(projectPath: string): Promise<string[]> {
+    const subpaths: string[] = await fse.readdir(projectPath);
+    const result: string[] = [];
+    await Promise.all(subpaths.map(async s => {
+        if (await fse.pathExists(path.join(projectPath, s, functionJsonFileName))) {
+            result.push(s);
+        }
+    }));
+    return result;
 }

--- a/src/tree/localProject/supportsLocalProjectTree.ts
+++ b/src/tree/localProject/supportsLocalProjectTree.ts
@@ -3,10 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ProjectLanguage, projectLanguageSetting } from "../../constants";
-import { getWorkspaceSetting } from "../../vsCodeConfig/settings";
+import { ProjectLanguage } from "../../constants";
 
-export function supportsLocalProjectTree(projectPath: string): boolean {
+export function supportsLocalProjectTree(projectLanguage: string | undefined): boolean {
     // The project tree relies heavily on a standard file structure, including "host.json" and "function.json" files
     // Languages not listed here (notably C# and Java) require a build step to generate files like "function.json" and are not yet supported
     // https://github.com/microsoft/vscode-azurefunctions/issues/1165
@@ -18,6 +17,6 @@ export function supportsLocalProjectTree(projectPath: string): boolean {
         ProjectLanguage.Python,
         ProjectLanguage.TypeScript
     ];
-    const projectLanguage: string | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);
+
     return supportedLanguages.some(l => l === projectLanguage);
 }


### PR DESCRIPTION
Two main improvements:
1. Delay prompting about AzureWebJobsStorage until user debugs, instead of right after creating a function. If a user never debugs, they will never see this warning. If a user _does_ debug without `AzureWebJobsStorage` configured correctly, they will always see this warning with the ability to fix. Unfortunately, this logic doesn't work for C# and Java
1. Make the warning more human-readable. I tried to avoid "AzureWebJobsStorage" and "local.settings.json" as words since they're very function-specific

![Screen Shot 2019-08-06 at 10 50 50 AM](https://user-images.githubusercontent.com/11282622/62566431-c9d1da80-b83d-11e9-98c9-b9271b8c0a8d.png)


Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1332