### PR TITLE
Don't upload empty setting values

### DIFF
--- a/src/commands/appSettings/confirmOverwriteSettings.ts
+++ b/src/commands/appSettings/confirmOverwriteSettings.ts
@@ -21,7 +21,9 @@ export async function confirmOverwriteSettings(sourceSettings: { [key: string]: 
         if (destinationSettings[key] === undefined) {
             addedKeys.push(key);
             destinationSettings[key] = sourceSettings[key];
-        } else if (destinationSettings[key] !== sourceSettings[key]) {
+        } else if (destinationSettings[key] === sourceSettings[key]) {
+            matchingKeys.push(key);
+        } else if (sourceSettings[key]) { // ignore empty settings
             if (!suppressPrompt) {
                 const yesToAll: vscode.MessageItem = { title: localize('yesToAll', 'Yes to all') };
                 const noToAll: vscode.MessageItem = { title: localize('noToAll', 'No to all') };
@@ -46,8 +48,6 @@ export async function confirmOverwriteSettings(sourceSettings: { [key: string]: 
             } else {
                 userIgnoredKeys.push(key);
             }
-        } else {
-            matchingKeys.push(key);
         }
     }
 


### PR DESCRIPTION
We write this by default for new projects:
```json
{
  "IsEncrypted": false,
  "Values": {
    "AzureWebJobsStorage": "",
    "FUNCTIONS_WORKER_RUNTIME": "node"
  }
}
```

If the user chooses to upload settings, it'll ask them if they want to overwrite `AzureWebJobsStorage`. If they click yes, they'll break their function app in azure. Instead, we'll just ignore empty settings (similar to how we never delete settings).

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1523