### PR TITLE
Patch release for "Add Binding" 😞

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## 0.19.1 - 2019-10-15
+
+### [Fixed](https://github.com/Microsoft/vscode-azurefunctions/issues?q=is%3Aissue+milestone%3A%220.19.1%22+is%3Aclosed)
+
+- Fix error "Expected value to be neither null nor undefined" when adding a binding
+
 ## 0.19.0 - 2019-10-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "0.19.1-alpha",
+    "version": "0.19.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "0.19.1-alpha",
+    "version": "0.19.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/addBinding/IBindingWizardContext.ts
+++ b/src/commands/addBinding/IBindingWizardContext.ts
@@ -3,12 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ProjectLanguage, ProjectRuntime } from "../../constants";
 import { IFunctionBinding } from "../../funcConfig/function";
 import { IBindingTemplate } from "../../templates/IBindingTemplate";
 import { IFunctionWizardContext } from "../createFunction/IFunctionWizardContext";
 
 export interface IBindingWizardContext extends IFunctionWizardContext {
     functionJsonPath: string;
+    language: ProjectLanguage;
+    runtime: ProjectRuntime;
     bindingDirection?: string;
     bindingTemplate?: IBindingTemplate;
     binding?: IFunctionBinding;

--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -5,11 +5,11 @@
 
 import { Uri, WorkspaceFolder } from "vscode";
 import { AzureWizard, IActionContext } from "vscode-azureextensionui";
-import { ProjectLanguage, projectLanguageSetting, ProjectRuntime, projectRuntimeSetting } from "../../constants";
+import { ProjectLanguage, ProjectRuntime } from "../../constants";
 import { LocalBindingsTreeItem } from "../../tree/localProject/LocalBindingsTreeItem";
 import { nonNullValue } from "../../utils/nonNull";
 import { getContainingWorkspace } from "../../utils/workspace";
-import { getWorkspaceSetting } from "../../vsCodeConfig/settings";
+import { verifyInitForVSCode } from "../../vsCodeConfig/verifyInitForVSCode";
 import { createChildNode } from "../createChildNode";
 import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
 import { createBindingWizard } from "./createBindingWizard";
@@ -21,8 +21,7 @@ export async function addBinding(context: IActionContext, data: Uri | LocalBindi
         const workspaceFolder: WorkspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'workspaceFolder');
         const workspacePath: string = workspaceFolder.uri.fsPath;
         const projectPath: string | undefined = await tryGetFunctionProjectRoot(workspacePath) || workspacePath;
-        const language: ProjectLanguage | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);
-        const runtime: ProjectRuntime | undefined = getWorkspaceSetting(projectRuntimeSetting, projectPath);
+        const [language, runtime]: [ProjectLanguage, ProjectRuntime] = await verifyInitForVSCode(context, projectPath);
 
         const wizardContext: IBindingWizardContext = Object.assign(context, { functionJsonPath: data.fsPath, workspacePath, projectPath, workspaceFolder, language, runtime });
         const wizard: AzureWizard<IBindingWizardContext> = createBindingWizard(wizardContext);

--- a/src/tree/localProject/LocalBindingsTreeItem.ts
+++ b/src/tree/localProject/LocalBindingsTreeItem.ts
@@ -6,7 +6,9 @@
 import { AzureWizard, ICreateChildImplContext } from 'vscode-azureextensionui';
 import { createBindingWizard } from '../../commands/addBinding/createBindingWizard';
 import { IBindingWizardContext } from '../../commands/addBinding/IBindingWizardContext';
+import { ProjectLanguage, ProjectRuntime } from '../../constants';
 import { nonNullProp } from '../../utils/nonNull';
+import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
 import { BindingsTreeItem } from '../BindingsTreeItem';
 import { BindingTreeItem } from '../BindingTreeItem';
 import { LocalFunctionTreeItem } from './LocalFunctionTreeItem';
@@ -19,11 +21,14 @@ export class LocalBindingsTreeItem extends BindingsTreeItem {
     }
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<BindingTreeItem> {
+        const [language, runtime]: [ProjectLanguage, ProjectRuntime] = await verifyInitForVSCode(context, this.parent.parent.parent.projectPath);
         const wizardContext: IBindingWizardContext = Object.assign(context, {
             functionJsonPath: this.parent.functionJsonPath,
             workspacePath: this.parent.parent.parent.workspacePath,
             projectPath: this.parent.parent.parent.projectPath,
-            workspaceFolder: this.parent.parent.parent.workspaceFolder
+            workspaceFolder: this.parent.parent.parent.workspaceFolder,
+            language,
+            runtime
         });
 
         const wizard: AzureWizard<IBindingWizardContext> = createBindingWizard(wizardContext);


### PR DESCRIPTION
When I changed this in https://github.com/microsoft/vscode-azurefunctions/pull/1525, I must've only tested the file uri entry point (which works) and not the command palette or tree entry point (which doesn't). language and runtime were optional on IFunctionWizardContext, but we need them when creating a binding

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1584