### PR TITLE
Prompt user to pick python version when creating a project 🐍

### DIFF
--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -11,7 +11,7 @@ import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { openUrl } from '../../utils/openUrl';
 import { FunctionListStep } from '../createFunction/FunctionListStep';
-import { addInitVSCodeStep } from '../initProjectForVSCode/InitVSCodeLanguageStep';
+import { addInitVSCodeSteps } from '../initProjectForVSCode/InitVSCodeLanguageStep';
 import { FuncVersionStep } from './FuncVersionStep';
 import { IProjectWizardContext } from './IProjectWizardContext';
 import { JavaAppNameStep } from './javaSteps/JavaAppNameStep';
@@ -23,9 +23,9 @@ import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreate
 import { JavaProjectCreateStep } from './ProjectCreateStep/JavaProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
 import { PowerShellProjectCreateStep } from './ProjectCreateStep/PowerShellProjectCreateStep';
-import { PythonProjectCreateStep } from './ProjectCreateStep/PythonProjectCreateStep';
 import { ScriptProjectCreateStep } from './ProjectCreateStep/ScriptProjectCreateStep';
 import { TypeScriptProjectCreateStep } from './ProjectCreateStep/TypeScriptProjectCreateStep';
+import { addPythonCreateProjectSteps } from './pythonSteps/addPythonCreateProjectSteps';
 
 export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizardContext> {
     public hideStepCount: boolean = true;
@@ -85,7 +85,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 executeSteps.push(await DotnetProjectCreateStep.createStep(context));
                 break;
             case ProjectLanguage.Python:
-                executeSteps.push(new PythonProjectCreateStep());
+                addPythonCreateProjectSteps(context, promptSteps, executeSteps);
                 break;
             case ProjectLanguage.PowerShell:
                 executeSteps.push(new PowerShellProjectCreateStep());
@@ -99,7 +99,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 break;
         }
 
-        await addInitVSCodeStep(context, executeSteps);
+        await addInitVSCodeSteps(context, promptSteps, executeSteps);
 
         const wizardOptions: IWizardOptions<IProjectWizardContext> = { promptSteps, executeSteps };
 

--- a/src/commands/createNewProject/ProjectCreateStep/ProjectCreateStepBase.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ProjectCreateStepBase.ts
@@ -12,7 +12,6 @@ import { IProjectWizardContext } from '../IProjectWizardContext';
 
 export abstract class ProjectCreateStepBase extends AzureWizardExecuteStep<IProjectWizardContext> {
     public priority: number = 10;
-    protected creatingMessage: string = localize('creating', 'Creating new project...');
 
     public abstract async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void>;
 
@@ -21,7 +20,7 @@ export abstract class ProjectCreateStepBase extends AzureWizardExecuteStep<IProj
         context.telemetry.properties.projectRuntime = context.version;
         context.telemetry.properties.openBehavior = context.openBehavior;
 
-        progress.report({ message: this.creatingMessage });
+        progress.report({ message: localize('creating', 'Creating new project...') });
         await fse.ensureDir(context.projectPath);
 
         await this.executeCore(context, progress);

--- a/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
+++ b/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, parseError } from "vscode-azureextensionui";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { IPythonVenvWizardContext } from "./IPythonVenvWizardContext";
+import { getPythonVersion, getSupportedPythonVersions, isSupportedPythonVersion } from './pythonVersion';
+
+export class EnterPythonAliasStep extends AzureWizardPromptStep<IPythonVenvWizardContext> {
+    public hideStepCount: boolean = true;
+
+    public async prompt(context: IPythonVenvWizardContext): Promise<void> {
+        const prompt: string = localize('pyAliasPlaceholder', 'Enter the Python alias or full path');
+        const supportedVersions: string[] = await getSupportedPythonVersions();
+        context.pythonAlias = await ext.ui.showInputBox({ prompt, validateInput: async (value: string): Promise<string | undefined> => await validatePythonAlias(supportedVersions, value) });
+    }
+
+    public shouldPrompt(context: IPythonVenvWizardContext): boolean {
+        return !!context.manuallyEnterAlias && !context.useExistingVenv && !context.pythonAlias;
+    }
+}
+
+async function validatePythonAlias(supportedVersions: string[], pyAlias: string): Promise<string | undefined> {
+    let pyVersion: string;
+    try {
+        pyVersion = await getPythonVersion(pyAlias);
+    } catch (error) {
+        return parseError(error).message;
+    }
+
+    if (isSupportedPythonVersion(supportedVersions, pyVersion)) {
+        return undefined;
+    } else {
+        const supportedVersionsString: string = supportedVersions.map(v => `"${v}.x"`).join(', ');
+        return localize('notMatchingVersion', 'Python version "{0}" does not match supported versions: {1}', pyVersion, supportedVersionsString);
+    }
+}

