### PR TITLE
Update appservice breaking changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
     "files.exclude": {
         "tools/JsonCli/src/**": true
     },
-    "typescript.preferences.importModuleSpecifier": "relative"
+    "typescript.preferences.importModuleSpecifier": "relative",
+    "appService.showBuildDuringDeployPrompt": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,5 @@
     "files.exclude": {
         "tools/JsonCli/src/**": true
     },
-    "typescript.preferences.importModuleSpecifier": "relative",
-    "appService.showBuildDuringDeployPrompt": false
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8666,9 +8666,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.46.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.46.0.tgz",
-            "integrity": "sha512-8UgmpbI+jnGWQ4OaZzfMhorEdhIoRQJzKEitTpH09MskalyjNfACNW4sKQ0UtCwQ3DNcX9yco4t++0DLrgZh4Q==",
+            "version": "0.47.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.47.0.tgz",
+            "integrity": "sha512-SwE9tNrHiIr3G1bLdzqPtJzBpys/SO11xgoa97klp8k3uemGqBlDxcul2uN+Ra+WvGoLUVMbKtcsRzG13e12QA==",
             "requires": {
                 "archiver": "^3.0.0",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1000,7 +1000,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.4",
         "semver": "^5.7.1",
-        "vscode-azureappservice": "^0.46.0",
+        "vscode-azureappservice": "^0.47.0",
         "vscode-azureextensionui": "^0.28.1",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1",

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -13,6 +13,7 @@ import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreTools
 import { localize } from '../../localize';
 import { ProductionSlotTreeItem } from '../../tree/ProductionSlotTreeItem';
 import { SlotTreeItemBase } from '../../tree/SlotTreeItemBase';
+import { isPathEqual } from '../../utils/fs';
 import * as workspaceUtil from '../../utils/workspace';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
@@ -100,7 +101,7 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
                 // preDeploy tasks are only required for zipdeploy so subpath may not exist
                 let deployFsPath: string = effectiveDeployFsPath;
 
-                if (siteConfig.scmType !== ScmType.None && effectiveDeployFsPath !== originalDeployFsPath) {
+                if (!isZipDeploy && !isPathEqual(effectiveDeployFsPath, originalDeployFsPath)) {
                     deployFsPath = originalDeployFsPath;
                     const noSubpathWarning: string = `WARNING: Ignoring deploySubPath "${getWorkspaceSetting(deploySubpathSetting, originalDeployFsPath)}" for non-zip deploy.`;
                     ext.outputChannel.appendLog(noSubpathWarning);

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -7,7 +7,7 @@ import { WebSiteManagementModels } from 'azure-arm-website';
 import * as vscode from 'vscode';
 import * as appservice from 'vscode-azureappservice';
 import { AzureTreeItem, DialogResponses, IActionContext } from 'vscode-azureextensionui';
-import { extensionPrefix, ProjectLanguage, ProjectRuntime, ScmType, showOutputChannelCommandId } from '../../constants';
+import { deploySubpathSetting, extensionPrefix, ProjectLanguage, ProjectRuntime, ScmType, showOutputChannelCommandId } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
@@ -24,13 +24,13 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
     addLocalFuncTelemetry(context);
 
     let node: SlotTreeItemBase | undefined;
-    let deployFsPath: string = await appservice.getDeployFsPath(target, extensionPrefix);
+    const { originalDeployFsPath, effectiveDeployFsPath } = await appservice.getDeployFsPath(target, extensionPrefix);
 
     if (target instanceof SlotTreeItemBase) {
         node = target;
     }
 
-    const workspaceFolder: vscode.WorkspaceFolder | undefined = workspaceUtil.getContainingWorkspace(deployFsPath);
+    const workspaceFolder: vscode.WorkspaceFolder | undefined = workspaceUtil.getContainingWorkspace(effectiveDeployFsPath);
     if (!workspaceFolder) {
         throw new Error(localize('folderOpenWarning', 'Failed to deploy because the path is not part of an open workspace. Open in a workspace and try again.'));
     }
@@ -60,7 +60,7 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
     context.telemetry.properties.isNewFunctionApp = String(isNewFunctionApp);
 
     const client: appservice.SiteClient = node.root.client;
-    const [language, runtime]: [ProjectLanguage, ProjectRuntime] = await verifyInitForVSCode(context, deployFsPath);
+    const [language, runtime]: [ProjectLanguage, ProjectRuntime] = await verifyInitForVSCode(context, effectiveDeployFsPath);
     context.telemetry.properties.projectLanguage = language;
     context.telemetry.properties.projectRuntime = runtime;
 
@@ -80,16 +80,11 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
         context.telemetry.properties.cancelStep = '';
     }
 
-    await runPreDeployTask(context, deployFsPath, siteConfig.scmType);
-
-    if (siteConfig.scmType === ScmType.LocalGit) {
-        // preDeploy tasks are not required for LocalGit so subpath may not exist
-        deployFsPath = workspaceFolder.uri.fsPath;
-    }
+    await runPreDeployTask(context, effectiveDeployFsPath, siteConfig.scmType);
 
     if (isZipDeploy) {
         // tslint:disable-next-line:no-floating-promises
-        validateGlobSettings(context, deployFsPath);
+        validateGlobSettings(context, effectiveDeployFsPath);
     }
 
     await node.runWithTemporaryDescription(
@@ -102,6 +97,15 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
                     ext.outputChannel.appendLog(localize('stopFunctionApp', 'Stopping Function App: {0} ...', client.fullName));
                     await client.stop();
                 }
+                // preDeploy tasks are only required for zipdeploy so subpath may not exist
+                let deployFsPath: string = effectiveDeployFsPath;
+
+                if (siteConfig.scmType !== ScmType.None && effectiveDeployFsPath !== originalDeployFsPath) {
+                    deployFsPath = originalDeployFsPath;
+                    const noSubpathWarning: string = `WARNING: Ignoring deploySubPath "${getWorkspaceSetting(deploySubpathSetting, originalDeployFsPath)}" for non-zip deploy.`;
+                    ext.outputChannel.appendLog(noSubpathWarning);
+                }
+
                 await appservice.deploy(client, deployFsPath, context, showOutputChannelCommandId);
             } finally {
                 if (language === ProjectLanguage.Java) {


### PR DESCRIPTION
appservice 0.47.0 changes `getDeployFsPath` to return the `originalDeployPath` that the user selected and the `effectiveDeployPath` where subpath settings have been appended.