### PR TITLE
Add nuget versioning logic for getting bundle templates

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -33,6 +33,7 @@ export * from './src/tree/AzureAccountTreeItemWithProjects';
 export * from './src/utils/cpUtils';
 export * from './src/utils/delay';
 export * from './src/utils/fs';
+export * from './src/utils/nugetUtils';
 export * from './src/utils/requestUtils';
 export * from './src/utils/venvUtils';
 export * from './src/vsCodeConfig/extensions';

--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -9,6 +9,7 @@ import { IBundleMetadata } from '../funcConfig/host';
 import { localize } from '../localize';
 import { IBindingTemplate } from '../templates/IBindingTemplate';
 import { IFunctionTemplate } from '../templates/IFunctionTemplate';
+import { nugetUtils } from './nugetUtils';
 import { requestUtils } from './requestUtils';
 
 export namespace bundleFeedUtils {
@@ -40,9 +41,7 @@ export namespace bundleFeedUtils {
 
         const feed: IBundleFeed = await getBundleFeed(bundleMetadata);
         const validVersions: string[] = Object.keys(feed.bundleVersions).filter((v: string) => !!semver.valid(v));
-        // For now just get the latest release and ignore user's bundle range from host.json
-        // https://github.com/microsoft/vscode-azurefunctions/issues/1203
-        const bundleVersion: string | null = semver.maxSatisfying(validVersions, '*');
+        const bundleVersion: string | undefined = nugetUtils.tryGetMaxInRange(bundleMetadata.version || feed.defaultVersionRange, validVersions);
         if (!bundleVersion) {
             throw new Error(localize('failedToFindBundleVersion', 'Failed to find bundle version satisfying range "{0}".', bundleMetadata.version));
         } else {

--- a/src/utils/nugetUtils.ts
+++ b/src/utils/nugetUtils.ts
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import { localize } from '../localize';
+
+export namespace nugetUtils {
+    const wildcard: string = '*';
+
+    export function tryGetMaxInRange(rangeString: string, versions: string[]): string | undefined {
+        let finalRange: string = wildcard;
+        const range: IVersionRange | string = parseVersionRange(rangeString);
+        if (typeof range === 'string') {
+            finalRange = range;
+        } else {
+            const minVersion: string | undefined = range.minVersion;
+            if (minVersion) {
+                if (minVersion.includes(wildcard)) {
+                    if (range.includeMinVersion) {
+                        versions = versions.filter(v => semver.satisfies(v, minVersion) || semver.gtr(v, minVersion));
+                    } else {
+                        versions = versions.filter(v => semver.gtr(v, minVersion));
+                    }
+                } else if (range.includeMinVersion) {
+                    versions = versions.filter(v => semver.gte(v, minVersion));
+                } else {
+                    versions = versions.filter(v => semver.gt(v, minVersion));
+                }
+            }
+
+            const maxVersion: string | undefined = range.maxVersion;
+            if (maxVersion) {
+                if (range.includeMaxVersion) {
+                    versions = versions.filter(v => semver.lte(v, maxVersion));
+                } else {
+                    versions = versions.filter(v => semver.lt(v, maxVersion));
+                }
+            }
+        }
+
+        return semver.maxSatisfying(versions, finalRange);
+    }
+
+    interface IVersionRange {
+        minVersion: string;
+        includeMinVersion: boolean;
+        maxVersion: string | undefined;
+        includeMaxVersion: boolean | undefined;
+    }
+
+    // Adapted from: https://github.com/NuGetArchive/NuGet.Versioning/blob/master/src/NuGet.Versioning/VersionRangeFactory.cs#L81
+    // More docs here: https://docs.microsoft.com/nuget/concepts/package-versioning
+    function parseVersionRange(value: string): IVersionRange | string {
+        const error: Error = new Error(localize('invalidRange', 'Invalid range "{0}"', value));
+
+        value = value.trim();
+
+        // * is the only range below 3 chars
+        if (value === wildcard) {
+            return value;
+        }
+
+        // Fail early if the string is too short to be valid
+        if (value.length < 3) {
+            throw error;
+        }
+
+        let includeMinVersion: boolean;
+        let minVersion: string | undefined;
+        let includeMaxVersion: boolean | undefined;
+        let maxVersion: string | undefined;
+
+        if (value[0] === '(' || value[0] === '[') {
+            // The first character must be [ or (
+            switch (value[0]) {
+                case '[':
+                    includeMinVersion = true;
+                    break;
+                case '(':
+                    includeMinVersion = false;
+                    break;
+                default:
+                    throw error;
+            }
+
+            // The last character must be ] or )
+            switch (value[value.length - 1]) {
+                case ']':
+                    includeMaxVersion = true;
+                    break;
+                case ')':
+                    includeMaxVersion = false;
+                    break;
+                default:
+                    throw error;
+            }
+
+            // Get rid of the two brackets
+            value = value.substring(1, value.length - 1);
+
+            // Split by comma, and make sure we get between 1 and 2 non-empty parts
+            const parts: string[] = value.split(',').map(p => p.trim());
+            if (parts.length > 2 || !parts.some(p => !!p)) {
+                throw error;
+            }
+
+            // If there is only one part, use it for both min and max
+            minVersion = parts[0];
+            maxVersion = parts.length === 2 ? parts[1] : parts[0];
+        } else {
+            if (value.includes(wildcard)) { // If the value has wildcards, it denotes a range
+                return value;
+            } else { // Otherwise, it denotes the minimum version (inclusive)
+                includeMinVersion = true;
+                minVersion = value;
+            }
+        }
+
+        if (minVersion) {
+            if (minVersion.includes(wildcard)) {
+                if (!semver.validRange(minVersion)) {
+                    throw error;
+                }
+            } else {
+                minVersion = appendMissingParts(minVersion);
+                if (!semver.valid(minVersion)) {
+                    throw error;
+                }
+            }
+        }
+
+        if (maxVersion) {
+            // max does not support wildcards
+            maxVersion = appendMissingParts(maxVersion);
+            if (!semver.valid(maxVersion)) {
+                throw error;
+            }
+        }
+
+        return {
+            minVersion,
+            includeMinVersion,
+            maxVersion,
+            includeMaxVersion
+        };
+    }
+
+    /**
+     * Appends ".0" until we have major, minor, and patch
+     */
+    function appendMissingParts(version: string): string {
+        if (/[^0-9.]/.test(version)) {
+            // Assume wildcard or prerelease versions are fine as-is
+            return version;
+        } else {
+            // tslint:disable-next-line: strict-boolean-expressions
+            let count: number = (version.match(/\./g) || []).length;
+            while (count < 2) {
+                version += '.0';
+                count += 1;
+            }
+            return version;
+        }
+    }
+}

--- a/test/nugetUtils.test.ts
+++ b/test/nugetUtils.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { nugetUtils } from '../extension.bundle';
+
+suite('nugetUtils.tryGetMaxInRange', () => {
+    interface ITestCase {
+        range: string;
+        expected?: string;
+    }
+
+    const versions: string[] = ['0.6.0', '1.0.0', '1.0.1', '1.1.0', '2.0.0-alpha', '2.1.0-beta', '2.0.0', '3.0.0'];
+
+    const testCases: ITestCase[] = [
+        // Ranges examples from https://github.com/NuGetArchive/NuGet.Versioning/blob/master/src/NuGet.Versioning/VersionRangeFactory.cs#L38
+        { range: '1.0', expected: '3.0.0' }, // 1.0 ≤ x
+        { range: '(,1.0]', expected: '1.0.0' }, // x <= 1.0
+        { range: '(,1.0)', expected: '0.6.0' }, // x < 1.0
+        { range: '[1.0]', expected: '1.0.0' }, // x === 1.0
+        { range: '(1.0,)', expected: '3.0.0' }, // 1.0 < x
+        { range: '(1.0, 2.0)', expected: '1.1.0' }, // 1.0 < x < 2.0
+        { range: '[1.0, 2.0]', expected: '2.0.0' }, // 1.0 <= x <= 2.0
+        // No matching range
+        { range: '(1.0)', expected: undefined },
+        { range: '(,0.6.0)', expected: undefined },
+        { range: '(,0.5.0]', expected: undefined },
+        { range: '(3.0.0,)', expected: undefined },
+        { range: '[3.0.1,)', expected: undefined },
+        { range: '(1.*, 2.0.0)', expected: undefined },
+        // Some other cases
+        { range: '[1.*, 2.0.0)', expected: '1.1.0' }, // default functions bundle range
+        { range: '(1.0.*, 2)', expected: '1.1.0' },
+        { range: '1.*', expected: '1.1.0' },
+        { range: '[1.*,)', expected: '3.0.0' },
+        { range: '[1,2)', expected: '1.1.0' },
+        { range: '[1,3)', expected: '2.0.0' },
+        { range: '(1.0.1,)', expected: '3.0.0' },
+        { range: '(,1]', expected: '1.0.0' },
+        { range: '2.0.0-alpha', expected: '3.0.0' }
+    ];
+
+    for (const testCase of testCases) {
+        test(testCase.range, () => {
+            assert.equal(nugetUtils.tryGetMaxInRange(testCase.range, versions), testCase.expected);
+        });
+    }
+
+    const invalidRanges: string[] = ['', '[,', '[,)', '1', '(,1.*]', '<,1.0>', '1.0.0.0'];
+    for (const invalidRange of invalidRanges) {
+        test(invalidRange, () => {
+            assert.throws(() => nugetUtils.tryGetMaxInRange(invalidRange, versions));
+        });
+    }
+});


### PR DESCRIPTION
The last piece (!) needed for bundle templates is to respect the version range they specify in host.json

Based on https://github.com/microsoft/vscode-azurefunctions/pull/1540

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1203