--- a/src/commands/createNewProject/pythonSteps/IPythonVenvWizardContext.ts
+++ b/src/commands/createNewProject/pythonSteps/IPythonVenvWizardContext.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from "vscode-azureextensionui";
+
+export interface IPythonVenvWizardContext extends IActionContext {
+    projectPath: string;
+    pythonAlias?: string;
+    manuallyEnterAlias?: boolean;
+    useExistingVenv?: boolean;
+    venvName?: string;
+    suppressSkipVenv?: boolean;
+}

--- a/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
+++ b/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from "vscode-azureextensionui";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { getGlobalSetting } from "../../../vsCodeConfig/settings";
+import { EnterPythonAliasStep } from "./EnterPythonAliasStep";
+import { IPythonVenvWizardContext } from "./IPythonVenvWizardContext";
+import { getPythonVersion, getSupportedPythonVersions, isSupportedPythonVersion } from './pythonVersion';
+
+export class PythonAliasListStep extends AzureWizardPromptStep<IPythonVenvWizardContext> {
+    public hideStepCount: boolean = true;
+
+    public async prompt(context: IPythonVenvWizardContext): Promise<void> {
+        const placeHolder: string = localize('selectAlias', 'Select a Python alias to create a virtual environment');
+        const result: string | boolean = (await ext.ui.showQuickPick(getPicks(context), { placeHolder })).data;
+        if (typeof result === 'string') {
+            context.pythonAlias = result;
+            context.telemetry.properties.pythonAliasBehavior = 'selectAlias';
+        } else {
+            context.manuallyEnterAlias = result;
+            context.telemetry.properties.pythonAliasBehavior = result ? 'enterAlias' : 'skipVenv';
+        }
+    }
+
+    public shouldPrompt(context: IPythonVenvWizardContext): boolean {
+        return !context.useExistingVenv && !context.pythonAlias;
+    }
+
+    public async getSubWizard(context: IPythonVenvWizardContext): Promise<IWizardOptions<IPythonVenvWizardContext> | undefined> {
+        if (context.manuallyEnterAlias) {
+            return {
+                promptSteps: [new EnterPythonAliasStep()]
+            };
+        } else {
+            return undefined;
+        }
+    }
+}
+
+async function getPicks(context: IPythonVenvWizardContext): Promise<IAzureQuickPickItem<string | boolean>[]> {
+    const supportedVersions: string[] = await getSupportedPythonVersions();
+
+    const aliasesToTry: string[] = ['python3', 'python', 'py'];
+    for (const version of supportedVersions) {
+        aliasesToTry.push(`python${version}`, `py -${version}`);
+    }
+
+    const globalPythonPathSetting: string | undefined = getGlobalSetting('pythonPath', 'python');
+    if (globalPythonPathSetting) {
+        aliasesToTry.unshift(globalPythonPathSetting);
+    }
+
+    const picks: IAzureQuickPickItem<string | boolean>[] = [];
+    const versions: string[] = [];
+    for (const alias of aliasesToTry) {
+        let version: string;
+        try {
+            version = await getPythonVersion(alias);
+        } catch {
+            continue;
+        }
+
+        if (isSupportedPythonVersion(supportedVersions, version) && !versions.some(v => v === version)) {
+            picks.push({
+                label: alias,
+                description: version,
+                data: alias
+            });
+            versions.push(version);
+        }
+    }
+
+    context.telemetry.properties.detectedPythonVersions = versions.join(',');
+
+    picks.push({ label: localize('enterAlias', '$(keyboard) Manually enter Python alias or full path'), data: true });
+
+    if (!context.suppressSkipVenv) {
+        picks.push({ label: localize('skipVenv', '$(circle-slash) Skip virtual environment'), data: false, suppressPersistence: true });
+    }
+
+    return picks;
+}

