### PR TITLE
Add @types/node to dev deps in package.json for TS projects

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -21,7 +21,8 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
 
     protected packageJsonDevDeps: { [key: string]: string } = {
         '@azure/functions': '^1.0.2-beta2',
-        typescript: '^3.3.3'
+        typescript: '^3.3.3',
+        '@types/node': '^12.12.15'
     };
 
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {


### PR DESCRIPTION
If the user picks TypeScript, there is a 99% chance they are going to want at least the Node types as well. For instance, they can't use `process` without throwing an error if they don't have the types. I think it's safe to assume they need it and include by default.