### PR TITLE
Slow the boat 🚢 on Azurite

### DIFF
--- a/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
+++ b/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
@@ -24,7 +24,11 @@ export class AzureWebJobsStoragePromptStep<T extends IAzureWebJobsStorageWizardC
 
         const message: string = localize('selectAzureWebJobsStorage', 'In order to debug, you must select a storage account for internal use by the Azure Functions runtime.');
 
-        const buttons: MessageItem[] = [selectAccount, useEmulator];
+        const buttons: MessageItem[] = [selectAccount];
+        if (process.platform === 'win32') {
+            // Only show on Windows until this is fixed: https://github.com/Microsoft/vscode-azurefunctions/issues/1245
+            buttons.push(useEmulator);
+        }
         if (!this._suppressSkipForNow) {
             buttons.push(skipForNow);
         }

--- a/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
+++ b/src/commands/appSettings/AzureWebJobsStoragePromptStep.ts
@@ -26,7 +26,7 @@ export class AzureWebJobsStoragePromptStep<T extends IAzureWebJobsStorageWizardC
 
         const buttons: MessageItem[] = [selectAccount];
         if (process.platform === 'win32') {
-            // Only show on Windows until this is fixed: https://github.com/Microsoft/vscode-azurefunctions/issues/1245
+            // Only show on Windows until Azurite is officially supported: https://github.com/Azure/azure-functions-core-tools/issues/1247
             buttons.push(useEmulator);
         }
         if (!this._suppressSkipForNow) {


### PR DESCRIPTION
Looks like I jumped the gun in terms of displaying the emulator as an option on mac/linux. https://github.com/microsoft/vscode-azurefunctions/issues/1245 was fixed, but there may be more issues. We should wait until the func cli officially says they support it, as tracked in https://github.com/Azure/azure-functions-core-tools/issues/1247