--- a/src/commands/createNewProject/pythonSteps/PythonVenvCreateStep.ts
+++ b/src/commands/createNewProject/pythonSteps/PythonVenvCreateStep.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { Progress } from 'vscode';
+import { AzureWizardExecuteStep } from 'vscode-azureextensionui';
+import { requirementsFileName } from '../../../constants';
+import { ext } from '../../../extensionVariables';
+import { localize } from "../../../localize";
+import { cpUtils } from "../../../utils/cpUtils";
+import { nonNullProp } from '../../../utils/nonNull';
+import { venvUtils } from '../../../utils/venvUtils';
+import { IPythonVenvWizardContext } from './IPythonVenvWizardContext';
+import { getPythonVersion } from './pythonVersion';
+
+export class PythonVenvCreateStep extends AzureWizardExecuteStep<IPythonVenvWizardContext> {
+    public priority: number = 12;
+
+    public async execute(context: IPythonVenvWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        progress.report({ message: localize('creatingVenv', 'Creating virtual environment...') });
+
+        const pythonAlias: string = nonNullProp(context, 'pythonAlias');
+        if (!context.venvName) {
+            context.venvName = '.venv';
+        }
+
+        // Don't wait just for telemetry and don't block on errors
+        // tslint:disable-next-line: no-floating-promises
+        getPythonVersion(pythonAlias).then(value => context.telemetry.properties.pythonVersion = value);
+
+        await cpUtils.executeCommand(ext.outputChannel, context.projectPath, pythonAlias, '-m', 'venv', context.venvName);
+
+        const requirementsPath: string = path.join(context.projectPath, requirementsFileName);
+        if (await fse.pathExists(requirementsPath)) {
+            try {
+                // Attempt to install packages so that users get Intellisense right away
+                await venvUtils.runCommandInVenv(`pip install -r ${requirementsFileName}`, context.venvName, context.projectPath);
+            } catch {
+                ext.outputChannel.appendLog(localize('pipInstallFailure', 'WARNING: Failed to install packages in your virtual environment. Run "pip install" manually instead.'));
+            }
+        }
+    }
+
+    public shouldExecute(context: IPythonVenvWizardContext): boolean {
+        return !context.useExistingVenv && !!context.pythonAlias;
+    }
+}

--- a/src/commands/createNewProject/pythonSteps/addPythonCreateProjectSteps.ts
+++ b/src/commands/createNewProject/pythonSteps/addPythonCreateProjectSteps.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardExecuteStep, AzureWizardPromptStep } from "vscode-azureextensionui";
+import { getWorkspaceSetting } from "../../../vsCodeConfig/settings";
+import { IProjectWizardContext } from '../IProjectWizardContext';
+import { PythonProjectCreateStep } from "../ProjectCreateStep/PythonProjectCreateStep";
+import { IPythonVenvWizardContext } from "./IPythonVenvWizardContext";
+import { PythonAliasListStep } from "./PythonAliasListStep";
+import { PythonVenvCreateStep } from "./PythonVenvCreateStep";
+
+export function addPythonCreateProjectSteps(
+    context: IProjectWizardContext & IPythonVenvWizardContext,
+    promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
+    executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): void {
+
+    const createPythonVenv: boolean = !!getWorkspaceSetting<boolean>('createPythonVenv', context.workspacePath);
+    context.telemetry.properties.createPythonVenv = String(createPythonVenv);
+
+    if (createPythonVenv) {
+        promptSteps.push(new PythonAliasListStep());
+        executeSteps.push(new PythonVenvCreateStep());
+    }
+
+    executeSteps.push(new PythonProjectCreateStep());
+}

