### PR TITLE
Add local project support for python 3.8

### DIFF
--- a/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
+++ b/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
@@ -14,7 +14,7 @@ export class EnterPythonAliasStep extends AzureWizardPromptStep<IPythonVenvWizar
 
     public async prompt(context: IPythonVenvWizardContext): Promise<void> {
         const prompt: string = localize('pyAliasPlaceholder', 'Enter the Python interpreter or full path');
-        const supportedVersions: string[] = await getSupportedPythonVersions();
+        const supportedVersions: string[] = await getSupportedPythonVersions(context.version);
         context.pythonAlias = await ext.ui.showInputBox({ prompt, validateInput: async (value: string): Promise<string | undefined> => await validatePythonAlias(supportedVersions, value) });
     }
 

--- a/src/commands/createNewProject/pythonSteps/IPythonVenvWizardContext.ts
+++ b/src/commands/createNewProject/pythonSteps/IPythonVenvWizardContext.ts
@@ -4,9 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IActionContext } from "vscode-azureextensionui";
+import { FuncVersion } from "../../../FuncVersion";
 
 export interface IPythonVenvWizardContext extends IActionContext {
     projectPath: string;
+    version: FuncVersion;
     pythonAlias?: string;
     manuallyEnterAlias?: boolean;
     useExistingVenv?: boolean;

--- a/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
+++ b/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
@@ -42,7 +42,7 @@ export class PythonAliasListStep extends AzureWizardPromptStep<IPythonVenvWizard
 }
 
 async function getPicks(context: IPythonVenvWizardContext): Promise<IAzureQuickPickItem<string | boolean>[]> {
-    const supportedVersions: string[] = await getSupportedPythonVersions();
+    const supportedVersions: string[] = await getSupportedPythonVersions(context.version);
 
     const aliasesToTry: string[] = ['python3', 'python', 'py'];
     for (const version of supportedVersions) {

--- a/src/commands/createNewProject/pythonSteps/pythonVersion.ts
+++ b/src/commands/createNewProject/pythonSteps/pythonVersion.ts
@@ -32,8 +32,8 @@ export async function getSupportedPythonVersions(funcVersionFromSetting: FuncVer
 
     const versionInfo: [string, string][] = [
         ['2.0.0', '3.6'],
-        ['2.7.1846', '3.7']
-        // ['3.?.?', '3.8'] todo update min version once func cli ships with 3.8 support
+        ['2.7.1846', '3.7'],
+        ['3.0.0', '3.8'] // Need to update the min version to be exact once func cli ships with 3.8 support
     ];
 
     for (const [minFuncVersion, pyVersion] of versionInfo) {

--- a/src/vsCodeConfig/verifyPythonVenv.ts
+++ b/src/vsCodeConfig/verifyPythonVenv.ts
@@ -12,10 +12,11 @@ import { PythonAliasListStep } from '../commands/createNewProject/pythonSteps/Py
 import { PythonVenvCreateStep } from '../commands/createNewProject/pythonSteps/PythonVenvCreateStep';
 import { pythonVenvSetting } from '../constants';
 import { ext } from '../extensionVariables';
+import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { getWorkspaceSetting, updateGlobalSetting } from './settings';
 
-export async function verifyPythonVenv(projectPath: string, context: IActionContext): Promise<void> {
+export async function verifyPythonVenv(projectPath: string, context: IActionContext, version: FuncVersion): Promise<void> {
     const settingKey: string = 'showPythonVenvWarning';
     if (getWorkspaceSetting<boolean>(settingKey)) {
 
@@ -30,7 +31,7 @@ export async function verifyPythonVenv(projectPath: string, context: IActionCont
                 context.errorHandling.suppressDisplay = false;
                 context.telemetry.properties.verifyConfigResult = 'update';
 
-                const wizardContext: IPythonVenvWizardContext = { ...context, venvName, projectPath, suppressSkipVenv: true };
+                const wizardContext: IPythonVenvWizardContext = { ...context, version, venvName, projectPath, suppressSkipVenv: true };
                 const wizard: AzureWizard<IPythonVenvWizardContext> = new AzureWizard(wizardContext, {
                     promptSteps: [new PythonAliasListStep()],
                     executeSteps: [new PythonVenvCreateStep()],

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -43,7 +43,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
                     context.telemetry.properties.projectLanguage = projectLanguage;
                     switch (projectLanguage) {
                         case ProjectLanguage.Python:
-                            await verifyPythonVenv(projectPath, context);
+                            await verifyPythonVenv(projectPath, context, version);
                             break;
                         case ProjectLanguage.CSharp:
                         case ProjectLanguage.FSharp:


### PR DESCRIPTION
I still need to update one line in this PR with the exact version of the func cli that adds support for Python 3.8 (which was supposed to happen yesterday), but otherwise this is good to go.

In combination with https://github.com/microsoft/vscode-azurefunctions/pull/1904, fixes https://github.com/microsoft/vscode-azurefunctions/issues/1854