### PR TITLE
Use new pattern for brew package name

### DIFF
--- a/src/funcCoreTools/getBrewPackageName.ts
+++ b/src/funcCoreTools/getBrewPackageName.ts
@@ -4,18 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { funcPackageName } from '../constants';
-import { FuncVersion, getMajorVersion, isPreviewVersion } from '../FuncVersion';
+import { FuncVersion, getMajorVersion } from '../FuncVersion';
 
 export function getBrewPackageName(version: FuncVersion): string {
-    let result: string = funcPackageName;
-    if (version !== FuncVersion.v2) { // v2 was the original version supported for brew and doesn't have the version in the name
-        const majorVersion: string = getMajorVersion(version);
-        result += '-v' + majorVersion;
-    }
-
-    if (isPreviewVersion(version)) {
-        result += '-preview';
-    }
-
-    return result;
+    return `${funcPackageName}@${getMajorVersion(version)}`;
 }


### PR DESCRIPTION
Old:
- v2: `azure-functions-core-tools`
- v3: `azure-functions-core-tools-v3-preview`

New:
- v2: `azure-functions-core-tools@2`
- v3: `azure-functions-core-tools@3`

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1738