### PR TITLE
Model C# tasks more closely after C# extension

### DIFF
--- a/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
@@ -86,17 +86,28 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
     }
 
     protected getTasks(): TaskDefinition[] {
+        const commonArgs: string[] = ['/property:GenerateFullPaths=true', '/consoleloggerparameters:NoSummary'];
+        const releaseArgs: string[] = ['--configuration', 'Release'];
+
         return [
             {
                 label: 'clean',
-                command: 'dotnet clean',
-                type: 'shell',
+                command: 'dotnet',
+                args: [
+                    'clean',
+                    ...commonArgs
+                ],
+                type: 'process',
                 problemMatcher: '$msCompile'
             },
             {
                 label: 'build',
-                command: 'dotnet build',
-                type: 'shell',
+                command: 'dotnet',
+                args: [
+                    'build',
+                    ...commonArgs
+                ],
+                type: 'process',
                 dependsOn: 'clean',
                 group: {
                     kind: 'build',
@@ -106,14 +117,24 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
             },
             {
                 label: 'clean release',
-                command: 'dotnet clean --configuration Release',
-                type: 'shell',
+                command: 'dotnet',
+                args: [
+                    'clean',
+                    ...releaseArgs,
+                    ...commonArgs
+                ],
+                type: 'process',
                 problemMatcher: '$msCompile'
             },
             {
                 label: dotnetPublishTaskLabel,
-                command: 'dotnet publish --configuration Release',
-                type: 'shell',
+                command: 'dotnet',
+                args: [
+                    'publish',
+                    ...releaseArgs,
+                    ...commonArgs
+                ],
+                type: 'process',
                 dependsOn: 'clean release',
                 problemMatcher: '$msCompile'
             },


### PR DESCRIPTION
Came about because of Nathan's work with App Service C# tasks. I think the important piece is the 
`GenerateFullPaths` arg because otherwise you get an error like this when you try to click a build error:
![Screen Shot 2019-09-25 at 4 30 35 PM](https://user-images.githubusercontent.com/11282622/65647203-cdb6e900-dfb2-11e9-81e3-fd87e5393776.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1480