### PR TITLE
Allow local emulator on mac/linux

### DIFF
--- a/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
+++ b/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
@@ -24,11 +24,7 @@ export class AzureWebJobsStoragePromptStep<T extends IAzureWebJobsStorageWizardC
 
         const message: string = localize('selectAzureWebJobsStorage', 'In order to debug, you must select a storage account for internal use by the Azure Functions runtime.');
 
-        const buttons: MessageItem[] = [selectAccount];
-        if (process.platform === 'win32') {
-            // Only show on Windows until this is fixed: https://github.com/Microsoft/vscode-azurefunctions/issues/1245
-            buttons.push(useEmulator);
-        }
+        const buttons: MessageItem[] = [selectAccount, useEmulator];
         if (!this._suppressSkipForNow) {
             buttons.push(skipForNow);
         }


### PR DESCRIPTION
Azurite supports leases now, so debugging works for me. Also they even have a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Azurite.azurite)!

Related to https://github.com/microsoft/vscode-azurefunctions/issues/1245