### PR TITLE
Support runtime versions 🏃🏻‍♂️⏰

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebSiteManagementClient } from 'azure-arm-website';
+import { Progress } from 'vscode';
+import { IAppServiceWizardContext } from 'vscode-azureappservice';
+import { AzureWizardExecuteStep, createAzureClient } from 'vscode-azureextensionui';
+import { ProjectLanguage, workerRuntimeKey } from '../../constants';
+import { ext } from '../../extensionVariables';
+import { FuncVersion } from '../../FuncVersion';
+import { localize } from '../../localize';
+import { nonNullProp } from '../../utils/nonNull';
+
+export interface IAppSettingsContext {
+    storageConnectionString?: string;
+    fileShareName?: string;
+    os: string;
+    runtime?: string;
+    aiInstrumentationKey?: string;
+}
+
+export class SiteCreateStep extends AzureWizardExecuteStep<IAppServiceWizardContext> {
+    public priority: number = 140;
+
+    public async execute(wizardContext: IAppServiceWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
+        const creatingNewApp: string = wizardContext.newSiteKind === AppKind.functionapp ?
+            localize('creatingNewFunctionApp', 'Creating new function app "{0}"...', wizardContext.newSiteName) :
+            localize('creatingNewWebApp', 'Creating new web app "{0}"...', wizardContext.newSiteName);
+        ext.outputChannel.appendLog(creatingNewApp);
+        progress.report({ message: creatingNewApp });
+        const client: WebSiteManagementClient = createAzureClient(wizardContext, WebSiteManagementClient);
+        wizardContext.site = await client.webApps.createOrUpdate(nonNullValueAndProp(wizardContext.resourceGroup, 'name'), nonNullProp(wizardContext, 'newSiteName'), {
+            name: wizardContext.newSiteName,
+            kind: wizardContext.newSiteKind,
+            location: nonNullValueAndProp(wizardContext.location, 'name'),
+            serverFarmId: wizardContext.plan ? wizardContext.plan.id : undefined,
+            clientAffinityEnabled: wizardContext.newSiteKind === AppKind.app,
+            siteConfig: await this.getNewSiteConfig(wizardContext),
+            reserved: wizardContext.newSiteOS === WebsiteOS.linux  // The secret property - must be set to true to make it a Linux plan. Confirmed by the team who owns this API.
+        });
+    }
+
+    public shouldExecute(wizardContext: IAppServiceWizardContext): boolean {
+        return !wizardContext.site;
+    }
+
+    private async getNewSiteConfig(wizardContext: IAppServiceWizardContext): Promise<SiteConfig> {
+        const newSiteConfig: SiteConfig = {};
+        let storageConnectionString: string | undefined;
+        let fileShareName: string | undefined;
+
+        if (wizardContext.newSiteOS === 'linux') {
+            if (wizardContext.useConsumptionPlan) {
+                newSiteConfig.use32BitWorkerProcess = false; // Needs to be explicitly set to false per the platform team
+            } else {
+                newSiteConfig.linuxFxVersion = this.getFunctionAppLinuxFxVersion(nonNullProp(wizardContext, 'newSiteRuntime'));
+            }
+        }
+
+        const storageClient: StorageManagementClient = createAzureClient(wizardContext, StorageManagementClient);
+
+        const storageAccount: StorageAccount = nonNullProp(wizardContext, 'storageAccount');
+        const [, storageResourceGroup] = nonNullValue(nonNullProp(storageAccount, 'id').match(/\/resourceGroups\/([^/]+)\//), 'Invalid storage account id');
+        const keysResult: StorageAccountListKeysResult = await storageClient.storageAccounts.listKeys(storageResourceGroup, nonNullProp(storageAccount, 'name'));
+
+        fileShareName = getNewFileShareName(nonNullProp(wizardContext, 'newSiteName'));
+
+        // https://github.com/Azure/azure-sdk-for-node/issues/4706
+        const endpointSuffix: string = wizardContext.environment.storageEndpointSuffix.replace(/^\./, '');
+
+        storageConnectionString = '';
+        if (keysResult.keys && keysResult.keys[0].value) {
+            storageConnectionString = `DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${keysResult.keys[0].value};EndpointSuffix=${endpointSuffix}`;
+        }
+
+        newSiteConfig.appSettings = await this.createSiteAppSettings(
+            {
+                storageConnectionString,
+                fileShareName,
+                os: nonNullProp(wizardContext, 'newSiteOS'),
+                runtime: wizardContext.newSiteRuntime,
+                // tslint:disable-next-line: strict-boolean-expressions
+                aiInstrumentationKey: wizardContext.appInsightsComponent && wizardContext.appInsightsComponent ? wizardContext.appInsightsComponent.instrumentationKey : undefined
+            });
+
+        return newSiteConfig;
+    }
+
+    private async createSiteAppSettings(context: IAppSettingsContext): Promise<WebSiteManagementModels.NameValuePair[]> {
+        const appSettings: WebSiteManagementModels.NameValuePair[] = [];
+
+        const cliFeedAppSettings: { [key: string]: string } = await cliFeedUtils.getAppSettings(version);
+        for (const key of Object.keys(cliFeedAppSettings)) {
+            appSettings.push({
+                name: key,
+                value: cliFeedAppSettings[key]
+            });
+        }
+
+        appSettings.push({
+            name: 'AzureWebJobsStorage',
+            value: context.storageConnectionString
+        });
+
+        // This setting only applies for v1 https://github.com/Microsoft/vscode-azurefunctions/issues/640
+        if (version === FuncVersion.v1) {
+            appSettings.push({
+                name: 'AzureWebJobsDashboard',
+                value: context.storageConnectionString
+            });
+        }
+
+        // These settings only apply for Windows https://github.com/Microsoft/vscode-azurefunctions/issues/625
+        if (context.os === 'windows') {
+            appSettings.push({
+                name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING',
+                value: context.storageConnectionString
+            });
+            appSettings.push({
+                name: 'WEBSITE_CONTENTSHARE',
+                value: context.fileShareName
+            });
+        }
+
+        if (context.runtime) {
+            appSettings.push({
+                name: workerRuntimeKey,
+                value: context.runtime
+            });
+        }
+
+        // This setting is not required, but we will set it since it has many benefits https://docs.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
+        // That being said, it doesn't work on v1 C# Script https://github.com/Microsoft/vscode-azurefunctions/issues/684
+        // It also doesn't apply for Linux Consumption, which has its own custom deploy logic in the the vscode-azureappservice package
+        if (context.os !== 'linux' && !(projectLanguage === ProjectLanguage.CSharpScript && version === FuncVersion.v1)) {
+            appSettings.push({
+                name: 'WEBSITE_RUN_FROM_PACKAGE',
+                value: '1'
+            });
+        }
+
+        if (context.aiInstrumentationKey) {
+            appSettings.push({
+                name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                value: context.aiInstrumentationKey
+            });
+        }
+
+        return appSettings;
+    }
+
+    private getFunctionAppLinuxFxVersion(runtime: string): string {
+        let middlePart: string;
+        switch (runtime) {
+            case 'node':
+                middlePart = 'node:2.0-node8';
+                break;
+            case 'python':
+                middlePart = 'python:2.0-python3.6';
+                break;
+            case 'dotnet':
+                middlePart = 'dotnet:2.0';
+                break;
+            default:
+                throw new RangeError(localize('unexpectedRuntime', 'Unexpected runtime "{0}".', runtime));
+        }
+
+        return `DOCKER|mcr.microsoft.com/azure-functions/${middlePart}-appservice`;
+    }
+}

--- a/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAppServiceWizardContext, WebsiteOS } from 'vscode-azureappservice';
+import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
+
+export class FunctionAppRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
+    public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
+        const runtimeItems: IAzureQuickPickItem<string>[] = [
+            { label: 'JavaScript', data: 'node' },
+            { label: '.NET', data: 'dotnet' }
+        ];
+
+        if (wizardContext.newSiteOS === WebsiteOS.linux) {
+            runtimeItems.push({ label: 'Python', data: 'python' });
+        } else {
+            runtimeItems.push({ label: 'Java', data: 'java' });
+            runtimeItems.push({ label: 'PowerShell', data: 'powershell' });
+        }
+
+        wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new app.' })).data;
+    }
+
+    public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {
+        return !wizardContext.newSiteRuntime;
+    }
+}

