### PR TITLE
Handle function apps that don't support remote build

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -19,6 +19,7 @@ import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
 import { notifyDeployComplete } from './notifyDeployComplete';
 import { runPreDeployTask } from './runPreDeployTask';
+import { validateRemoteBuild } from './validateRemoteBuild';
 import { verifyAppSettings } from './verifyAppSettings';
 
 export async function deploy(context: IActionContext, target?: vscode.Uri | string | SlotTreeItemBase, functionAppId?: string | {}): Promise<void> {
@@ -68,6 +69,8 @@ export async function deploy(context: IActionContext, target?: vscode.Uri | stri
     if (language === ProjectLanguage.Python && !node.root.client.isLinux) {
         throw new Error(localize('pythonNotAvailableOnWindows', 'Python projects are not supported on Windows Function Apps.  Deploy to a Linux Function App instead.'));
     }
+
+    await validateRemoteBuild(context, client, workspaceFolder.uri.fsPath, language);
 
     await verifyAppSettings(context, node, runtime, language);
 

--- a/src/commands/deploy/validateRemoteBuild.ts
+++ b/src/commands/deploy/validateRemoteBuild.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { SiteClient } from 'vscode-azureappservice';
+import { IActionContext } from 'vscode-azureextensionui';
+import { deploySubpathSetting, packTaskName, preDeployTaskSetting, ProjectLanguage } from '../../constants';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
+import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
+import { ensureGitIgnoreContents } from '../initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep';
+
+export async function validateRemoteBuild(context: IActionContext, client: SiteClient, workspacePath: string, language: ProjectLanguage): Promise<void> {
+    if (language === ProjectLanguage.Python && !client.kuduUrl) {
+        const remoteBuildKey: string = 'scmDoBuildDuringDeployment';
+
+        const remoteBuild: boolean | undefined = getWorkspaceSetting(remoteBuildKey, workspacePath);
+        if (remoteBuild) {
+            const message: string = localize('remoteBuildNotSupported', 'The selected Function App doesn\'t support your project\'s configuration. Deploy to a newer Function App or downgrade your config.');
+            const learnMoreLink: string = 'https://aka.ms/AA5vsfd';
+            const downgrade: vscode.MessageItem = { title: localize('downgrade', 'Downgrade config') };
+            context.telemetry.properties.cancelStep = 'validateRemoteBuild';
+            await ext.ui.showWarningMessage(message, { learnMoreLink, modal: true }, downgrade);
+            context.telemetry.properties.cancelStep = undefined;
+
+            const projectPath: string = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */) || workspacePath;
+            await updateWorkspaceSetting(remoteBuildKey, false, workspacePath);
+            await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
+            const zipFileName: string = path.basename(projectPath) + '.zip';
+            // Always use posix separators for config checked in to source control
+            await updateWorkspaceSetting(deploySubpathSetting, path.posix.join(path.relative(workspacePath, projectPath), zipFileName), workspacePath);
+            await ensureGitIgnoreContents(projectPath, [zipFileName]);
+        }
+    }
+}


### PR DESCRIPTION
![Screen Shot 2019-10-08 at 4 15 02 PM](https://user-images.githubusercontent.com/11282622/66440149-deba1e00-e9e6-11e9-9711-2f61af495b0d.png)

This will pop up for users with new projects and old function apps in Azure (created before Aug. 1st, 2019). I'll update the aka.ms link with more info closer to release date.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1548