### PR TITLE
Enable logs for new function apps

### DIFF
--- a/src/commands/logstream/enableFileLogging.ts
+++ b/src/commands/logstream/enableFileLogging.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WebSiteManagementModels } from 'azure-arm-website';
+import { SiteClient } from 'vscode-azureappservice';
+
+export async function enableFileLogging(client: SiteClient, logsConfig?: WebSiteManagementModels.SiteLogsConfig): Promise<void> {
+    // tslint:disable-next-line: strict-boolean-expressions
+    logsConfig = logsConfig || await client.getLogsConfig();
+
+    // tslint:disable-next-line:strict-boolean-expressions
+    logsConfig.applicationLogs = logsConfig.applicationLogs || {};
+    // tslint:disable-next-line:strict-boolean-expressions
+    logsConfig.applicationLogs.fileSystem = logsConfig.applicationLogs.fileSystem || {};
+    logsConfig.applicationLogs.fileSystem.level = 'Information';
+    // Azure will throw errors if these have incomplete information (aka missing a sasUrl). Since we already know these are turned off, just make them undefined
+    logsConfig.applicationLogs.azureBlobStorage = undefined;
+    logsConfig.applicationLogs.azureTableStorage = undefined;
+    await client.updateLogsConfig(logsConfig);
+}

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -14,6 +14,7 @@ import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionT
 import { SlotTreeItemBase } from '../../tree/SlotTreeItemBase';
 import { nonNullProp } from '../../utils/nonNull';
 import { openUrl } from '../../utils/openUrl';
+import { enableFileLogging } from './enableFileLogging';
 
 export async function startStreamingLogs(context: IActionContext, treeItem?: SlotTreeItemBase | RemoteFunctionTreeItem): Promise<void> {
     if (!treeItem) {
@@ -37,15 +38,7 @@ export async function startStreamingLogs(context: IActionContext, treeItem?: Slo
             if (!isApplicationLoggingEnabled(logsConfig)) {
                 const message: string = localize('enableApplicationLogging', 'Do you want to enable application logging for "{0}"?', client.fullName);
                 await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.cancel);
-                // tslint:disable-next-line:strict-boolean-expressions
-                logsConfig.applicationLogs = logsConfig.applicationLogs || {};
-                // tslint:disable-next-line:strict-boolean-expressions
-                logsConfig.applicationLogs.fileSystem = logsConfig.applicationLogs.fileSystem || {};
-                logsConfig.applicationLogs.fileSystem.level = 'Information';
-                // Azure will throw errors if these have incomplete information (aka missing a sasUrl). Since we already know these are turned off, just make them undefined
-                logsConfig.applicationLogs.azureBlobStorage = undefined;
-                logsConfig.applicationLogs.azureTableStorage = undefined;
-                await client.updateLogsConfig(logsConfig);
+                await enableFileLogging(client, logsConfig);
             }
         };
 


### PR DESCRIPTION
Matt asked for this in app service (https://github.com/microsoft/vscode-azureappservice/issues/1287) and I figure it makes sense here, too

Per [these docs](https://docs.microsoft.com/azure/app-service/troubleshoot-diagnostic-logs):
> The Filesystem option is for temporary debugging purposes, and turns itself off in 12 hours.