### PR TITLE
Fix version bump message for brew v3 ☕️

### DIFF
--- a/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -13,6 +13,7 @@ import { localize } from '../localize';
 import { openUrl } from '../utils/openUrl';
 import { requestUtils } from '../utils/requestUtils';
 import { getWorkspaceSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
+import { getBrewPackageName } from './getBrewPackageName';
 import { getFuncPackageManagers } from './getFuncPackageManagers';
 import { getLocalFuncCoreToolsVersion } from './getLocalFuncCoreToolsVersion';
 import { getNpmDistTag } from "./getNpmDistTag";
@@ -70,7 +71,7 @@ export async function validateFuncCoreToolsIsLatest(): Promise<void> {
                     return;
                 }
 
-                if (semver.gt(newestVersion, localVersion)) {
+                if (semver.major(newestVersion) === semver.major(localVersion) && semver.gt(newestVersion, localVersion)) {
                     context.telemetry.properties.outOfDateFunc = 'true';
                     const message: string = localize(
                         'outdatedFunctionRuntime',
@@ -103,7 +104,8 @@ export async function validateFuncCoreToolsIsLatest(): Promise<void> {
 async function getNewestFunctionRuntimeVersion(packageManager: PackageManager | undefined, versionFromSetting: FuncVersion, context: IActionContext): Promise<string | undefined> {
     try {
         if (packageManager === PackageManager.brew) {
-            const brewRegistryUri: string = 'https://aka.ms/AA1t7go';
+            const packageName: string = getBrewPackageName(versionFromSetting);
+            const brewRegistryUri: string = `https://raw.githubusercontent.com/Azure/homebrew-functions/master/Formula/${packageName}.rb`;
             const request: requestUtils.Request = await requestUtils.getDefaultRequest(brewRegistryUri);
             const brewInfo: string = await requestUtils.sendRequest(request);
             const matches: RegExpMatchArray | null = brewInfo.match(/version\s+["']([^"']+)["']/i);


### PR DESCRIPTION
As a reminder, here's the relevant warning:
![Screen Shot 2019-10-28 at 3 16 22 PM](https://user-images.githubusercontent.com/11282622/67722317-0e30ca80-f996-11e9-89ec-d51d4d2457c0.png)

I decided to give up on an aka.ms link for a few reasons:
1. If this fails for any reason, we suppress the error. The only downside is the user isn't prompted to update. (Although I added some extra logic just to make sure we're not recommending updating past a major version)
1. I think it's more likely that we forget to update an aka.ms link for this as opposed to the underlying link structure changing