### PR TITLE
Better cleaning 🧹 of test workspace 

### DIFF
--- a/test/addBinding.test.ts
+++ b/test/addBinding.test.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { commands, Uri } from 'vscode';
 import { AzExtTreeItem } from 'vscode-azureextensionui';
 import { ext, getRandomHexString, IFunctionBinding, IFunctionJson, ProjectLanguage } from '../extension.bundle';
-import { createTestActionContext, testUserInput, testWorkspacePath } from './global.test';
+import { cleanTestWorkspace, createTestActionContext, testUserInput, testWorkspacePath } from './global.test';
 
 suite('Add Binding', async () => {
     let functionJsonPath: string;
@@ -17,7 +17,7 @@ suite('Add Binding', async () => {
     let initialBindingsCount: number;
 
     suiteSetup(async () => {
-        await fse.emptyDir(testWorkspacePath);
+        await cleanTestWorkspace();
         await testUserInput.runWithInputs([testWorkspacePath, ProjectLanguage.JavaScript, /http\s*trigger/i, functionName, 'Anonymous'], async () => {
             await commands.executeCommand('azureFunctions.createNewProject');
         });

--- a/test/nightly/createProjectAndDeploy.test.ts
+++ b/test/nightly/createProjectAndDeploy.test.ts
@@ -4,11 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as fse from 'fs-extra';
 import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as vscode from 'vscode';
 import { getRandomHexString, isWindows, ProjectLanguage, requestUtils } from '../../extension.bundle';
-import { longRunningTestsEnabled, testUserInput, testWorkspacePath } from '../global.test';
+import { cleanTestWorkspace, longRunningTestsEnabled, testUserInput, testWorkspacePath } from '../global.test';
 import { getCSharpValidateOptions, getJavaScriptValidateOptions, getPowerShellValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from '../validateProject';
 import { getRotatingAuthLevel, getRotatingLocation, getRotatingNodeVersion, getRotatingPythonVersion } from './getRotatingValue';
 import { resourceGroupsToDelete } from './global.nightly.test';
@@ -20,6 +19,14 @@ suite('Create Project and Deploy', async function (this: ISuiteCallbackContext):
         if (!longRunningTestsEnabled) {
             this.skip();
         }
+    });
+
+    suiteTeardown(async function (this: IHookCallbackContext): Promise<void> {
+        if (!longRunningTestsEnabled) {
+            this.skip();
+        }
+
+        await cleanTestWorkspace();
     });
 
     test('JavaScript', async () => {
@@ -51,7 +58,7 @@ suite('Create Project and Deploy', async function (this: ISuiteCallbackContext):
 
 async function testCreateProjectAndDeploy(validateProjectOptions: IValidateProjectOptions, projectLanguage: ProjectLanguage, createProjInputs: (RegExp | string)[] = [], deployInputs: (RegExp | string)[] = []): Promise<void> {
     const functionName: string = 'func' + getRandomHexString(); // function name must start with a letter
-    await fse.emptyDir(testWorkspacePath);
+    await cleanTestWorkspace();
 
     await testUserInput.runWithInputs([testWorkspacePath, projectLanguage, /http\s*trigger/i, functionName, ...createProjInputs, getRotatingAuthLevel()], async () => {
         await vscode.commands.executeCommand('azureFunctions.createNewProject');

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -5,11 +5,10 @@
 
 import * as assert from 'assert';
 import { WebSiteManagementModels as Models } from 'azure-arm-website';
-import * as fse from 'fs-extra';
 import { IHookCallbackContext, ISuiteCallbackContext } from 'mocha';
 import * as vscode from 'vscode';
 import { DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
-import { longRunningTestsEnabled, testUserInput, testWorkspacePath } from '../global.test';
+import { cleanTestWorkspace, longRunningTestsEnabled, testUserInput } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
 import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
@@ -30,7 +29,7 @@ suite('Function App Operations', async function (this: ISuiteCallbackContext): P
         }
 
         // Ensure files/settings from previous tests don't affect this suite
-        await fse.emptyDir(testWorkspacePath);
+        await cleanTestWorkspace();
 
         appName = getRandomHexString();
         app2Name = getRandomHexString();

--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { TestInput } from 'vscode-azureextensiondev';
 import { CentralTemplateProvider, FuncVersion, IFunctionTemplate, ProjectLanguage, TemplateFilter, TemplateSource } from '../extension.bundle';
-import { createTestActionContext, longRunningTestsEnabled, runForTemplateSource, testUserInput, testWorkspacePath } from './global.test';
+import { cleanTestWorkspace, createTestActionContext, longRunningTestsEnabled, runForTemplateSource, testUserInput, testWorkspacePath } from './global.test';
 
 addSuite(undefined);
 addSuite(TemplateSource.Latest);
@@ -61,7 +61,7 @@ async function javaPreTest(testContext: IHookCallbackContext): Promise<void> {
     // Java templates require you to have a project open, so create one here
     if (!await fse.pathExists(path.join(testWorkspacePath, 'pom.xml'))) { // No need to create for every template source
         const inputs: (string | TestInput | RegExp)[] = [testWorkspacePath, ProjectLanguage.Java, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, 'javaAppName'];
-        await fse.emptyDir(testWorkspacePath);
+        await cleanTestWorkspace();
         await testUserInput.runWithInputs(inputs, async () => {
             await vscode.commands.executeCommand('azureFunctions.createNewProject');
         });


### PR DESCRIPTION
One of the nightly tests was failing because projectLanguage still had a value from a previous test even though we had deleted `.vscode/settings.json`