### PR TITLE
"Support" log streaming for linux function apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,6 +1562,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
+        "azure-arm-appinsights": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/azure-arm-appinsights/-/azure-arm-appinsights-2.1.0.tgz",
+            "integrity": "sha512-fKf22qIxbv+SpShfm/D61+k0CtsyFGXQVGl+2lPgLrP2PB2++1DIpeVC9xQRxI3808jv1wH7iKH0tAzIJdmqRA==",
+            "requires": {
+                "ms-rest": "^2.3.3",
+                "ms-rest-azure": "^2.5.5"
+            }
+        },
         "azure-arm-cosmosdb": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/azure-arm-cosmosdb/-/azure-arm-cosmosdb-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -959,6 +959,7 @@
     "dependencies": {
         "azure-arm-cosmosdb": "^1.1.2",
         "azure-arm-eventhub": "^3.2.0",
+        "azure-arm-appinsights": "^2.1.0",
         "azure-arm-sb": "^2.3.0-preview",
         "azure-arm-storage": "^4.0.0",
         "azure-arm-website": "^5.3.0",
@@ -966,6 +967,7 @@
         "extract-zip": "^1.6.6",
         "fs-extra": "^4.0.2",
         "ms-rest-azure": "^2.3.1",
+        "opn": "^6.0.0",
         "portfinder": "^1.0.13",
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.4",

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -3,14 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ApplicationInsightsManagementClient, ApplicationInsightsManagementModels as AIModels } from 'azure-arm-appinsights';
 import { WebSiteManagementModels } from 'azure-arm-website';
 import * as appservice from 'vscode-azureappservice';
