### PR TITLE
Don't prompt for func version as often

### DIFF
--- a/src/FuncVersion.ts
+++ b/src/FuncVersion.ts
@@ -18,14 +18,13 @@ export enum FuncVersion {
 export const latestGAVersion: FuncVersion = FuncVersion.v2;
 
 export async function promptForFuncVersion(message?: string): Promise<FuncVersion> {
-    const picks: IAzureQuickPickItem<FuncVersion | undefined>[] = [];
+    let picks: IAzureQuickPickItem<FuncVersion | undefined>[] = [
+        { label: 'Azure Functions v2', description: '(.NET Core)', data: FuncVersion.v2 },
+        { label: 'Azure Functions v3 Preview', description: '(.NET Core)', data: FuncVersion.v3 },
+        { label: 'Azure Functions v1', description: '(.NET Framework)', data: FuncVersion.v1 }
+    ];
 
-    picks.push({ label: 'Azure Functions v2', description: '(.NET Core)', data: FuncVersion.v2 });
-    picks.push({ label: 'Azure Functions v3 Preview', description: '(.NET Core)', data: FuncVersion.v3 });
-
-    if (isWindows) {
-        picks.push({ label: 'Azure Functions v1', description: '(.NET Framework)', data: FuncVersion.v1 });
-    }
+    picks = picks.filter(p => osSupportsVersion(p.data));
 
     picks.push({ label: localize('learnMore', 'Learn more...'), description: '', data: undefined });
 
@@ -52,8 +51,16 @@ export function tryParseFuncVersion(data: string | undefined): FuncVersion | und
     return undefined;
 }
 
+export function getGAVersionsForOS(): FuncVersion[] {
+    return Object.values(FuncVersion).filter(v => !isPreviewVersion(v) && osSupportsVersion(v));
+}
+
 export function isPreviewVersion(version: FuncVersion): boolean {
     return version === FuncVersion.v3;
+}
+
+function osSupportsVersion(version: FuncVersion | undefined): boolean {
+    return version !== FuncVersion.v1 || isWindows;
 }
 
 export function getMajorVersion(data: string): string {

--- a/src/commands/deploy/runPreDeployTask.ts
+++ b/src/commands/deploy/runPreDeployTask.ts
@@ -17,7 +17,7 @@ export async function runPreDeployTask(context: IActionContext, deployFsPath: st
     const preDeployTask: string | undefined = getWorkspaceSetting(preDeployTaskSetting, deployFsPath);
     if (preDeployTask && preDeployTask.startsWith('func:')) {
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to run preDeployTask "{0}".', preDeployTask);
-        if (!await validateFuncCoreToolsInstalled(message)) {
+        if (!await validateFuncCoreToolsInstalled(message, deployFsPath)) {
             throw new UserCancelledError();
         }
     }

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -8,6 +8,7 @@ import { AzureWizardExecuteStep, AzureWizardPromptStep, IWizardOptions } from 'v
 import { ProjectLanguage } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { tryGetLocalFuncVersion } from '../../funcCoreTools/tryGetLocalFuncVersion';
+import { FuncVersion, getGAVersionsForOS } from '../../FuncVersion';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { FuncVersionStep } from '../createNewProject/FuncVersionStep';
@@ -96,5 +97,12 @@ export async function addInitVSCodeStep(context: IProjectWizardContext, executeS
 
     if (context.version === undefined) {
         context.version = await tryGetLocalFuncVersion();
+        if (context.version === undefined) {
+            // If only one GA version is supported on this OS, automatically use that
+            const gaVersions: FuncVersion[] = getGAVersionsForOS();
+            if (gaVersions.length === 1) {
+                context.version = gaVersions[0];
+            }
+        }
     }
 }

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -35,7 +35,8 @@ export async function preDebugValidate(context: IActionContext, debugConfig: vsc
 
     try {
         context.telemetry.properties.lastValidateStep = 'funcInstalled';
-        shouldContinue = await validateFuncCoreToolsInstalled();
+        const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to debug your local functions.');
+        shouldContinue = await validateFuncCoreToolsInstalled(message, workspace.uri.fsPath);
 
         if (shouldContinue) {
             context.telemetry.properties.lastValidateStep = 'getProjectRoot';

--- a/src/funcCoreTools/installFuncCoreTools.ts
+++ b/src/funcCoreTools/installFuncCoreTools.ts
@@ -11,8 +11,9 @@ import { cpUtils } from '../utils/cpUtils';
 import { getBrewPackageName } from './getBrewPackageName';
 import { getNpmDistTag, INpmDistTag } from './getNpmDistTag';
 
-export async function installFuncCoreTools(packageManagers: PackageManager[]): Promise<void> {
-    const version: FuncVersion = await promptForFuncVersion(localize('selectVersion', 'Select the version of the runtime to install'));
+export async function installFuncCoreTools(packageManagers: PackageManager[], version?: FuncVersion): Promise<void> {
+    // tslint:disable-next-line: strict-boolean-expressions
+    version = version || await promptForFuncVersion(localize('selectVersion', 'Select the version of the runtime to install'));
 
     ext.outputChannel.show();
     // Use the first package manager


### PR DESCRIPTION
Talked to Matt and there are a few cases where we don't want to prompt for func version:
1. If you're creating a project, we auto detect the version from the func cli installed on your machine. If you don't have the func cli installed, this PR changes to automatically use v2 on mac/linux instead of prompting for v2 vs. v3 preview (v1 is windows-only).
1. If you try to debug without the func cli installed, we prompt you to install. This PR changes to use the version already set in your project