### PR TITLE
Don't log "Deploy Completed" to output channel

### DIFF
--- a/src/commands/deploy/notifyDeployComplete.ts
+++ b/src/commands/deploy/notifyDeployComplete.ts
@@ -17,7 +17,6 @@ import { startStreamingLogs } from '../logstream/startStreamingLogs';
 
 export async function notifyDeployComplete(context: IActionContext, node: SlotTreeItemBase, workspacePath: string): Promise<void> {
     const deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', node.root.client.fullName);
-    ext.outputChannel.appendLog(deployComplete);
     const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
     const streamLogs: MessageItem = { title: localize('streamLogs', 'Stream logs') };
     const uploadSettings: MessageItem = { title: localize('uploadAppSettings', 'Upload settings') };


### PR DESCRIPTION
Here's the full log today:
```
4:00:32 PM emjjs44: Creating zip package...
4:00:32 PM emjjs44: Starting deployment...
4:00:40 PM emjjs44: Updating submodules.
4:00:40 PM emjjs44: Preparing deployment for commit id '5d84f480ec'.
4:00:41 PM emjjs44: Skipping build. Project type: Run-From-Zip
4:00:42 PM emjjs44: Skipping post build. Project type: Run-From-Zip
4:00:45 PM emjjs44: Syncing 2 function triggers with payload size 159 bytes successful.
4:00:45 PM emjjs44: Deployment successful.
4:00:51 PM: Deployment to "emjjs44" completed.
4:00:51 PM emjjs44: Querying triggers...
4:01:03 PM: HTTP Trigger Urls:
  HttpTrigger3: https://emjjs44.azurewebsites.net/api/HttpTrigger3
```

That line is annoying for two reasons:
1. It's the only line that has the timestamp, but not the resource prefix
1. It seems redundant with the "Deployment successful" line above