### PR TITLE
Use markdown format for links

### DIFF
--- a/src/templates/script/parseScriptTemplates.ts
+++ b/src/templates/script/parseScriptTemplates.ts
@@ -123,7 +123,7 @@ function parseScriptSetting(data: object, resources: IResources, variables: IVar
         name: getVariableValue(resources, variables, rawSetting.name),
         resourceType: rawSetting.resource,
         valueType: rawSetting.value,
-        description: rawSetting.help ? getResourceValue(resources, rawSetting.help) : undefined,
+        description: rawSetting.help ? replaceHtmlLinkWithMarkdown(getResourceValue(resources, rawSetting.help)) : undefined,
         defaultValue: rawSetting.defaultValue ? getVariableValue(resources, variables, rawSetting.defaultValue) : undefined,
         label: getVariableValue(resources, variables, rawSetting.label),
         enums: enums,
@@ -132,7 +132,7 @@ function parseScriptSetting(data: object, resources: IResources, variables: IVar
             if (rawSetting.validators) {
                 for (const validator of rawSetting.validators) {
                     if (!value || value.match(validator.expression) === null) {
-                        return getVariableValue(resources, variables, validator.errorText);
+                        return replaceHtmlLinkWithMarkdown(getVariableValue(resources, variables, validator.errorText));
                     }
                 }
             }
@@ -140,6 +140,15 @@ function parseScriptSetting(data: object, resources: IResources, variables: IVar
             return undefined;
         }
     };
+}
+
+function replaceHtmlLinkWithMarkdown(text: string): string {
+    const match: RegExpMatchArray | null = text.match(/<a[^>]*href=['"]([^'"]*)['"][^>]*>([^<]*)<\/a>/i);
+    if (match) {
+        return text.replace(match[0], `[${match[2]}](${match[1]})`);
+    } else {
+        return text;
+    }
 }
 
 export function parseScriptBindings(config: IConfig, resources: IResources): IBindingTemplate[] {


### PR DESCRIPTION
Markdown looks a bit better than html:
![timercron](https://user-images.githubusercontent.com/4258913/59138178-842d8a00-8940-11e9-876e-6355f936adcf.png)
![Screen Shot 2019-10-08 at 10 03 05 AM](https://user-images.githubusercontent.com/11282622/66417445-d943e000-e9b4-11e9-8668-0ec9108c61b2.png)

More importantly, markdown is how VS Code supports clickable links in notifications and I filed https://github.com/microsoft/vscode/issues/82112 to do the same for input boxes.
![Screen Shot 2019-10-08 at 10 05 07 AM](https://user-images.githubusercontent.com/11282622/66417582-2922a700-e9b5-11e9-9f86-411d88b65903.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1331