-import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { createAzureClient, DialogResponses, IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { ProductionSlotTreeItem } from '../../tree/ProductionSlotTreeItem';
 import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionTreeItem';
 import { SlotTreeItemBase } from '../../tree/SlotTreeItemBase';
+import { nonNullProp } from '../../utils/nonNull';
+import { openUrl } from '../../utils/openUrl';
 
 export async function startStreamingLogs(context: IActionContext, treeItem?: SlotTreeItemBase | RemoteFunctionTreeItem): Promise<void> {
     if (!treeItem) {
@@ -18,24 +21,60 @@ export async function startStreamingLogs(context: IActionContext, treeItem?: Slo
     }
 
     const client: appservice.SiteClient = treeItem.client;
-    const verifyLoggingEnabled: () => Promise<void> = async (): Promise<void> => {
-        const logsConfig: WebSiteManagementModels.SiteLogsConfig = await client.getLogsConfig();
-        if (!isApplicationLoggingEnabled(logsConfig)) {
-            const message: string = localize('enableApplicationLogging', 'Do you want to enable application logging for "{0}"?', client.fullName);
-            await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.cancel);
-            // tslint:disable-next-line:strict-boolean-expressions
-            logsConfig.applicationLogs = logsConfig.applicationLogs || {};
-            // tslint:disable-next-line:strict-boolean-expressions
-            logsConfig.applicationLogs.fileSystem = logsConfig.applicationLogs.fileSystem || {};
-            logsConfig.applicationLogs.fileSystem.level = 'Information';
-            // Azure will throw errors if these have incomplete information (aka missing a sasUrl). Since we already know these are turned off, just make them undefined
-            logsConfig.applicationLogs.azureBlobStorage = undefined;
-            logsConfig.applicationLogs.azureTableStorage = undefined;
-            await client.updateLogsConfig(logsConfig);
-        }
-    };
 
-    await appservice.startStreamingLogs(client, verifyLoggingEnabled, treeItem.logStreamLabel, treeItem.logStreamPath);
+    if (client.isLinux) {
+        await openLiveMetricsStream(treeItem);
+    } else {
+        const verifyLoggingEnabled: () => Promise<void> = async (): Promise<void> => {
+            const logsConfig: WebSiteManagementModels.SiteLogsConfig = await client.getLogsConfig();
+            if (!isApplicationLoggingEnabled(logsConfig)) {
+                const message: string = localize('enableApplicationLogging', 'Do you want to enable application logging for "{0}"?', client.fullName);
+                await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.cancel);
+                // tslint:disable-next-line:strict-boolean-expressions
+                logsConfig.applicationLogs = logsConfig.applicationLogs || {};
+                // tslint:disable-next-line:strict-boolean-expressions
+                logsConfig.applicationLogs.fileSystem = logsConfig.applicationLogs.fileSystem || {};
+                logsConfig.applicationLogs.fileSystem.level = 'Information';
+                // Azure will throw errors if these have incomplete information (aka missing a sasUrl). Since we already know these are turned off, just make them undefined
+                logsConfig.applicationLogs.azureBlobStorage = undefined;
+                logsConfig.applicationLogs.azureTableStorage = undefined;
+                await client.updateLogsConfig(logsConfig);
+            }
+        };
+
+        await appservice.startStreamingLogs(client, verifyLoggingEnabled, treeItem.logStreamLabel, treeItem.logStreamPath);
+    }
+}
+
+/**
+ * Linux Function Apps only support streaming through App Insights
+ * For initial support, we will just open the "Live Metrics Stream" view in the portal
+ */
+async function openLiveMetricsStream(treeItem: SlotTreeItemBase | RemoteFunctionTreeItem): Promise<void> {
+    const appSettings: WebSiteManagementModels.StringDictionary = await treeItem.client.listApplicationSettings();
+    const aiKey: string | undefined = appSettings.properties && appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY;
+    if (!aiKey) {
+        // https://github.com/microsoft/vscode-azurefunctions/issues/1432
+        throw new Error(localize('mustConfigureAI', 'You must configure Application Insights to stream logs on Linux Function Apps.'));
+    } else {
+        const aiClient: ApplicationInsightsManagementClient = createAzureClient(treeItem.root, ApplicationInsightsManagementClient);
+        const components: AIModels.ApplicationInsightsComponentListResult = await aiClient.components.list();
+        const component: AIModels.ApplicationInsightsComponent | undefined = components.find(c => c.instrumentationKey === aiKey);
+        if (!component) {
+            throw new Error(localize('failedToFindAI', 'Failed to find application insights component.'));
+        } else {
+            const componentId: string = encodeURIComponent(JSON.stringify({
+                Name: treeItem.client.fullName,
+                SubscriptionId: treeItem.root.subscriptionId,
+                ResourceGroup: treeItem.client.resourceGroup
+            }));
+            const resourceId: string = encodeURIComponent(nonNullProp(component, 'id'));
+
+            // Not using `openInPortal` because this url is so unconventional
+            const url: string = `${treeItem.root.environment.portalUrl}/#blade/AppInsightsExtension/QuickPulseBladeV2/ComponentId/${componentId}/ResourceId/${resourceId}`;
+            await openUrl(url);
+        }
+    }
 }
 
 function isApplicationLoggingEnabled(config: WebSiteManagementModels.SiteLogsConfig): boolean {

--- a/src/tree/remoteProject/RemoteFunctionTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { WebSiteManagementModels } from 'azure-arm-website';
 import { ProgressLocation, window } from 'vscode';
-import { IFunctionKeys, IHostKeys, SiteClient } from 'vscode-azureappservice';
+import { IFunctionKeys, IHostKeys, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzExtTreeItem, DialogResponses } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { HttpAuthLevel, ParsedFunctionJson } from '../../funcConfig/function';
@@ -34,8 +34,12 @@ export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
         return ti;
     }
 
+    public get root(): ISiteTreeRoot {
+        return this.parent.parent.root;
+    }
+
     public get client(): SiteClient {
-        return this.parent.parent.root.client;
+        return this.root.client;
     }
 
     public get logStreamLabel(): string {

--- a/src/utils/openUrl.ts
+++ b/src/utils/openUrl.ts
@@ -3,8 +3,14 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+// tslint:disable-next-line:no-require-imports
+import opn = require("opn");
 
 export async function openUrl(url: string): Promise<void> {
-    await vscode.env.openExternal(vscode.Uri.parse(url));
+    // Using this functionality is blocked by https://github.com/Microsoft/vscode/issues/25852
+    // Specifically, opening the Live Metrics Stream for Linux Function Apps doesn't work in this extension.
+    // await vscode.env.openExternal(vscode.Uri.parse(url));
+
+    // tslint:disable-next-line: no-unsafe-any
+    opn(url);
 }


### PR DESCRIPTION
It's really just opening the Live Metrics stream in the portal. AFAIK there's no api for us to display this information directly in VS Code

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/589