### PR TITLE
Change background endspattern to stop at "Application Started"

### DIFF
--- a/package.json
+++ b/package.json
@@ -721,7 +721,7 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
-                    "endsPattern": "^.*Host lock lease acquired by instance ID.*$"
+                    "endsPattern": "^Application started.+$"
                 },
                 "severity": "error"
             }


### PR DESCRIPTION
This change will background the task when azure functions is ready to accept connections. This will save a few seconds between the task starting and the debug being available and speed up the developer feedback loop.