### PR TITLE
Remove extra prompt for open behavior

### DIFF
--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -38,7 +38,7 @@ export async function createNewProject(
 
     if (!openFolder) {
         wizardContext.openBehavior = 'DontOpen';
-    } else {
+    } else if (!wizardContext.openBehavior) {
         wizardContext.openBehavior = getWorkspaceSetting(projectOpenBehaviorSetting);
         context.telemetry.properties.openBehaviorFromSetting = String(!!wizardContext.openBehavior);
     }


### PR DESCRIPTION
Found a bug. Repro steps:
1. Open an empty folder in VS Code
1. Select Create function
1. When prompted that you have to create a project first, select "Yes"

Expected:
It doesn't ask about open behavior since folder is already open

Actual:
It asks about open behavior