--- a/src/commands/createNewProject/pythonSteps/pythonVersion.ts
+++ b/src/commands/createNewProject/pythonSteps/pythonVersion.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as semver from 'semver';
+import { ext } from '../../../extensionVariables';
+import { getLocalFuncCoreToolsVersion } from '../../../funcCoreTools/getLocalFuncCoreToolsVersion';
+import { localize } from "../../../localize";
+import { cpUtils } from "../../../utils/cpUtils";
+
+export async function getPythonVersion(pyAlias: string): Promise<string> {
+    const result: cpUtils.ICommandResult = await cpUtils.tryExecuteCommand(undefined /*don't display output*/, undefined /*default to cwd*/, `${pyAlias} --version`);
+    if (result.code !== 0) {
+        throw new Error(localize('failValidate', 'Failed to validate version: {0}', result.cmdOutputIncludingStderr));
+    }
+
+    const matches: RegExpMatchArray | null = result.cmdOutputIncludingStderr.match(/^Python (\S*)/i);
+    if (matches === null || !matches[1]) {
+        throw new Error(localize('failedParse', 'Failed to parse version: {0}', result.cmdOutputIncludingStderr));
+    } else {
+        return matches[1];
+    }
+}
+
+export async function getSupportedPythonVersions(): Promise<string[]> {
+    const versions: string[] = ['3.6'];
+
+    const minFuncVersion: string = '2.7.1846';
+    try {
+        const currentVersion: string | null = await getLocalFuncCoreToolsVersion();
+        if (currentVersion && semver.lt(currentVersion, minFuncVersion)) {
+            ext.outputChannel.appendLine(localize('outOfDateWarning', 'WARNING: Some Python versions are not supported with version "{0}" of the func CLI. Update to at least "{1}".', currentVersion, minFuncVersion));
+            return versions;
+        }
+    } catch {
+        // ignore
+    }
+
+    versions.push('3.7');
+    return versions;
+}
+
+export function isSupportedPythonVersion(supportedVersions: string[], version: string): boolean {
+    return !!supportedVersions.some(v => semver.satisfies(version, v));
+}

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -18,9 +18,9 @@ import { DotnetScriptInitVSCodeStep } from './InitVSCodeStep/DotnetScriptInitVSC
 import { JavaInitVSCodeStep } from './InitVSCodeStep/JavaInitVSCodeStep';
 import { JavaScriptInitVSCodeStep } from './InitVSCodeStep/JavaScriptInitVSCodeStep';
 import { PowerShellInitVSCodeStep } from './InitVSCodeStep/PowerShellInitVSCodeStep';
-import { PythonInitVSCodeStep } from './InitVSCodeStep/PythonInitVSCodeStep';
 import { ScriptInitVSCodeStep } from './InitVSCodeStep/ScriptInitVSCodeStep';
 import { TypeScriptInitVSCodeStep } from './InitVSCodeStep/TypeScriptInitVSCodeStep';
+import { addPythonInitVSCodeSteps } from './pythonSteps/addPythonInitVSCodeSteps';
 
 export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizardContext> {
     public hideStepCount: boolean = true;
@@ -56,7 +56,7 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
         const executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[] = [];
         const promptSteps: AzureWizardPromptStep<IProjectWizardContext>[] = [];
 
-        await addInitVSCodeStep(context, executeSteps);
+        await addInitVSCodeSteps(context, promptSteps, executeSteps);
         if (language !== ProjectLanguage.CSharp && language !== ProjectLanguage.FSharp) { // version will be detected from proj file
             promptSteps.push(new FuncVersionStep());
         }
@@ -65,7 +65,11 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
     }
 }
 
