### PR TITLE
Verify bundle in "Add Binding" feature

### DIFF
--- a/src/commands/addBinding/BindingCreateStep.ts
+++ b/src/commands/addBinding/BindingCreateStep.ts
@@ -9,6 +9,7 @@ import { IFunctionBinding, IFunctionJson } from "../../funcConfig/function";
 import { IBindingTemplate } from "../../templates/IBindingTemplate";
 import { confirmEditJsonFile } from '../../utils/fs';
 import { nonNullProp } from "../../utils/nonNull";
+import { verifyExtensionBundle } from "../../utils/verifyExtensionBundle";
 import { getBindingSetting } from "../createFunction/IFunctionWizardContext";
 import { IBindingWizardContext } from "./IBindingWizardContext";
 
@@ -36,6 +37,8 @@ export class BindingCreateStep extends AzureWizardExecuteStep<IBindingWizardCont
             return functionJson;
         });
         context.binding = binding;
+
+        await verifyExtensionBundle(context, bindingTemplate);
 
         window.showTextDocument(await workspace.openTextDocument(Uri.file(context.functionJsonPath)));
     }

--- a/src/commands/createFunction/FunctionCreateStepBase.ts
+++ b/src/commands/createFunction/FunctionCreateStepBase.ts
@@ -10,7 +10,7 @@ import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { IFunctionTemplate } from '../../templates/IFunctionTemplate';
 import { nonNullProp } from '../../utils/nonNull';
-import { shouldUseExtensionBundle, verifyExtensionBundle } from '../../utils/verifyExtensionBundle';
+import { verifyExtensionBundle } from '../../utils/verifyExtensionBundle';
 import { getContainingWorkspace } from '../../utils/workspace';
 import { IFunctionWizardContext } from './IFunctionWizardContext';
 
@@ -51,9 +51,7 @@ export abstract class FunctionCreateStepBase<T extends IFunctionWizardContext> e
         progress.report({ message: localize('creatingFunction', 'Creating new {0}...', template.name) });
 
         const newFilePath: string = await this.executeCore(context);
-        if (await shouldUseExtensionBundle(context, template)) {
-            await verifyExtensionBundle(context);
-        }
+        await verifyExtensionBundle(context, template);
 
         const cachedFunc: ICachedFunction = { projectPath: context.projectPath, newFilePath, isHttpTrigger: template.isHttpTrigger };
 

--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -14,6 +14,7 @@ import { requestUtils } from './requestUtils';
 
 export namespace bundleFeedUtils {
     export const defaultBundleId: string = 'Microsoft.Azure.Functions.ExtensionBundle';
+    export const defaultVersionRange: string = '[1.*, 2.0.0)';
 
     interface IBundleFeed {
         defaultVersionRange: string;
@@ -56,6 +57,11 @@ export namespace bundleFeedUtils {
 
     export function isBundleTemplate(template: IFunctionTemplate | IBindingTemplate): boolean {
         return !template.isHttpTrigger && !template.isTimerTrigger;
+    }
+
+    export async function getLatestVersionRange(): Promise<string> {
+        const feed: IBundleFeed = await getBundleFeed(undefined);
+        return feed.defaultVersionRange;
     }
 
     // We access the feed pretty frequently, so cache it and periodically refresh it

--- a/src/utils/verifyExtensionBundle.ts
+++ b/src/utils/verifyExtensionBundle.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { parseError } from 'vscode-azureextensionui';
+import { IFunctionWizardContext } from '../commands/createFunction/IFunctionWizardContext';
+import { extInstallCommand, hostFileName, ProjectLanguage, ProjectRuntime, settingsFileName, tasksFileName, vscodeFolderName } from '../constants';
+import { IHostJsonV2 } from '../funcConfig/host';
+import { localize } from '../localize';
+import { IFunctionTemplate } from '../templates/IFunctionTemplate';
+import { writeFormattedJson } from './fs';
+
+export async function verifyExtensionBundle(context: IFunctionWizardContext): Promise<void> {
+    const hostFilePath: string = path.join(context.projectPath, hostFileName);
+    try {
+        const hostJson: IHostJsonV2 = <IHostJsonV2>await fse.readJSON(hostFilePath);
+        if (!hostJson.extensionBundle) {
+            // https://github.com/Microsoft/vscode-azurefunctions/issues/1202
+            hostJson.extensionBundle = {
+                id: 'Microsoft.Azure.Functions.ExtensionBundle',
+                version: '[1.*, 2.0.0)'
+            };
+            await writeFormattedJson(hostFilePath, hostJson);
+        }
+    } catch (error) {
+        throw new Error(localize('failedToParseHostJson', 'Failed to parse {0}: {1}', hostFileName, parseError(error).message));
+    }
+}
+
+export async function shouldUseExtensionBundle(context: IFunctionWizardContext, template: IFunctionTemplate): Promise<boolean> {
+    // v1 doesn't support bundles
+    // http and timer triggers don't need a bundle
+    // F# and C# specify extensions as dependencies in their proj file instead of using a bundle
+    if (context.runtime === ProjectRuntime.v1 ||
+        template.isHttpTrigger || template.isTimerTrigger ||
+        context.language === ProjectLanguage.CSharp || context.language === ProjectLanguage.FSharp) {
+        return false;
+    }
+
+    // Old projects setup to use "func extensions install" shouldn't use a bundle because it could lead to duplicate or conflicting binaries
+    try {
+        const filesToCheck: string[] = [tasksFileName, settingsFileName];
+        for (const file of filesToCheck) {
+            const filePath: string = path.join(context.workspacePath, vscodeFolderName, file);
+            if (await fse.pathExists(filePath)) {
+                const contents: string = (await fse.readFile(filePath)).toString();
+                if (contents.includes(extInstallCommand)) {
+                    return false;
+                }
+            }
+        }
+    } catch {
+        // ignore and use bundles (the default for new projects)
+    }
+
+    return true;
+}


### PR DESCRIPTION
Previously we would only verify bundle in "Create function" feature. First commit just moved the code, [second commit](https://github.com/microsoft/vscode-azurefunctions/commit/b17a6a7b8c1ca87ebdf305d0956c35a8ab1fd814) actually changed it.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1343
Also fixes https://github.com/microsoft/vscode-azurefunctions/issues/1202 to get latest bundle range instead of hard-coded default.