### PR TITLE
Add a setting to control terminating func host

### DIFF
--- a/package.json
+++ b/package.json
@@ -937,6 +937,11 @@
                         "type": "boolean",
                         "description": "%azureFunctions.enableOutputTimestamps%",
                         "default": true
+                    },
+                    "azureFunctions.stopFuncTaskPostDebug": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.stopFuncTaskPostDebug%",
+                        "default": true
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -67,6 +67,7 @@
     "azureFunctions.startJavaRemoteDebug": "Attach Debugger",
     "azureFunctions.startRemoteDebug": "Start Remote Debugging",
     "azureFunctions.startStreamingLogs": "Start Streaming Logs",
+    "azureFunctions.stopFuncTaskPostDebug": "Automatically stop the task running the Azure Functions host when a debug sessions ends.",
     "azureFunctions.stopFunctionApp": "Stop",
     "azureFunctions.stopStreamingLogs": "Stop Streaming Logs",
     "azureFunctions.swapSlot": "Swap Slot...",


### PR DESCRIPTION
I believe `funcExecution.terminate()` is causing problems in both https://github.com/microsoft/vscode-azurefunctions/issues/1401 and https://github.com/microsoft/vscode-azurefunctions/issues/781 after a debug session ends. I don't have time to fully investigate those before 0.19.0, but I think this simple setting could unblock people.