### PR TITLE
Change how debug telemetry is tracked

### DIFF
--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -43,9 +43,13 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
         await callWithTelemetryAndErrorHandling('resolveDebugConfiguration', async (context: IActionContext) => {
             context.telemetry.properties.isActivationEvent = 'true';
             context.errorHandling.suppressDisplay = true;
+            context.telemetry.suppressIfSuccessful = true;
 
             this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
             if (debugConfiguration.preLaunchTask === hostStartTaskName) {
+                context.telemetry.properties.isActivationEvent = 'false';
+                context.telemetry.suppressIfSuccessful = false;
+
                 const preDebugResult: IPreDebugValidateResult = await preDebugValidate(context, debugConfiguration);
                 if (!preDebugResult.shouldContinue) {
                     // Stop debugging only in this case


### PR DESCRIPTION
- Only track it if we know it's Functions debugging
- Don't mark it as an activation event if we know it's Functions debugging