### PR TITLE
Add timeout when getting cli/bundle feed

### DIFF
--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -6,7 +6,7 @@
 import { ProjectRuntime } from '../constants';
 import { ext, TemplateSource } from '../extensionVariables';
 import { localize } from '../localize';
-import { requestUtils } from './requestUtils';
+import { feedUtils } from './feedUtils';
 
 export namespace cliFeedUtils {
     const funcCliFeedUrl: string = 'https://aka.ms/V00v5v';
@@ -85,18 +85,7 @@ export namespace cliFeedUtils {
         };
     }
 
-    // We access the cli feed pretty frequently, so cache it and periodically refresh it
-    let cachedCliFeed: ICliFeed | undefined;
-    let nextRefreshTime: number = Date.now();
-
     async function getCliFeed(): Promise<ICliFeed> {
-        if (!cachedCliFeed || Date.now() > nextRefreshTime) {
-            const request: requestUtils.Request = await requestUtils.getDefaultRequest(funcCliFeedUrl);
-            const response: string = await requestUtils.sendRequest(request);
-            cachedCliFeed = <ICliFeed>JSON.parse(response);
-            nextRefreshTime = Date.now() + 10 * 60 * 1000;
-        }
-
-        return cachedCliFeed;
+        return feedUtils.getJsonFeed(funcCliFeedUrl);
     }
 }

--- a/src/utils/feedUtils.ts
+++ b/src/utils/feedUtils.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { parseError } from 'vscode-azureextensionui';
+import { localize } from '../localize';
+import { requestUtils } from './requestUtils';
+
+export namespace feedUtils {
+    interface ICachedFeed {
+        data: {};
+        nextRefreshTime: {};
+    }
+
+    const cachedFeeds: Map<string, ICachedFeed> = new Map<string, ICachedFeed>();
+
+    /**
+     * Provides some helper logic when getting a json feed:
+     * 1. Caches the feed for 10 minutes since these feeds don't change very often and we don't want to make repeated calls to get the same information
+     * 2. Sets timeout for getting the feed to 15 seconds since we would rather default to the "backup" logic than wait a long time
+     */
+    export async function getJsonFeed<T extends {}>(url: string): Promise<T> {
+        let cachedFeed: ICachedFeed | undefined = cachedFeeds.get(url);
+        if (!cachedFeed || Date.now() > cachedFeed.nextRefreshTime) {
+            const request: requestUtils.Request = await requestUtils.getDefaultRequest(url);
+            request.timeout = 15 * 1000;
+
+            let response: string;
+            try {
+                response = await requestUtils.sendRequest(request);
+            } catch (error) {
+                if (parseError(error).errorType === 'ETIMEDOUT') {
+                    throw new Error(localize('timeoutFeed', 'Timed out retrieving feed "{0}".', url));
+                } else {
+                    throw error;
+                }
+            }
+            cachedFeed = { data: <{}>JSON.parse(response), nextRefreshTime: Date.now() + 10 * 60 * 1000 };
+            cachedFeeds.set(url, cachedFeed);
+        }
+
+        return <T>cachedFeed.data;
+    }
+}


### PR DESCRIPTION
and combine caching logic into one util file. See comment above `getJsonFeed` for more info.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1145 - this is the last stuff I wanted to do to close that issue. I think there are still potential issues with templates, but at least now it should be easier for users to diagnose/report those issues.