--- a/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
@@ -3,28 +3,56 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAppServiceWizardContext, WebsiteOS } from 'vscode-azureappservice';
+import { WebsiteOS } from 'vscode-azureappservice';
 import { AzureWizardPromptStep, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
+import { FuncVersion } from '../../FuncVersion';
+import { localize } from '../../localize';
+import { IFunctionAppWizardContext } from './IFunctionAppWizardContext';
 
-export class FunctionAppRuntimeStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
-    public async prompt(wizardContext: IAppServiceWizardContext): Promise<void> {
-        const runtimeItems: IAzureQuickPickItem<string>[] = [
-            { label: 'JavaScript', data: 'node' },
-            { label: '.NET', data: 'dotnet' }
-        ];
-
-        if (wizardContext.newSiteOS === WebsiteOS.linux) {
-            runtimeItems.push({ label: 'Python', data: 'python' });
-        } else {
-            runtimeItems.push({ label: 'Java', data: 'java' });
-            runtimeItems.push({ label: 'PowerShell', data: 'powershell' });
-        }
-
-        wizardContext.newSiteRuntime = (await ext.ui.showQuickPick(runtimeItems, { placeHolder: 'Select a runtime for your new app.' })).data;
+export class FunctionAppRuntimeStep extends AzureWizardPromptStep<IFunctionAppWizardContext> {
+    public async prompt(context: IFunctionAppWizardContext): Promise<void> {
+        const picks: IAzureQuickPickItem<string>[] = this.getPicks(context);
+        const placeHolder: string = localize('selectRuntime', 'Select a runtime');
+        context.newSiteRuntime = (await ext.ui.showQuickPick(picks, { placeHolder })).data;
     }
 
-    public shouldPrompt(wizardContext: IAppServiceWizardContext): boolean {
-        return !wizardContext.newSiteRuntime;
+    public shouldPrompt(context: IFunctionAppWizardContext): boolean {
+        if (context.newSiteRuntime) {
+            return false;
+        } else if (context.runtimeFilter) {
+            const picks: IAzureQuickPickItem<string>[] = this.getPicks(context);
+            if (picks.length === 1) {
+                // This needs to be set in `shouldPrompt` instead of `prompt`, otherwise the back button won't work
+                context.newSiteRuntime = picks[0].data;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private getPicks(context: IFunctionAppWizardContext): IAzureQuickPickItem<string>[] {
+        const picks: IAzureQuickPickItem<string>[] = [];
+
+        picks.push({ label: '.NET', data: 'dotnet' });
+
+        if (context.version === FuncVersion.v1) {
+            picks.unshift({ label: 'Node.js', data: 'node' });
+        } else {
+            picks.unshift({ label: 'Node.js 8', data: 'node|8' });
+            picks.unshift({ label: 'Node.js 10', data: 'node|10' });
+
+            if (context.newSiteOS === WebsiteOS.linux) {
+                picks.push({ label: 'Python 3.7', data: 'python|3.7' });
+                picks.push({ label: 'Python 3.6', data: 'python|3.6' });
+            } else {
+                picks.push({ label: 'Java', data: 'java' });
+                picks.push({ label: 'PowerShell', data: 'powershell' });
+            }
+        }
+
+        const runtimeFilter: string | undefined = context.runtimeFilter;
+        return runtimeFilter ? picks.filter(r => r.data.startsWith(runtimeFilter)) : picks;
     }
 }

--- a/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
+++ b/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAppServiceWizardContext } from 'vscode-azureappservice';
+import { FuncVersion } from '../../FuncVersion';
+
+export interface IFunctionAppWizardContext extends IAppServiceWizardContext {
+    version: FuncVersion;
+    language: string | undefined;
+    runtimeFilter?: string;
+}

--- a/src/commands/createFunctionApp/createFunctionApp.ts
+++ b/src/commands/createFunctionApp/createFunctionApp.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureParentTreeItem, IActionContext } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
-import { localize } from '../localize';
-import { ProductionSlotTreeItem } from '../tree/ProductionSlotTreeItem';
-import { ICreateFuntionAppContext, SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+import { ProductionSlotTreeItem } from '../../tree/ProductionSlotTreeItem';
+import { ICreateFuntionAppContext, SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 
 export async function createFunctionApp(context: IActionContext & Partial<ICreateFuntionAppContext>, subscription?: AzureParentTreeItem | string, newResourceGroupName?: string): Promise<string> {
     let node: AzureParentTreeItem | undefined;

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -23,7 +23,7 @@ import { configureDeploymentSource } from './configureDeploymentSource';
 import { copyFunctionUrl } from './copyFunctionUrl';
 import { createChildNode } from './createChildNode';
 import { createFunction } from './createFunction/createFunction';
-import { createFunctionApp, createFunctionAppAdvanced } from './createFunctionApp';
+import { createFunctionApp, createFunctionAppAdvanced } from './createFunctionApp/createFunctionApp';
 import { createNewProject } from './createNewProject/createNewProject';
 import { createSlot } from './createSlot';
 import { deleteNode } from './deleteNode';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,3 +88,4 @@ export const tsConfigFileName: string = 'tsconfig.json';
 export const localEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
 
 export const workerRuntimeKey: string = 'FUNCTIONS_WORKER_RUNTIME';
+export const extensionVersionKey: string = 'FUNCTIONS_EXTENSION_VERSION';

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -8,7 +8,6 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { AzureWizard, IActionContext, parseError } from "vscode-azureextensionui";
-import { getWorkspaceSetting } from "../../extension.bundle";
 import { AzureWebJobsStorageExecuteStep } from "../commands/appSettings/AzureWebJobsStorageExecuteStep";
 import { AzureWebJobsStoragePromptStep } from "../commands/appSettings/AzureWebJobsStoragePromptStep";
 import { IAzureWebJobsStorageWizardContext } from "../commands/appSettings/IAzureWebJobsStorageWizardContext";
@@ -22,7 +21,7 @@ import { localize } from '../localize';
 import { getFunctionFolders } from "../tree/localProject/LocalFunctionsTreeItem";
 import { supportsLocalProjectTree } from "../tree/localProject/supportsLocalProjectTree";
 import { getDebugConfigs, isDebugConfigEqual } from '../vsCodeConfig/launch';
-import { getFunctionsWorkerRuntime } from "../vsCodeConfig/settings";
+import { getFunctionsWorkerRuntime, getWorkspaceSetting } from "../vsCodeConfig/settings";
 
 export interface IPreDebugValidateResult {
     workspace: vscode.WorkspaceFolder;

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -74,7 +74,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
 
     public async createChildImpl(context: ICreateFuntionAppContext): Promise<AzureTreeItem> {
         const version: FuncVersion = await getDefaultFuncVersion(context);
+        context.telemetry.properties.projectRuntime = version;
         const language: string | undefined = getWorkspaceSettingFromAnyFolder(projectLanguageSetting);
+        context.telemetry.properties.projectLanguage = language;
 
         const wizardContext: IFunctionAppWizardContext = Object.assign(context, this.root, {
             newSiteKind: AppKind.functionapp,
@@ -175,8 +177,6 @@ async function getDefaultFuncVersion(context: IActionContext): Promise<FuncVersi
         version = latestGAVersion;
         context.telemetry.properties.runtimeSource = 'Backup';
     }
-
-    context.telemetry.properties.projectRuntime = version;
 
     return version;
 }

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -55,7 +55,7 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
     });
 
     // https://github.com/Microsoft/vscode-azurefunctions/blob/master/docs/api.md#create-function-app
-    test('Create - API ', async () => {
+    test('Create - API', async () => {
         const apiRgName: string = getRandomHexString();
         resourceGroupsToDelete.push(apiRgName);
         const apiAppName: string = getRandomHexString();

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -5,10 +5,11 @@
 
 import * as assert from 'assert';
 import { WebSiteManagementModels as Models } from 'azure-arm-website';
+import * as fse from 'fs-extra';
 import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as vscode from 'vscode';
 import { DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
-import { longRunningTestsEnabled, testUserInput } from '../global.test';
+import { longRunningTestsEnabled, testUserInput, testWorkspacePath } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
 import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
@@ -27,6 +28,9 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
         if (!longRunningTestsEnabled) {
             this.skip();
         }
+
+        // Ensure files/settings from previous tests don't affect this suite
+        await fse.emptyDir(testWorkspacePath);
 
         appName = getRandomHexString();
         app2Name = getRandomHexString();

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
 import { longRunningTestsEnabled, testUserInput } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
-import { getRotatingLocation } from './getRotatingValue';
+import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
 import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
 
 // tslint:disable-next-line: max-func-body-length
@@ -60,7 +60,7 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
         resourceGroupsToDelete.push(apiRgName);
         const apiAppName: string = getRandomHexString();
         await runWithFuncSetting('projectLanguage', ProjectLanguage.JavaScript, async () => {
-            await testUserInput.runWithInputs([apiAppName, getRotatingLocation()], async () => {
+            await testUserInput.runWithInputs([apiAppName, getRotatingNodeVersion(), getRotatingLocation()], async () => {
                 const actualFuncAppId: string = <string>await vscode.commands.executeCommand('azureFunctions.createFunctionApp', testAccount.getSubscriptionContext().subscriptionId, apiRgName);
                 const site: Models.Site = await testClient.webApps.get(apiRgName, apiAppName);
                 assert.ok(site);

--- a/test/nightly/getRotatingValue.ts
+++ b/test/nightly/getRotatingValue.ts
@@ -17,6 +17,20 @@ export function getRotatingLocation(): string {
     return locations[locationCount % locations.length];
 }
 
+let nodeVersionCount: number = getStartingIndex();
+const nodeVersions: RegExp[] = [/node.*8/i, /node.*10/i];
+export function getRotatingNodeVersion(): RegExp {
+    nodeVersionCount += 1;
+    return nodeVersions[nodeVersionCount % nodeVersions.length];
+}
+
+let pyVersionCount: number = getStartingIndex();
+const pyVersions: RegExp[] = [/python.*3\.6/i]; // 3.7 should work soon, but not quite yet
+export function getRotatingPythonVersion(): RegExp {
+    pyVersionCount += 1;
+    return pyVersions[pyVersionCount % pyVersions.length];
+}
+
 /**
  * Adds a little more spice to the rotation
  */


### PR DESCRIPTION
Functions will support Python 3.6, Python 3.7, Node 8, and Node 10. Here's how that changes our experience per discussions with Matt:
1. Prompt for runtime in basic create, but only show related runtimes and only if there's more than one version supported
1. Prompt for all runtimes in advanced create

I decided to move both the create and runtime step in to this repo, because I felt like there wasn't much shared code left in those files. I tried to split it up into two commits to make the diff better (one for copying code and one for editing the code), but I feel like it didn't help a whole lot 🤷‍♂️ Also - I'll handle fixing nightly tests in a separate PR.

Here's the nitty gritty on how to set the versions (For any runtime/plan combination not mentioned below, we don’t have to specify the version):
- Windows Consumption:
    - Node: Set WEBSITE_NODE_DEFAULT_VERSION to “~8” or “~10”
- Windows Dedicated: same as consumption
- Linux Consumption:
    - Node: Set linuxFxVersion to “node|8” or “node|10”
    - Python: Set linuxFxVersion to “python|3.6” or “python|3.7”
- Linux dedicated:
    - Node: Set linuxFxVersion to “DOCKER|mcr.microsoft.com/azure-functions/node:2.0-node8-appservice” or “DOCKER|mcr.microsoft.com/azure-functions/node:2.0-node10-appservice”
    - Python: Set linuxFxVersion to “DOCKER|mcr.microsoft.com/azure-functions/python:2.0-python3.6-appservice” or “DOCKER|mcr.microsoft.com/azure-functions/python:2.0-python3.7-appservice”
    - .NET: Set linuxFxVersion to “DOCKER|mcr.microsoft.com/azure-functions/dotnet:2.0-appservice”

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1497