### PR TITLE
Fix Node 10 on Linux Consumption

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -54,8 +54,13 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         if (context.newSiteOS === WebsiteOS.linux) {
             if (context.useConsumptionPlan) {
                 newSiteConfig.use32BitWorkerProcess = false; // Needs to be explicitly set to false per the platform team
-                if (isVersionedRuntime(context.newSiteRuntime)) {
-                    newSiteConfig.linuxFxVersion = context.newSiteRuntime;
+                if (context.newSiteRuntime && isVersionedRuntime(context.newSiteRuntime)) {
+                    // The platform currently requires a minor version to be specified, even though only the major version is respected for Node
+                    let linuxFxVersion: string = context.newSiteRuntime;
+                    if (!linuxFxVersion.includes('.')) {
+                        linuxFxVersion += '.0';
+                    }
+                    newSiteConfig.linuxFxVersion = linuxFxVersion;
                 }
             } else {
                 newSiteConfig.linuxFxVersion = this.getDockerLinuxFxVersion(context);
@@ -151,7 +156,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
 }
 
 const separator: string = '|';
-function isVersionedRuntime(runtime: string | undefined): boolean {
+function isVersionedRuntime(runtime: string): boolean {
     return !!runtime && runtime.includes(separator);
 }
 

--- a/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
@@ -40,12 +40,12 @@ export class FunctionAppRuntimeStep extends AzureWizardPromptStep<IFunctionAppWi
         if (context.version === FuncVersion.v1) {
             picks.unshift({ label: 'Node.js', data: 'node' });
         } else {
-            picks.unshift({ label: 'Node.js 8', data: 'node|8' });
-            picks.unshift({ label: 'Node.js 10', data: 'node|10' });
+            picks.unshift({ label: 'Node.js 8.x', data: 'node|8' });
+            picks.unshift({ label: 'Node.js 10.x', data: 'node|10' });
 
             if (context.newSiteOS === WebsiteOS.linux) {
-                picks.push({ label: 'Python 3.7', data: 'python|3.7' });
-                picks.push({ label: 'Python 3.6', data: 'python|3.6' });
+                picks.push({ label: 'Python 3.7.x', data: 'python|3.7' });
+                picks.push({ label: 'Python 3.6.x', data: 'python|3.6' });
             } else {
                 picks.push({ label: 'Java', data: 'java' });
                 picks.push({ label: 'PowerShell', data: 'powershell' });


### PR DESCRIPTION
Right now Linux Consumption is falling back to Node 8 when we specify "node|10" as linuxFxVersion. Per the platform team, we have to specify a minor version even thought it'll be ignored.

Also updated to the runtime labels in the quick pick