### PR TITLE
Fix create c# v3 function

### DIFF
--- a/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
+++ b/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
@@ -30,8 +30,18 @@ export function getDotnetVerifiedTemplateIds(version: string): string[] {
         ]);
     }
 
+    let ids: string[] = convertToFullIds(verifiedTemplateIds, version);
+    if (version === FuncVersion.v3) {
+        // Also include v2 ids since v3 templates still use '2' in the id and it's not clear if/when that'll change
+        // https://github.com/microsoft/vscode-azurefunctions/issues/1602
+        ids = ids.concat(convertToFullIds(verifiedTemplateIds, FuncVersion.v2));
+    }
+    return ids;
+}
+
+function convertToFullIds(ids: string[], version: string): string[] {
     const majorVersion: string = getMajorVersion(version);
-    return verifiedTemplateIds.map((id: string) => {
+    return ids.map((id: string) => {
         return `Azure.Function.CSharp.${id}.${majorVersion}.x`;
     });
 }

--- a/src/templates/dotnet/parseDotnetTemplates.ts
+++ b/src/templates/dotnet/parseDotnetTemplates.ts
@@ -89,10 +89,6 @@ export async function parseDotnetTemplates(rawTemplates: object[], version: Func
         // Fall back to v2 templates since v3 templates still use '2' in the id and it's not clear if/when that'll change
         // https://github.com/microsoft/vscode-azurefunctions/issues/1602
         filteredTemplates = filterTemplatesByVersion(functionTemplates, FuncVersion.v2);
-        filteredTemplates = filteredTemplates.map(t => {
-            t.id = t.id.replace('2', '3');
-            return t;
-        });
     }
 
     await copyCSharpSettingsFromJS(filteredTemplates, version);


### PR DESCRIPTION
I can't actually change the id on the template object or it won't create. The only reason I did that was for the list of verified template ids, but I can change that logic anyways.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1636

See https://github.com/microsoft/vscode-azurefunctions/pull/1638 for tests to cover this