### PR TITLE
Simplify validation of language/version when deploying

### DIFF
--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -9,8 +9,6 @@ import { feedUtils } from './feedUtils';
 
 export namespace cliFeedUtils {
     const funcCliFeedUrl: string = 'https://aka.ms/V00v5v';
-    const v1DefaultNodeVersion: string = '6.5.0';
-    const defaultNodeVersion: string = '~10';
 
     interface ICliFeed {
         tags: {
@@ -25,8 +23,6 @@ export namespace cliFeedUtils {
         templateApiZip: string;
         itemTemplates: string;
         projectTemplates: string;
-        FUNCTIONS_EXTENSION_VERSION: string;
-        nodeVersion: string;
     }
 
     interface ITag {
@@ -52,30 +48,6 @@ export namespace cliFeedUtils {
     export async function getRelease(templateVersion: string): Promise<IRelease> {
         const cliFeed: ICliFeed = await getCliFeed();
         return cliFeed.releases[templateVersion];
-    }
-
-    /**
-     * Returns the app settings that should be used when creating or deploying to a Function App, based on version
-     */
-    export async function getAppSettings(version: FuncVersion): Promise<{ [key: string]: string }> {
-        let funcVersion: string;
-        let nodeVersion: string;
-
-        try {
-            const cliFeed: ICliFeed = await getCliFeed();
-            const release: string = await getLatestVersion(version);
-            funcVersion = cliFeed.releases[release].FUNCTIONS_EXTENSION_VERSION;
-            nodeVersion = cliFeed.releases[release].nodeVersion;
-        } catch {
-            // ignore and use defaults
-            funcVersion = version;
-            nodeVersion = version === FuncVersion.v1 ? v1DefaultNodeVersion : defaultNodeVersion;
-        }
-
-        return {
-            FUNCTIONS_EXTENSION_VERSION: funcVersion,
-            WEBSITE_NODE_DEFAULT_VERSION: nodeVersion
-        };
     }
 
     async function getCliFeed(): Promise<ICliFeed> {

--- a/test/assertThrowsAsync.ts
+++ b/test/assertThrowsAsync.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+
+/**
+ * Same as assert.throws except for async functions
+ */
+export async function assertThrowsAsync<T>(block: () => Promise<T>, error: RegExp | Function, message?: string): Promise<void> {
+    // tslint:disable-next-line:typedef
+    let blockSync = (): void => { /* ignore */ };
+    try {
+        await block();
+    } catch (e) {
+        blockSync = (): void => { throw e; };
+    } finally {
+        assert.throws(blockSync, error, message);
+    }
+}

--- a/test/verifyVersionAndLanguage.test.ts
+++ b/test/verifyVersionAndLanguage.test.ts
@@ -5,27 +5,27 @@
 
 import { FuncVersion, ProjectLanguage, verifyVersionAndLanguage } from '../extension.bundle';
 import { assertThrowsAsync } from './assertThrowsAsync';
-import { testUserInput } from './global.test';
+import { createTestActionContext, testUserInput } from './global.test';
 
 // tslint:disable-next-line: max-func-body-length
 suite('verifyVersionAndLanguage', () => {
     test('Local: ~1, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~1', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: 1.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~2', async () => {
@@ -33,7 +33,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
         await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -42,27 +42,27 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
         await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
     test('Local: ~2, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~2', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: 2.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~1', async () => {
@@ -70,7 +70,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
         await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -79,7 +79,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
         await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -88,7 +88,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'node'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2/node, Remote: ~2/dotnet', async () => {
@@ -96,7 +96,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await assertThrowsAsync(async () => await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/node, Remote: ~1/dotnet', async () => {
@@ -104,7 +104,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~1',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await assertThrowsAsync(async () => await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/unknown, Remote: ~2/dotnet', async () => {
@@ -112,6 +112,6 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await verifyVersionAndLanguage('testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
     });
 });

--- a/test/verifyVersionAndLanguage.test.ts
+++ b/test/verifyVersionAndLanguage.test.ts
@@ -3,106 +3,84 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as assert from 'assert';
 import { FuncVersion, ProjectLanguage, verifyVersionAndLanguage } from '../extension.bundle';
+import { assertThrowsAsync } from './assertThrowsAsync';
 import { testUserInput } from './global.test';
 
 // tslint:disable-next-line: max-func-body-length
 suite('verifyVersionAndLanguage', () => {
     test('Local: ~1, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage(FuncVersion.v1, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {});
+        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~1', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
-        await verifyVersionAndLanguage(FuncVersion.v1, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '~1'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: 1.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
-        await verifyVersionAndLanguage(FuncVersion.v1, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '1.0.0'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~2', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~1');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION); // Verify this exists, but don't actually verify the value since I don't want to update the test every time the default node version changes
     });
 
     test('Local: ~1, Remote: 2.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage('testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~1');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION);
     });
 
     test('Local: ~2, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {});
+        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~2', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
-        await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '~2'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: 2.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
-        await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '2.0.0'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~1', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~2');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION);
     });
 
     test('Local: ~2, Remote: 1.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~2');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION);
     });
 
     test('Local: ~2/node, Remote: ~2/node', async () => {
@@ -110,11 +88,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'node'
         };
-        await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '~2',
-            FUNCTIONS_WORKER_RUNTIME: 'node'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2/node, Remote: ~2/dotnet', async () => {
@@ -122,12 +96,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~2');
-        assert.equal(props.FUNCTIONS_WORKER_RUNTIME, 'node');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/node, Remote: ~1/dotnet', async () => {
@@ -135,12 +104,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~1',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await testUserInput.runWithInputs(['Update remote settings'], async () => {
-            await verifyVersionAndLanguage(FuncVersion.v2, ProjectLanguage.JavaScript, props);
-        });
-        assert.equal(props.FUNCTIONS_EXTENSION_VERSION, '~2');
-        assert.equal(props.FUNCTIONS_WORKER_RUNTIME, 'node');
-        assert.ok(props.WEBSITE_NODE_DEFAULT_VERSION);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage('testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/unknown, Remote: ~2/dotnet', async () => {
@@ -148,10 +112,6 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await verifyVersionAndLanguage(FuncVersion.v2, <ProjectLanguage>"unknown", props);
-        assert.deepEqual(props, {
-            FUNCTIONS_EXTENSION_VERSION: '~2',
-            FUNCTIONS_WORKER_RUNTIME: 'dotnet'
-        });
+        await verifyVersionAndLanguage('testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
     });
 });


### PR DESCRIPTION
In the past, we would validate the local language/version with the remote langauge/version when deploying and gave the user the option to update remote app settings. That gets complicated really quickly and we'd honestly prefer users just created a brand new app with the right settings. So instead we will do this:
1. If the versions don't match, warn the user and give them the option to "Deploy Anyway". Many apps will "just work" if there's a mismatch between v2 and v3
![Screen Shot 2020-01-17 at 1 25 30 PM](https://user-images.githubusercontent.com/11282622/72647602-c040b880-392d-11ea-9df1-e373fed11dee.png)

1. If the languages don't match, throw an error. We think this is an unlikely scenario anyways (most people only use one language), and there's no point in "Deploy Anyway" because it won't work
![Screen Shot 2020-01-17 at 1 31 50 PM](https://user-images.githubusercontent.com/11282622/72647608-c46cd600-392d-11ea-83bf-c8d84b081156.png)


Fixes #1662