### PR TITLE
Handle lack of internet connection or if the www.powershellgallery.com is down when creating a PowerShell function app

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -8,6 +8,7 @@ import * as retry from 'p-retry';
 import * as path from 'path';
 import { Progress } from 'vscode';
 import * as xml2js from 'xml2js';
+import { localize } from '../../../localize';
 import { confirmOverwriteFile } from "../../../utils/fs";
 import { requestUtils } from '../../../utils/requestUtils';
 import { IProjectWizardContext } from '../IProjectWizardContext';
@@ -75,11 +76,11 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         const majorVersion: number | undefined = await this.getLatestAzModuleMajorVersion(progress);
         if (majorVersion !== undefined) {
             progress.report({
-                message: `Successfully retrieved ${this.azModuleName} information from PowerShell Gallery"`
+                message: localize('successfullyConnected', 'Successfully retrieved {0} information from PowerShell Gallery', this.azModuleName)
             });
         } else {
             progress.report({
-                message: `Failed to get ${this.azModuleName} module version. Edit the requirements.psd1 file when the powershellgallery.com is accessible.`
+                message: localize('failedToConnect', 'Failed to get {0} module version. Edit the requirements.psd1 file when the powershellgallery.com is accessible.', this.azModuleName)
             });
         }
 
@@ -95,7 +96,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
 
     private async getLatestAzModuleMajorVersion(progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<number | undefined> {
         progress.report({
-            message: 'Connecting to PowerShell Gallery...'
+            message: localize('connecting', 'Connecting to PowerShell Gallery...')
         });
 
         const xmlResult: string | undefined = await this.getPSGalleryAzModuleInfo();

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -67,8 +67,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         }
 
         const requirementspsd1Path: string = path.join(context.projectPath, requirementspsd1FileName);
-        const isOnline: boolean = await confirmOverwriteFile(requirementspsd1Path);
-        if (isOnline) {
+        if (await confirmOverwriteFile(requirementspsd1Path)) {
             if (await this.isPowerShellGallaryAccessible()) {
                 await fse.writeFile(requirementspsd1Path, requirementspsd1);
             } else {

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -51,8 +51,7 @@ const requirementspsd1Offine: string = `# This file enables modules to be automa
 # See https://aka.ms/functionsmanageddependency for additional information.
 #
 @{
-    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'.
-    # Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '3.*'
+    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'. Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '3.*'
     # 'Az' = 'MAJOR_VERSION.*'
 }`;
 


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-azurefunctions/issues/1379

cc: @Francisco-Gamino @eamonoreilly

After this change, when a PowerShell function app is created, we connect to the www.powershellgallery.com (PSGallery) to retrieve the latest available module version for the Azure Az module. 

Here is what the file content looks like:
```
# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in public preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'.
    'Az' = '3.*'
}

```
If we could not connect to the PSGallery, or if the user does not have internet connection, we still create the file as an empty hashtable--leaving the Az module version commented out. In addition to this, we provide instructions for the user to get the Az major version once he or she has internet connectivity or the PSGallery is back up. 

Here is what the file content looks like for this case:
```
# This file enables modules to be automatically managed by the Functions service.
# Only the Azure Az module is supported in public preview.
# See https://aka.ms/functionsmanageddependency for additional information.
#
@{
    # For latest supported version, go to 'https://www.powershellgallery.com/packages/Az'. Uncomment the next line and replace the MAJOR_VERSION, e.g., 'Az' = '3.*'
    # 'Az' = 'MAJOR_VERSION.*'
}
```