### PR TITLE
Fix CONTENT* setting logic for linux premium

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8666,9 +8666,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.52.0.tgz",
-            "integrity": "sha512-Wa9hCIhcf/Ddio18ZShs8zj/Fk4p7ITPPsHRZCBah4nR5OkC+c7S7keAJKOAFxFr5F7sglksJB4Ixio4XTUiSQ==",
+            "version": "0.52.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.52.1.tgz",
+            "integrity": "sha512-bdgcYqicQb8CAy5hxKN816yg5+9aQa2U00r80/3MbIYFI1uFOuMHvggR2MNbojZV0Wd2ZhmRC2x+LpsGgTdZ1g==",
             "requires": {
                 "archiver": "^3.0.0",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1029,7 +1029,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.4",
         "semver": "^5.7.1",
-        "vscode-azureappservice": "^0.52.0",
+        "vscode-azureappservice": "^0.52.1",
         "vscode-azureextensionui": "^0.28.4",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1",

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -144,8 +144,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
         let result: boolean | undefined = this._cachedIsConsumption;
         if (result === undefined) {
             try {
-                const asp: WebSiteManagementModels.AppServicePlan | undefined = await this.root.client.getAppServicePlan();
-                result = !asp || !asp.sku || !asp.sku.tier || asp.sku.tier.toLowerCase() === 'dynamic';
+                result = await this.root.client.getIsConsumption();
             } catch {
                 // ignore and use default
                 result = true;


### PR DESCRIPTION
Linux premium apps should have the CONTENT* app settings

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1682

Depends on https://github.com/microsoft/vscode-azuretools/pull/630