### PR TITLE
Make runtime logic consistent when creating function app in Azure

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppRuntimeStep.ts
@@ -43,31 +43,40 @@ export class FunctionAppRuntimeStep extends AzureWizardPromptStep<IFunctionAppWi
     private getPicks(context: IFunctionAppWizardContext): IAzureQuickPickItem<string>[] {
         const picks: IAzureQuickPickItem<string>[] = [];
 
-        picks.push({ label: '.NET', data: 'dotnet' });
-
         if (context.version === FuncVersion.v1) {
-            picks.unshift({ label: 'Node.js', data: 'node' });
+            // v1 doesn't need a version in `data`
+            picks.push({ label: 'Node.js 6', data: 'node' });
+            picks.push({ label: '.NET Framework 4.7', data: 'dotnet' });
         } else {
-            if (context.version === FuncVersion.v2) {
-                picks.unshift({ label: 'Node.js 8.x', data: 'node|8' });
-            }
-            picks.unshift({ label: 'Node.js 10.x', data: 'node|10' });
             if (context.version !== FuncVersion.v2) {
-                picks.unshift({ label: 'Node.js 12.x', data: 'node|12' });
+                picks.push({ label: 'Node.js 12', data: 'node|12' });
+            }
+            picks.push({ label: 'Node.js 10', data: 'node|10' });
+            if (context.version === FuncVersion.v2) {
+                picks.push({ label: 'Node.js 8', data: 'node|8' });
+            }
+
+            if (context.version === FuncVersion.v2) {
+                picks.push({ label: '.NET Core 2.2', data: 'dotnet|2.2' });
+            } else {
+                picks.push({ label: '.NET Core 3.1', data: 'dotnet|3.1' });
             }
 
             if (context.newSiteOS !== WebsiteOS.windows) {
-                picks.push({ label: 'Python 3.7.x', data: 'python|3.7' });
-                picks.push({ label: 'Python 3.6.x', data: 'python|3.6' });
+                if (context.version !== FuncVersion.v2) {
+                    picks.push({ label: 'Python 3.8', data: 'python|3.8' });
+                }
+                picks.push({ label: 'Python 3.7', data: 'python|3.7' });
+                picks.push({ label: 'Python 3.6', data: 'python|3.6' });
             }
 
             if (context.newSiteOS !== WebsiteOS.linux) {
-                picks.push({ label: 'PowerShell', data: 'powershell' });
+                picks.push({ label: 'PowerShell Core 6', data: 'powershell|6' });
             }
 
             // v1 doesn't support java at all. v2 is windows-only. v3+ supports both OS's.
             if (context.version !== FuncVersion.v2 || context.newSiteOS !== WebsiteOS.linux) {
-                picks.push({ label: 'Java', data: 'java|8' });
+                picks.push({ label: 'Java 8', data: 'java|8' });
             }
         }
 


### PR DESCRIPTION
1. Per https://github.com/Azure/azure-functions-host/issues/5628, dedicated and premium plans no longer need to specify `linuxFxVersion` as a Docker image - we can just use `runtime|version` like we already do for consumption
2. In the quick pick, I made sure each pick has the version listed and I got rid of the `.x` (I tried to find a conclusive pattern in other docs related `.x`, but couldn't find one. I just think it's ugly).

||v1|v2|v3|
|---|---|---|---|
|Before|![v1before](https://user-images.githubusercontent.com/11282622/74882278-aa0a8b80-5323-11ea-9685-83f3fceb29e8.png)|![v2before](https://user-images.githubusercontent.com/11282622/74882291-b1319980-5323-11ea-9bfa-9504a4da4d67.png)|![v3before](https://user-images.githubusercontent.com/11282622/74882308-b4c52080-5323-11ea-8fc3-8451944438fc.png)|
|After|![v1after](https://user-images.githubusercontent.com/11282622/74882363-d1615880-5323-11ea-93b3-21009df83f52.png)|![v2after](https://user-images.githubusercontent.com/11282622/74882377-d7efd000-5323-11ea-8d72-31e56f010943.png)|![v3after](https://user-images.githubusercontent.com/11282622/74882394-dd4d1a80-5323-11ea-91f5-af40ad824363.png)|

3. Added Python 3.8 - related to https://github.com/microsoft/vscode-azurefunctions/issues/1854
