### PR TITLE
Fix handling of old brew package tags

### DIFF
--- a/src/funcCoreTools/getBrewPackageName.ts
+++ b/src/funcCoreTools/getBrewPackageName.ts
@@ -5,7 +5,37 @@
 
 import { funcPackageName } from '../constants';
 import { FuncVersion, getMajorVersion } from '../FuncVersion';
+import { cpUtils } from '../utils/cpUtils';
 
 export function getBrewPackageName(version: FuncVersion): string {
     return `${funcPackageName}@${getMajorVersion(version)}`;
+}
+
+export async function tryGetInstalledBrewPackageName(version: FuncVersion): Promise<string | undefined> {
+    const brewPackageName: string = getBrewPackageName(version);
+    if (await isBrewPackageInstalled(brewPackageName)) {
+        return brewPackageName;
+    } else {
+        let oldPackageName: string | undefined;
+        if (version === FuncVersion.v2) {
+            oldPackageName = funcPackageName;
+        } else if (version === FuncVersion.v3) {
+            oldPackageName = funcPackageName + '-v3-preview';
+        }
+
+        if (oldPackageName && await isBrewPackageInstalled(oldPackageName)) {
+            return oldPackageName;
+        } else {
+            return undefined;
+        }
+    }
+}
+
+async function isBrewPackageInstalled(packageName: string): Promise<boolean> {
+    try {
+        await cpUtils.executeCommand(undefined, undefined, 'brew', 'ls', packageName);
+        return true;
+    } catch (error) {
+        return false;
+    }
 }

--- a/src/funcCoreTools/getFuncPackageManagers.ts
+++ b/src/funcCoreTools/getFuncPackageManagers.ts
@@ -6,7 +6,7 @@
 import { funcPackageName, PackageManager } from '../constants';
 import { FuncVersion } from '../FuncVersion';
 import { cpUtils } from '../utils/cpUtils';
-import { getBrewPackageName } from './getBrewPackageName';
+import { tryGetInstalledBrewPackageName } from './getBrewPackageName';
 
 export async function getFuncPackageManagers(isFuncInstalled: boolean): Promise<PackageManager[]> {
     const result: PackageManager[] = [];
@@ -35,14 +35,18 @@ export async function getFuncPackageManagers(isFuncInstalled: boolean): Promise<
 async function hasBrew(isFuncInstalled: boolean): Promise<boolean> {
     for (const version of Object.values(FuncVersion)) {
         if (version !== FuncVersion.v1) {
-            const brewPackageName: string = getBrewPackageName(version);
-            try {
-                isFuncInstalled ?
-                    await cpUtils.executeCommand(undefined, undefined, 'brew', 'ls', brewPackageName) :
+            if (isFuncInstalled) {
+                const packageName: string | undefined = await tryGetInstalledBrewPackageName(version);
+                if (packageName) {
+                    return true;
+                }
+            } else {
+                try {
                     await cpUtils.executeCommand(undefined, undefined, 'brew', '--version');
-                return true;
-            } catch (error) {
-                // an error indicates no brew
+                    return true;
+                } catch (error) {
+                    // an error indicates no brew
+                }
             }
         }
     }

--- a/src/funcCoreTools/uninstallFuncCoreTools.ts
+++ b/src/funcCoreTools/uninstallFuncCoreTools.ts
@@ -10,7 +10,7 @@ import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { cpUtils } from '../utils/cpUtils';
 import { nonNullValue } from '../utils/nonNull';
-import { getBrewPackageName } from './getBrewPackageName';
+import { tryGetInstalledBrewPackageName } from './getBrewPackageName';
 import { getFuncPackageManagers } from './getFuncPackageManagers';
 import { tryGetLocalFuncVersion } from './tryGetLocalFuncVersion';
 
@@ -35,7 +35,7 @@ export async function uninstallFuncCoreTools(_context: IActionContext, packageMa
             break;
         case PackageManager.brew:
             const version: FuncVersion = nonNullValue(await tryGetLocalFuncVersion(), 'localFuncVersion');
-            const brewPackageName: string = getBrewPackageName(version);
+            const brewPackageName: string = nonNullValue(await tryGetInstalledBrewPackageName(version), 'brewPackageName');
             await cpUtils.executeCommand(ext.outputChannel, undefined, 'brew', 'uninstall', brewPackageName);
             break;
         default:

--- a/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -38,6 +38,7 @@ export async function validateFuncCoreToolsIsLatest(): Promise<void> {
                 return;
             } else if (packageManagers.length === 1) {
                 packageManager = packageManagers[0];
+                context.telemetry.properties.packageManager = packageManager;
             } else {
                 context.telemetry.properties.multiFunc = 'true';
                 if (showMultiCoreToolsWarning) {


### PR DESCRIPTION
So I already moved `getBrewPackageName` to the new pattern (which always uses `@<major version>`). However, here are a few scenarios that are messed up because of this:
1. If you have old tag (i.e. "azure-functions-core-tools-v3-preview") installed, and run our command to uninstall the func cli it will fail because it tries to uninstall new tag (i.e. "azure-functions-core-tools@3") which doesn't exist on the machine
1. If you have old tag installed and cli team pushes an update, you will never be prompted to "Update to the latest version for the best experience" because it's looking for new tag only

The main fix is just to check the old tags in addition to the new tags. However, I also decided to have the "update" case uninstall the old tag (which will probably be deprecated soon? idk) and install the new tag.