### PR TITLE
Don't show error from pinging

### DIFF
--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -23,8 +23,12 @@ export async function startStreamingLogs(context: IActionContext, treeItem?: Slo
     const client: appservice.SiteClient = treeItem.client;
 
     if (client.isLinux) {
-        // https://github.com/microsoft/vscode-azurefunctions/issues/1472
-        await appservice.pingFunctionApp(treeItem.client);
+        try {
+            // https://github.com/microsoft/vscode-azurefunctions/issues/1472
+            await appservice.pingFunctionApp(treeItem.client);
+        } catch {
+            // ignore and open portal anyways
+        }
 
         await openLiveMetricsStream(treeItem);
     } else {


### PR DESCRIPTION
Seems like the ping will succeed if your function app is set up for remote build, but will fail if it's not. Either way, failing to ping shouldn't block opening up the live metrics stream in the portal

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1570