### PR TITLE
Vary location and auth level for nightly tests

### DIFF
--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
 import { longRunningTestsEnabled, testUserInput } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
+import { getRotatingLocation } from './getRotatingValue';
 import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
 
 // tslint:disable-next-line: max-func-body-length
@@ -36,7 +37,7 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
     });
 
     test('Create - Advanced', async () => {
-        const testInputs: string[] = [appName, 'Windows', 'Consumption Plan', '.NET', '$(plus) Create new resource group', rgName, '$(plus) Create new storage account', saName, '$(plus) Create new Application Insights resource', aiName, 'East US'];
+        const testInputs: string[] = [appName, 'Windows', 'Consumption Plan', '.NET', '$(plus) Create new resource group', rgName, '$(plus) Create new storage account', saName, '$(plus) Create new Application Insights resource', aiName, getRotatingLocation()];
         await testUserInput.runWithInputs(testInputs, async () => {
             await vscode.commands.executeCommand('azureFunctions.createFunctionAppAdvanced');
         });
@@ -59,7 +60,7 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
         resourceGroupsToDelete.push(apiRgName);
         const apiAppName: string = getRandomHexString();
         await runWithFuncSetting('projectLanguage', ProjectLanguage.JavaScript, async () => {
-            await testUserInput.runWithInputs([apiAppName, 'West US'], async () => {
+            await testUserInput.runWithInputs([apiAppName, getRotatingLocation()], async () => {
                 const actualFuncAppId: string = <string>await vscode.commands.executeCommand('azureFunctions.createFunctionApp', testAccount.getSubscriptionContext().subscriptionId, apiRgName);
                 const site: Models.Site = await testClient.webApps.get(apiRgName, apiAppName);
                 assert.ok(site);

--- a/test/nightly/getRotatingValue.ts
+++ b/test/nightly/getRotatingValue.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+let authCount: number = getStartingIndex();
+const authLevels: string[] = ['Anonymous', 'Function', 'Admin'];
+export function getRotatingAuthLevel(): string {
+    authCount += 1;
+    return authLevels[authCount % authLevels.length];
+}
+
+let locationCount: number = getStartingIndex();
+const locations: string[] = ['Australia East', 'East Asia', 'East US', 'North Europe', 'South Central US', 'Southeast Asia', 'UK South', 'West Europe'];
+export function getRotatingLocation(): string {
+    locationCount += 1;
+    return locations[locationCount % locations.length];
+}
+
+/**
+ * Adds a little more spice to the rotation
+ */
+function getStartingIndex(): number {
+    if (process.platform === 'darwin') {
+        return 0;
+    } else if (process.platform === 'win32') {
+        return 1;
+    } else {
+        return 2;
+    }
+}


### PR DESCRIPTION
We've been having intermittent errors with nightly tests. One theory I have is that we reach subscription quotas for specific locations. So I added some "rotating" logic to make sure it varies the location. Even if that theory is wrong (haven't found anything conclusive yet), I figure this could still be useful to cover more bases