### PR TITLE
Use vscode.env.shell when picking python venv stuff

### DIFF
--- a/src/utils/venvUtils.ts
+++ b/src/utils/venvUtils.ts
@@ -18,11 +18,11 @@ export namespace venvUtils {
         powerShell
     }
 
-    export function convertToVenvCommand(command: string, folderPath: string, platform: NodeJS.Platform = process.platform): string {
-        const terminal: Terminal = getTerminal(platform);
+    export function convertToVenvCommand(command: string, folderPath: string): string {
+        const terminal: Terminal = getTerminal(process.platform);
         const venvName: string | undefined = getWorkspaceSetting<string>(pythonVenvSetting, folderPath);
         if (venvName) {
-            return joinCommands(terminal, getVenvActivateCommand(venvName, terminal, platform), command);
+            return joinCommands(terminal, getVenvActivateCommand(venvName, terminal, process.platform), command);
         } else {
             return command;
         }

--- a/src/utils/venvUtils.ts
+++ b/src/utils/venvUtils.ts
@@ -5,7 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import * as vscode from 'vscode';
 import { pythonVenvSetting } from "../constants";
 import { ext } from '../extensionVariables';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
@@ -57,12 +57,9 @@ export namespace venvUtils {
 
     function getTerminal(platform: NodeJS.Platform): Terminal {
         if (platform === 'win32') {
-            const config: WorkspaceConfiguration = workspace.getConfiguration();
-            const terminalSetting: string | undefined = config.get('terminal.integrated.shell.windows');
-            if (!terminalSetting || /(powershell|pwsh)/i.test(terminalSetting)) {
-                // powershell is the default if setting isn't defined
+            if (/(powershell|pwsh)/i.test(vscode.env.shell)) {
                 return Terminal.powerShell;
-            } else if (/bash/i.test(terminalSetting)) {
+            } else if (/bash/i.test(vscode.env.shell)) {
                 return Terminal.bash;
             } else {
                 return Terminal.cmd;

--- a/test/venvUtils.test.ts
+++ b/test/venvUtils.test.ts
@@ -11,9 +11,10 @@ import { cpUtils, ext, getGlobalSetting, pythonVenvSetting, updateGlobalSetting,
 import { longRunningTestsEnabled, testFolderPath } from './global.test';
 import { runWithSetting } from './runWithSetting';
 
+// tslint:disable-next-line: max-func-body-length
 suite('venvUtils', () => {
     const command: string = 'do a thing';
-    const terminalSetting: string = 'terminal.integrated.shell.windows';
+    const windowsTerminalSetting: string = 'terminal.integrated.shell.windows';
     const venvName: string = '.venv';
     const testFolder: string = path.join(testFolderPath, 'venvUtils');
     let oldVenvValue: string | undefined;
@@ -62,48 +63,69 @@ suite('venvUtils', () => {
         await venvUtils.runCommandInVenv('python --version', venvName, testFolder);
     });
 
-    test('convertToVenvCommand Windows powershell', async () => {
-        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe', async () => {
-            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'win32'), '.venv\\Scripts\\activate ; do a thing');
+    test('convertToVenvCommand Windows powershell', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+        await runWithSetting(windowsTerminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '.venv\\Scripts\\activate ; do a thing');
             assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'win32'), '.venv\\Scripts\\python -m do a thing');
         });
     });
 
-    test('convertToVenvCommand Windows pwsh', async () => {
-        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\pwsh.exe', async () => {
-            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'win32'), '.venv\\Scripts\\activate ; do a thing');
+    test('convertToVenvCommand Windows pwsh', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+        await runWithSetting(windowsTerminalSetting, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\pwsh.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '.venv\\Scripts\\activate ; do a thing');
             assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'win32'), '.venv\\Scripts\\python -m do a thing');
         });
     });
 
-    test('convertToVenvCommand Windows cmd', async () => {
-        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\cmd.exe', async () => {
-            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'win32'), '.venv\\Scripts\\activate && do a thing');
+    test('convertToVenvCommand Windows cmd', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+        await runWithSetting(windowsTerminalSetting, 'C:\\Windows\\System32\\cmd.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '.venv\\Scripts\\activate && do a thing');
             assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'win32'), '.venv\\Scripts\\python -m do a thing');
         });
     });
 
-    test('convertToVenvCommand Windows git bash', async () => {
-        await runWithSetting(terminalSetting, 'C:\\Program Files\\Git\\bin\\bash.exe', async () => {
-            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'win32'), '. .venv/Scripts/activate && do a thing');
+    test('convertToVenvCommand Windows git bash', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+        await runWithSetting(windowsTerminalSetting, 'C:\\Program Files\\Git\\bin\\bash.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '. .venv/Scripts/activate && do a thing');
             assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'win32'), '.venv/Scripts/python -m do a thing');
         });
     });
 
-    test('convertToVenvCommand Windows bash', async () => {
-        await runWithSetting(terminalSetting, 'C:\\Windows\\System32\\bash.exe', async () => {
-            assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'win32'), '. .venv/Scripts/activate && do a thing');
+    test('convertToVenvCommand Windows bash', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'win32') {
+            this.skip();
+        }
+        await runWithSetting(windowsTerminalSetting, 'C:\\Windows\\System32\\bash.exe', async () => {
+            assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '. .venv/Scripts/activate && do a thing');
             assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'win32'), '.venv/Scripts/python -m do a thing');
         });
     });
 
-    test('convertToVenvCommand Mac', async () => {
-        assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'darwin'), '. .venv/bin/activate && do a thing');
+    test('convertToVenvCommand Mac', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'darwin') {
+            this.skip();
+        }
+        assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '. .venv/bin/activate && do a thing');
         assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'darwin'), '.venv/bin/python -m do a thing');
     });
 
-    test('convertToVenvCommand Linux', async () => {
-        assert.equal(venvUtils.convertToVenvCommand(command, testFolder, 'linux'), '. .venv/bin/activate && do a thing');
+    test('convertToVenvCommand Linux', async function (this: ITestCallbackContext): Promise<void> {
+        if (process.platform !== 'linux') {
+            this.skip();
+        }
+        assert.equal(venvUtils.convertToVenvCommand(command, testFolder), '. .venv/bin/activate && do a thing');
         assert.equal(venvUtils.convertToVenvPythonCommand(command, venvName, 'linux'), '.venv/bin/python -m do a thing');
     });
 });


### PR DESCRIPTION
Should be more robust than checking the settings directly

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1505