### PR TITLE
Fix getFunctionNameFromId for slots

### DIFF
--- a/src/tree/remoteProject/RemoteFunctionTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionTreeItem.ts
@@ -87,7 +87,7 @@ export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
 }
 
 export function getFunctionNameFromId(id: string): string {
-    const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/(?:[^\/]+)\/resourceGroups\/(?:[^\/]+)\/providers\/Microsoft.Web\/sites\/(?:[^\/]+)\/functions\/([^\/]+)/);
+    const matches: RegExpMatchArray | null = id.match(/\/subscriptions\/[^\/]+\/resourceGroups\/[^\/]+\/providers\/Microsoft.Web\/sites\/[^\/]+(?:\/slots\/[^\/]+)?\/functions\/([^\/]+)/);
 
     if (matches === null || matches.length < 2) {
         throw new Error(localize('invalidFuncId', 'Invalid Functions Id'));


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/601, this reg exp now needs to handle slot ids as well