### PR TITLE
Fix `includeTemplate` for java

### DIFF
--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -55,6 +55,13 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
         }
     }
 
+    /**
+     * Unlike script where templates come from multiple sources (bundle vs non-bundle), java always gets templates from the same source (maven)
+     */
+    public includeTemplate(): boolean {
+        return true;
+    }
+
     protected async getCacheKeySuffix(): Promise<string> {
         return 'Java';
     }


### PR DESCRIPTION
Nightly tests caught a bug where java was only showing two templates (http and timer) instead of the expected number. Java needs include templates here since it never gets anything from the bundle source.