-export async function addInitVSCodeStep(context: IProjectWizardContext, executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
+export async function addInitVSCodeSteps(
+    context: IProjectWizardContext,
+    promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
+    executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
+
     switch (context.language) {
         case ProjectLanguage.JavaScript:
             executeSteps.push(new JavaScriptInitVSCodeStep());
@@ -78,7 +82,7 @@ export async function addInitVSCodeStep(context: IProjectWizardContext, executeS
             executeSteps.push(new DotnetInitVSCodeStep());
             break;
         case ProjectLanguage.Python:
-            executeSteps.push(new PythonInitVSCodeStep());
+            await addPythonInitVSCodeSteps(context, promptSteps, executeSteps);
             break;
         case ProjectLanguage.PowerShell:
             executeSteps.push(new PowerShellInitVSCodeStep());

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
@@ -12,18 +12,18 @@ import { pythonDebugConfig } from '../../../debug/PythonDebugProvider';
 import { ext } from '../../../extensionVariables';
 import { venvUtils } from '../../../utils/venvUtils';
 import { IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
-import { getExistingVenv } from '../../createNewProject/ProjectCreateStep/PythonProjectCreateStep';
+import { IPythonVenvWizardContext } from '../../createNewProject/pythonSteps/IPythonVenvWizardContext';
 import { ScriptInitVSCodeStep } from './ScriptInitVSCodeStep';
 
 export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
     private _venvName: string | undefined;
 
-    protected async executeCore(context: IProjectWizardContext): Promise<void> {
+    protected async executeCore(context: IProjectWizardContext & IPythonVenvWizardContext): Promise<void> {
         await super.executeCore(context);
 
         this.settings.push({ key: 'scmDoBuildDuringDeployment', value: true });
 
-        this._venvName = await getExistingVenv(context.projectPath);
+        this._venvName = context.venvName;
         if (this._venvName) {
             this.settings.push({ key: pythonVenvSetting, value: this._venvName });
             await ensureVenvInFuncIgnore(context.projectPath, this._venvName);

--- a/src/commands/initProjectForVSCode/pythonSteps/PythonVenvListStep.ts
+++ b/src/commands/initProjectForVSCode/pythonSteps/PythonVenvListStep.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardPromptStep, IAzureQuickPickItem } from "vscode-azureextensionui";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { IPythonVenvWizardContext } from "../../createNewProject/pythonSteps/IPythonVenvWizardContext";
+
+export class PythonVenvListStep extends AzureWizardPromptStep<IPythonVenvWizardContext> {
+    public hideStepCount: boolean = true;
+
+    private readonly _venvs: string[];
+
+    public constructor(venvs: string[]) {
+        super();
+        this._venvs = venvs;
+    }
+
+    public async prompt(context: IPythonVenvWizardContext): Promise<void> {
+        const picks: IAzureQuickPickItem<string>[] = this._venvs.map(venv => { return { label: venv, data: venv }; });
+        const placeHolder: string = localize('selectVenv', 'Select a virtual environment to use for your project');
+        context.venvName = (await ext.ui.showQuickPick(picks, { placeHolder, suppressPersistence: true })).data;
+    }
+
+    public shouldPrompt(context: IPythonVenvWizardContext): boolean {
+        return !!context.useExistingVenv && !context.venvName;
+    }
+}

--- a/src/commands/initProjectForVSCode/pythonSteps/addPythonInitVSCodeSteps.ts
+++ b/src/commands/initProjectForVSCode/pythonSteps/addPythonInitVSCodeSteps.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import { AzureWizardExecuteStep, AzureWizardPromptStep } from "vscode-azureextensionui";
+import { venvUtils } from '../../../utils/venvUtils';
+import { IProjectWizardContext } from "../../createNewProject/IProjectWizardContext";
+import { IPythonVenvWizardContext } from "../../createNewProject/pythonSteps/IPythonVenvWizardContext";
+import { PythonInitVSCodeStep } from "../InitVSCodeStep/PythonInitVSCodeStep";
+import { PythonVenvListStep } from "./PythonVenvListStep";
+
+export async function addPythonInitVSCodeSteps(
+    context: IProjectWizardContext & IPythonVenvWizardContext,
+    promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
+    executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
+
+    const venvs: string[] = [];
+
+    if (await fse.pathExists(context.projectPath)) {
+        const fsPaths: string[] = await fse.readdir(context.projectPath);
+        await Promise.all(fsPaths.map(async venvName => {
+            if (await venvUtils.venvExists(venvName, context.projectPath)) {
+                venvs.push(venvName);
+            }
+        }));
+    }
+
+    if (venvs.length > 0) {
+        context.useExistingVenv = true;
+        if (venvs.length === 1) {
+            context.venvName = venvs[0];
+        } else {
+            promptSteps.push(new PythonVenvListStep(venvs));
+        }
+    }
+
+    executeSteps.push(new PythonInitVSCodeStep());
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const launchFileName: string = 'launch.json';
 export const settingsFileName: string = 'settings.json';
 export const vscodeFolderName: string = '.vscode';
 export const gitignoreFileName: string = '.gitignore';
+export const requirementsFileName: string = 'requirements.txt';
 
 export enum PackageManager {
     npm = 'npm',

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -30,7 +30,8 @@ suite('Create New Project', async () => {
 
         testCases.push({
             ...getPythonValidateOptions('.venv', version),
-            timeout: 2 * 60 * 1000
+            timeout: 2 * 60 * 1000,
+            inputs: [/3\.6/]
         });
 
         const appName: string = 'javaApp';

--- a/test/project/createNewPythonProject.test.ts
+++ b/test/project/createNewPythonProject.test.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import { IHookCallbackContext } from 'mocha';
 import * as path from 'path';
-import { FuncVersion, getRandomHexString, isWindows, Platform } from '../../extension.bundle';
+import { FuncVersion, getRandomHexString } from '../../extension.bundle';
 import { longRunningTestsEnabled, testFolderPath } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { createAndValidateProject } from './createAndValidateProject';
@@ -23,7 +23,7 @@ suite('Create New Python Project', async () => {
         }
         this.timeout(2 * 60 * 1000);
 
-        const alias: string = isWindows ? 'py -3.6' : 'python3.6';
+        const alias: string = process.platform === 'win32' ? 'py -3.6' : 'python3.6';
         await createAndValidateProject({ ...getPythonValidateOptions('.venv', FuncVersion.v2), inputs: [/enter/i, alias] });
     });
 
@@ -50,7 +50,7 @@ suite('Create New Python Project', async () => {
 });
 
 async function createTestVenv(projectPath: string, venvName: string): Promise<void> {
-    if (process.platform === Platform.Windows) {
+    if (process.platform === 'win32') {
         await fse.ensureFile(path.join(projectPath, venvName, 'Scripts', 'activate'));
     } else {
         await fse.ensureFile(path.join(projectPath, venvName, 'bin', 'activate'));

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -45,10 +45,21 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
         return process.platform === 'win32' ? [venvName, 'Scripts', 'activate'] : [venvName, 'bin', 'activate'];
     }
 
-    test('Python', async () => {
+    test('Python no venv', async () => {
+        const mockFiles: MockFile[] = [['HttpTrigger', '__init__.py'], 'requirements.txt'];
+        await initAndValidateProject({ ...getPythonValidateOptions(undefined), mockFiles });
+    });
+
+    test('Python single venv', async () => {
         const venvName: string = 'testEnv';
         const mockFiles: MockFile[] = [['HttpTrigger', '__init__.py'], 'requirements.txt', getMockVenvPath(venvName)];
         await initAndValidateProject({ ...getPythonValidateOptions(venvName), mockFiles });
+    });
+
+    test('Python multiple venvs', async () => {
+        const venvName: string = 'world';
+        const mockFiles: MockFile[] = [['HttpTrigger', '__init__.py'], 'requirements.txt', getMockVenvPath('hello'), getMockVenvPath(venvName)];
+        await initAndValidateProject({ ...getPythonValidateOptions(venvName), mockFiles, inputs: [venvName] });
     });
 
     test('F#', async () => {


### PR DESCRIPTION
The current experience will default to Python 3.6 if we find it on the machine and otherwise prompt the user to enter the python path. Instead, we will check for any supported version and prompt something like this:
![Screen Shot 2019-11-07 at 4 01 17 PM](https://user-images.githubusercontent.com/11282622/68498354-7fc90e00-020b-11ea-9994-9aa580080935.png)

This will show every time users create a python project, which is kind of annoying from a "number of prompts" standpoint. To mitigate this, I moved the logic into wizard prompt steps (instead of `PythonProjectCreateStep`, an execute step) which means users get proper support for things like the back button. On the plus side, these prompts make it more obvious what python version is being used and how to skip creating a venv.

Validation if they try to manually enter a path:
![Screen Shot 2019-11-07 at 4 16 10 PM](https://user-images.githubusercontent.com/11282622/68498442-ac7d2580-020b-11ea-8f96-94f4cc7f090a.png)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1658