### PR TITLE
Simplify typescript package.json scripts

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -14,10 +14,8 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
     protected packageJsonScripts: { [key: string]: string } = {
         build: 'tsc',
         watch: 'tsc -w',
-        prestart: 'npm run build && func extensions install',
-        'start:host': 'func start',
-        start: 'npm run start:host & npm run watch',
-        'build:production': 'npm run prestart && npm prune --production',
+        prestart: 'npm run build',
+        start: 'func start',
         test: 'echo \"No tests yet...\"'
     };
 


### PR DESCRIPTION
There's a few problems with these scripts:
1. "func extension install" is no longer needed
1. Combining commands into one script (aka the stuff with the `&`) is different on each OS, so these actually fail today for certain OS's

Instead, I simplified it to the bare minimum scripts that should at least provide a starting point for users, but more importantly should work in all cases. Also we prioritize the VS Code debug experience, which doesn't really rely on these scripts, so simpler is better for our own maintenance.

Fixes: https://github.com/microsoft/vscode-azurefunctions/issues/1413