### PR TITLE
Default enableOutputTimestamps to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -926,7 +926,8 @@
                     },
                     "azureFunctions.enableOutputTimestamps": {
                         "type": "boolean",
-                        "description": "%azureFunctions.enableOutputTimestamps%"
+                        "description": "%azureFunctions.enableOutputTimestamps%",
+                        "default": true
                     }
                 }
             }


### PR DESCRIPTION
Matches behavior before this setting existed and matches app service extension: https://github.com/microsoft/vscode-azureappservice/blob/master/package.json#L819