### PR TITLE
Show better error message when slots aren't supported

### DIFF
--- a/src/tree/ProductionSlotTreeItem.ts
+++ b/src/tree/ProductionSlotTreeItem.ts
@@ -6,6 +6,7 @@
 import { WebSiteManagementModels } from 'azure-arm-website';
 import { SiteClient } from 'vscode-azureappservice';
 import { AzExtTreeItem } from 'vscode-azureextensionui';
+import { localize } from '../localize';
 import { SlotsTreeItem } from './SlotsTreeItem';
 import { SlotTreeItem } from './SlotTreeItem';
 import { SlotTreeItemBase } from './SlotTreeItemBase';
@@ -28,23 +29,31 @@ export class ProductionSlotTreeItem extends SlotTreeItemBase {
 
     public async loadMoreChildrenImpl(): Promise<AzExtTreeItem[]> {
         const children: AzExtTreeItem[] = await super.loadMoreChildrenImpl();
-        // Slots are not yet supported for Linux Consumption
-        if (!this.root.client.isLinux || !await this.getIsConsumption()) {
+        if (await this.supportsSlots()) {
             children.push(this._slotsTreeItem);
         }
         return children;
     }
 
-    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined {
+    public async pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined> {
         for (const expectedContextValue of expectedContextValues) {
             switch (expectedContextValue) {
                 case SlotsTreeItem.contextValue:
                 case SlotTreeItem.contextValue:
-                    return this._slotsTreeItem;
+                    if (await this.supportsSlots()) {
+                        return this._slotsTreeItem;
+                    } else {
+                        throw new Error(localize('slotNotSupported', 'Linux Consumption apps do not support slots.'));
+                    }
                 default:
             }
         }
 
         return super.pickTreeItemImpl(expectedContextValues);
+    }
+
+    private async supportsSlots(): Promise<boolean> {
+        // Slots are not yet supported for Linux Consumption
+        return !this.root.client.isLinux || !await this.getIsConsumption();
     }
 }

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -169,7 +169,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
         return [this._functionsTreeItem, this.appSettingsTreeItem, this._proxiesTreeItem, this.deploymentsNode];
     }
 
-    public pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): AzExtTreeItem | undefined {
+    public async pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined> {
         for (const expectedContextValue of expectedContextValues) {
             switch (expectedContextValue) {
                 case AppSettingsTreeItem.contextValue:


### PR DESCRIPTION
Specifically when the user selects a function app during a command palette command.

Related to https://github.com/microsoft/vscode-azurefunctions/pull/1559#discussion_r332786161