### PR TITLE
Use "func: extensions install" if extensions.csproj exists

### DIFF
--- a/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
@@ -40,7 +40,7 @@ export class JavaScriptInitVSCodeStep extends ScriptInitVSCodeStep {
                     command: hostStartCommand,
                     problemMatcher: funcWatchProblemMatcher,
                     isBackground: true,
-                    dependsOn: this.requiresFuncExtensionsInstall ? [extInstallTaskName, npmInstallTaskLabel] : npmInstallTaskLabel
+                    dependsOn: this.useFuncExtensionsInstall ? [extInstallTaskName, npmInstallTaskLabel] : npmInstallTaskLabel
                 },
                 {
                     type: 'shell',
@@ -51,7 +51,7 @@ export class JavaScriptInitVSCodeStep extends ScriptInitVSCodeStep {
                     type: 'shell',
                     label: npmPruneTaskLabel,
                     command: 'npm prune --production', // This removes dev dependencies, but importantly also installs prod dependencies
-                    dependsOn: this.requiresFuncExtensionsInstall ? extInstallTaskName : undefined,
+                    dependsOn: this.useFuncExtensionsInstall ? extInstallTaskName : undefined,
                     problemMatcher: []
                 }
             ];

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep.ts
@@ -42,7 +42,7 @@ export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
 
     protected getTasks(): TaskDefinition[] {
         const pipInstallLabel: string = 'pipInstall';
-        const dependsOn: string | undefined = this.requiresFuncExtensionsInstall ? extInstallTaskName : this._venvName ? pipInstallLabel : undefined;
+        const dependsOn: string | undefined = this.useFuncExtensionsInstall ? extInstallTaskName : this._venvName ? pipInstallLabel : undefined;
         const tasks: TaskDefinition[] = [
             {
                 type: func,
@@ -54,7 +54,7 @@ export class PythonInitVSCodeStep extends ScriptInitVSCodeStep {
         ];
 
         if (this._venvName) {
-            if (this.requiresFuncExtensionsInstall) {
+            if (this.useFuncExtensionsInstall) {
                 tasks.push({
                     type: func,
                     command: extInstallCommand,

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
@@ -36,6 +36,7 @@ export class ScriptInitVSCodeStep extends InitVSCodeStepBase {
             const extensionsCsprojPath: string = path.join(context.projectPath, 'extensions.csproj');
             if (await fse.pathExists(extensionsCsprojPath)) {
                 this.useFuncExtensionsInstall = true;
+                context.telemetry.properties.hasExtensionsCsproj = 'true';
             } else if (context.version === FuncVersion.v2) { // no need to check v1 or v3+
                 const currentVersion: string | null = await getLocalFuncCoreToolsVersion();
                 // Starting after this version, projects can use extension bundle instead of running "func extensions install"

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/TypeScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/TypeScriptInitVSCodeStep.ts
@@ -27,7 +27,7 @@ export class TypeScriptInitVSCodeStep extends JavaScriptInitVSCodeStep {
                 type: 'shell',
                 label: npmBuildTaskLabel,
                 command: 'npm run build',
-                dependsOn: this.requiresFuncExtensionsInstall ? [extInstallTaskName, npmInstallTaskLabel] : npmInstallTaskLabel,
+                dependsOn: this.useFuncExtensionsInstall ? [extInstallTaskName, npmInstallTaskLabel] : npmInstallTaskLabel,
                 problemMatcher: '$tsc'
             },
             {

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -24,11 +24,19 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
     });
 
     test('JavaScript with extensions.csproj', async () => {
-        await initAndValidateProject({ ...getJavaScriptValidateOptions(), mockFiles: [['HttpTriggerJs', 'index.js'], 'extensions.csproj'] });
+        const options: IValidateProjectOptions = getJavaScriptValidateOptions(true /* hasPackageJson */);
+        options.expectedSettings['files.exclude'] = { obj: true, bin: true };
+        await initAndValidateProject({ ...options, mockFiles: [['HttpTriggerJs', 'index.js'], 'package.json'] });
     });
 
     test('TypeScript', async () => {
         await initAndValidateProject({ ...getTypeScriptValidateOptions(), mockFiles: [['HttpTrigger', 'index.ts'], 'tsconfig.json', 'package.json'] });
+    });
+
+    test('TypeScript with extensions.csproj', async () => {
+        const options: IValidateProjectOptions = getTypeScriptValidateOptions();
+        options.expectedSettings['files.exclude'] = { obj: true, bin: true };
+        await initAndValidateProject({ ...options, mockFiles: [['HttpTrigger', 'index.ts'], 'tsconfig.json', 'package.json', 'extensions.csproj'] });
     });
 
     test('C#', async () => {
@@ -62,6 +70,16 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
         await initAndValidateProject({ ...getPythonValidateOptions(venvName), mockFiles, inputs: [venvName] });
     });
 
+    test('Python with extensions.csproj', async () => {
+        const venvName: string = 'testEnv';
+        const options: IValidateProjectOptions = getPythonValidateOptions(venvName);
+        options.expectedTasks.push('extensions install');
+        options.expectedSettings['files.exclude'] = { obj: true, bin: true };
+        options.expectedSettings['azureFunctions.preDeployTask'] = 'func: extensions install';
+        const mockFiles: MockFile[] = [['HttpTrigger', '__init__.py'], 'requirements.txt', getMockVenvPath(venvName), 'extensions.csproj'];
+        await initAndValidateProject({ ...options, mockFiles });
+    });
+
     test('F#', async () => {
         const mockFiles: MockFile[] = [{ fsPath: 'test.fsproj', contents: '<TargetFramework>netstandard2.0<\/TargetFramework><AzureFunctionsVersion>v2</AzureFunctionsVersion>' }];
         await initAndValidateProject({ ...getFSharpValidateOptions('test', 'netstandard2.0'), mockFiles });
@@ -85,6 +103,13 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
 
     test('PowerShell', async () => {
         await initAndValidateProject({ ...getPowerShellValidateOptions(), mockFiles: [['HttpTriggerPS', 'run.ps1'], 'profile.ps1', 'requirements.psd1'] });
+    });
+
+    test('PowerShell with extensions.csproj', async () => {
+        const options: IValidateProjectOptions = getPowerShellValidateOptions();
+        options.expectedSettings['files.exclude'] = { obj: true, bin: true };
+        options.expectedSettings['azureFunctions.preDeployTask'] = 'func: extensions install';
+        await initAndValidateProject({ ...options, mockFiles: [['HttpTriggerPS', 'run.ps1'], 'profile.ps1', 'requirements.psd1', 'extensions.csproj'] });
     });
 
     test('Multi-language', async () => {

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -26,7 +26,7 @@ suite('Init Project For VS Code', async function (this: ISuiteCallbackContext): 
     test('JavaScript with extensions.csproj', async () => {
         const options: IValidateProjectOptions = getJavaScriptValidateOptions(true /* hasPackageJson */);
         options.expectedSettings['files.exclude'] = { obj: true, bin: true };
-        await initAndValidateProject({ ...options, mockFiles: [['HttpTriggerJs', 'index.js'], 'package.json'] });
+        await initAndValidateProject({ ...options, mockFiles: [['HttpTriggerJs', 'index.js'], 'package.json', 'extensions.csproj'] });
     });
 
     test('TypeScript', async () => {

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -287,7 +287,7 @@ const commonExpectedPaths: string[] = [
 export interface IValidateProjectOptions {
     language: ProjectLanguage;
     version: FuncVersion;
-    expectedSettings: { [key: string]: string | boolean | undefined };
+    expectedSettings: { [key: string]: string | boolean | object | undefined };
     expectedPaths: string[];
     expectedExtensionRecs: string[];
     expectedDebugConfigs: string[];
@@ -327,11 +327,11 @@ export async function validateProject(projectPath: string, options: IValidatePro
     const settings: { [key: string]: string | boolean } = <{ [key: string]: string }>await fse.readJSON(path.join(projectPath, '.vscode', 'settings.json'));
     const keys: string[] = Object.keys(options.expectedSettings);
     for (const key of keys) {
-        const value: string | boolean | undefined = options.expectedSettings[key];
+        const value: string | boolean | object | undefined = options.expectedSettings[key];
         if (key === 'debug.internalConsoleOptions' && isPathEqual(testWorkspacePath, projectPath)) {
             // skip validating - it will be set in 'test.code-workspace' file instead of '.vscode/settings.json'
         } else {
-            assert.equal(settings[key], value, `The setting with key "${key}" is not set to value "${value}".`);
+            assert.deepStrictEqual(settings[key], value, `The setting with key "${key}" is not set to value "${value}".`);
         }
         delete settings[key];
     }


### PR DESCRIPTION
When initializing for using for use with VS Code, previously we would add "func: extensions install" logic only if the user's func cli version didn't support bundles. However, there are still cases where people might not want to use bundles and could use "extensions.csproj" instead - now we will respect that file.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/1698