### PR TITLE
Show fewer warnings about templates

### DIFF
--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -147,10 +147,6 @@ export class CentralTemplateProvider {
                 bindingTemplates: result.bindingTemplates.filter(b => provider.includeTemplate(b))
             };
         } else if (latestErrorMessage) {
-            if (!context.errorHandling.suppressDisplay) {
-                // Show output so that users see cache/backup errors as well
-                ext.outputChannel.show();
-            }
             throw new Error(latestErrorMessage);
         } else {
             // This should only happen for dev/test scenarios where we explicitly set templateSource

--- a/src/templates/script/ScriptBundleTemplateProvider.ts
+++ b/src/templates/script/ScriptBundleTemplateProvider.ts
@@ -7,7 +7,6 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { hostFileName } from '../../constants';
-import { ext } from '../../extensionVariables';
 import { IBundleMetadata, parseHostJson } from '../../funcConfig/host';
 import { localize } from '../../localize';
 import { bundleFeedUtils } from '../../utils/bundleFeedUtils';
@@ -68,10 +67,13 @@ export class ScriptBundleTemplateProvider extends ScriptTemplateProvider {
     private async getBundleInfo(): Promise<IBundleMetadata | undefined> {
         let data: unknown;
         if (this.projectPath) {
-            try {
-                data = await fse.readJSON(path.join(this.projectPath, hostFileName));
-            } catch (error) {
-                ext.outputChannel.appendLine(localize('failedToParseHostJson', 'WARNING: Function templates may not reflect your extension bundle. Failed to parse host.json: "{0}"', parseError(error).message));
+            const hostJsonPath: string = path.join(this.projectPath, hostFileName);
+            if (await fse.pathExists(hostJsonPath)) {
+                try {
+                    data = await fse.readJSON(hostJsonPath);
+                } catch (error) {
+                    throw new Error(localize('failedToParseHostJson', 'Failed to parse host.json: "{0}"', parseError(error).message));
+                }
             }
         }
 


### PR DESCRIPTION
When creating a new project, users will almost always get this printed in the output:
![Screen Shot 2020-01-13 at 4 01 16 PM](https://user-images.githubusercontent.com/11282622/72302176-ff18fa80-361d-11ea-93c6-a725cb576abe.png)
I changed it so that we don't print that if the file doesn't exist (which it won't for new projects).

I also changed it to be an error instead of a warning if the file _does_ exist (aka for existing projects). This shouldn't happen very often and the error makes it pretty clear how to fix the problem, so I think it makes sense if it's in their face:
![Screen Shot 2020-01-13 at 3 58 29 PM](https://user-images.githubusercontent.com/11282622/72302273-54550c00-361e-11ea-9f5e-44bc7b23a030.png)