### PR TITLE
Add situation-specific error messages for command palette

### DIFF
--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -8,6 +8,7 @@ import { AzureWizard, IActionContext } from "vscode-azureextensionui";
 import { ProjectLanguage } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { FuncVersion } from "../../FuncVersion";
+import { localize } from "../../localize";
 import { LocalFunctionTreeItem } from "../../tree/localProject/LocalFunctionTreeItem";
 import { nonNullValue } from "../../utils/nonNull";
 import { getContainingWorkspace } from "../../utils/workspace";
@@ -29,7 +30,8 @@ export async function addBinding(context: IActionContext, data: Uri | LocalFunct
         projectPath = await tryGetFunctionProjectRoot(workspacePath) || workspacePath;
     } else {
         if (!data) {
-            data = await ext.tree.showTreeItemPicker<LocalFunctionTreeItem>(/Local;ReadWrite;Function;/i, context);
+            const noItemFoundErrorMessage: string = localize('noLocalProject', 'No matching functions found. C# and Java projects do not support this operation.');
+            data = await ext.tree.showTreeItemPicker<LocalFunctionTreeItem>(/Local;ReadWrite;Function;/i, { ...context, noItemFoundErrorMessage });
         }
 
         functionJsonPath = data.functionJsonPath;

--- a/src/commands/copyFunctionUrl.ts
+++ b/src/commands/copyFunctionUrl.ts
@@ -11,7 +11,8 @@ import { FunctionTreeItemBase } from '../tree/FunctionTreeItemBase';
 
 export async function copyFunctionUrl(context: IActionContext, node?: FunctionTreeItemBase): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;Http;/i, context);
+        const noItemFoundErrorMessage: string = localize('noHTTPFunctions', 'No HTTP functions found.');
+        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;Http;/i, { ...context, noItemFoundErrorMessage });
     }
 
     if (node.triggerUrl) {

--- a/src/commands/deleteFunction.ts
+++ b/src/commands/deleteFunction.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtTreeItem, IActionContext, ITreeItemPickerContext } from 'vscode-azureextensionui';
+import { localize } from '../localize';
+import { deleteNode } from './deleteNode';
+
+export async function deleteFunction(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
+    (<ITreeItemPickerContext>context).noItemFoundErrorMessage = localize('noFuntionsToDelete', 'No matching functions found or your function app is read-only.');
+    await deleteNode(context, /Remote;ReadWrite;Function;/i, node);
+}

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -14,7 +14,8 @@ import { requestUtils } from '../utils/requestUtils';
 
 export async function executeFunction(context: IActionContext, node?: FunctionTreeItemBase): Promise<void> {
     if (!node) {
-        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;Timer;/i, context);
+        const noItemFoundErrorMessage: string = localize('noTimerFunctions', 'No timer functions found.');
+        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;Timer;/i, { ...context, noItemFoundErrorMessage });
     }
 
     const name: string = node.name;

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -27,6 +27,7 @@ import { createFunction } from './createFunction/createFunction';
 import { createFunctionApp, createFunctionAppAdvanced } from './createFunctionApp/createFunctionApp';
 import { createNewProject } from './createNewProject/createNewProject';
 import { createSlot } from './createSlot';
+import { deleteFunction } from './deleteFunction';
 import { deleteNode } from './deleteNode';
 import { deployProductionSlot, deploySlot } from './deploy/deploy';
 import { connectToGitHub } from './deployments/connectToGitHub';
@@ -71,7 +72,7 @@ export function registerCommands(): void {
     registerCommand('azureFunctions.createFunctionAppAdvanced', createFunctionAppAdvanced);
     registerCommand('azureFunctions.createNewProject', createNewProject);
     registerCommand('azureFunctions.createSlot', createSlot);
-    registerCommand('azureFunctions.deleteFunction', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, /Remote;ReadWrite;Function;/i, node));
+    registerCommand('azureFunctions.deleteFunction', deleteFunction);
     registerCommand('azureFunctions.deleteFunctionApp', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, ProductionSlotTreeItem.contextValue, node));
     registerCommand('azureFunctions.deleteProxy', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, ProxyTreeItem.contextValue, node));
     registerCommand('azureFunctions.deleteSlot', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, SlotTreeItem.contextValue, node));


### PR DESCRIPTION
The default error message is "No matching resources found.", which isn't very helpful.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1751
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1561
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1491