### PR TITLE
Always append 1 to default function name

### DIFF
--- a/src/commands/createFunction/FunctionNameStepBase.ts
+++ b/src/commands/createFunction/FunctionNameStepBase.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
+import * as path from 'path';
 import { AzureWizardPromptStep } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -28,6 +30,24 @@ export abstract class FunctionNameStepBase<T extends IFunctionWizardContext> ext
 
     protected abstract getUniqueFunctionName(context: T): Promise<string | undefined>;
     protected abstract validateFunctionNameCore(context: T, name: string): Promise<string | undefined>;
+
+    /**
+     * NOTE: This will always at least add `1` to the default value to (hopefully) make clear the function name is an instance of the template
+     */
+    protected async getUniqueFsPath(folderPath: string, defaultValue: string, fileExtension?: string): Promise<string | undefined> {
+        let count: number = 1;
+        const maxCount: number = 1024;
+
+        while (count < maxCount) {
+            const fileName: string = defaultValue + count.toString();
+            if (!(await fse.pathExists(path.join(folderPath, fileExtension ? fileName + fileExtension : fileName)))) {
+                return fileName;
+            }
+            count += 1;
+        }
+
+        return undefined;
+    }
 
     private async validateFunctionName(context: T, name: string | undefined): Promise<string | undefined> {
         if (!name) {

--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionNameStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionNameStep.ts
@@ -7,7 +7,6 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { localize } from "../../../localize";
 import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
-import * as fsUtil from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionNameStepBase } from '../FunctionNameStepBase';
 import { getFileExtension, IDotnetFunctionWizardContext } from './IDotnetFunctionWizardContext';
@@ -15,7 +14,7 @@ import { getFileExtension, IDotnetFunctionWizardContext } from './IDotnetFunctio
 export class DotnetFunctionNameStep extends FunctionNameStepBase<IDotnetFunctionWizardContext> {
     protected async getUniqueFunctionName(context: IDotnetFunctionWizardContext): Promise<string | undefined> {
         const template: IFunctionTemplate = nonNullProp(context, 'functionTemplate');
-        return await fsUtil.getUniqueFsPath(context.projectPath, template.defaultFunctionName, getFileExtension(context));
+        return await this.getUniqueFsPath(context.projectPath, template.defaultFunctionName, getFileExtension(context));
     }
 
     protected async validateFunctionNameCore(context: IDotnetFunctionWizardContext, name: string): Promise<string | undefined> {

--- a/src/commands/createFunction/javaSteps/JavaFunctionNameStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionNameStep.ts
@@ -6,7 +6,6 @@
 import * as fse from 'fs-extra';
 import { localize } from "../../../localize";
 import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
-import { getUniqueFsPath } from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
 import { getJavaClassName, getJavaFunctionFilePath, getJavaPackagePath, IJavaProjectWizardContext } from '../../createNewProject/javaSteps/IJavaProjectWizardContext';
 import { FunctionNameStepBase } from '../FunctionNameStepBase';
@@ -16,7 +15,7 @@ export class JavaFunctionNameStep extends FunctionNameStepBase<IFunctionWizardCo
     protected async getUniqueFunctionName(context: IFunctionWizardContext & IJavaProjectWizardContext): Promise<string | undefined> {
         const template: IFunctionTemplate = nonNullProp(context, 'functionTemplate');
         const packageName: string = nonNullProp(context, 'javaPackageName');
-        return await getUniqueFsPath(getJavaPackagePath(context.projectPath, packageName), getJavaClassName(template.defaultFunctionName), '.java');
+        return await this.getUniqueFsPath(getJavaPackagePath(context.projectPath, packageName), getJavaClassName(template.defaultFunctionName), '.java');
     }
 
     protected async validateFunctionNameCore(context: IFunctionWizardContext & IJavaProjectWizardContext, name: string): Promise<string | undefined> {

--- a/src/commands/createFunction/scriptSteps/ScriptFunctionNameStep.ts
+++ b/src/commands/createFunction/scriptSteps/ScriptFunctionNameStep.ts
@@ -7,7 +7,6 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { localize } from "../../../localize";
 import { IScriptFunctionTemplate } from '../../../templates/script/parseScriptTemplates';
-import * as fsUtil from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionNameStepBase } from '../FunctionNameStepBase';
 import { IScriptFunctionWizardContext } from './IScriptFunctionWizardContext';
@@ -15,7 +14,7 @@ import { IScriptFunctionWizardContext } from './IScriptFunctionWizardContext';
 export class ScriptFunctionNameStep extends FunctionNameStepBase<IScriptFunctionWizardContext> {
     protected async getUniqueFunctionName(context: IScriptFunctionWizardContext): Promise<string | undefined> {
         const template: IScriptFunctionTemplate = nonNullProp(context, 'functionTemplate');
-        return await fsUtil.getUniqueFsPath(context.projectPath, template.defaultFunctionName);
+        return await this.getUniqueFsPath(context.projectPath, template.defaultFunctionName);
     }
 
     protected async validateFunctionNameCore(context: IScriptFunctionWizardContext, name: string): Promise<string | undefined> {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -66,20 +66,6 @@ export async function confirmOverwriteFile(fsPath: string): Promise<boolean> {
     }
 }
 
-export async function getUniqueFsPath(folderPath: string, defaultValue: string, fileExtension?: string): Promise<string | undefined> {
-    let count: number = 0;
-    const maxCount: number = 1024;
-
-    while (count < maxCount) {
-        const fileName: string = defaultValue + (count === 0 ? '' : count.toString());
-        if (!(await fse.pathExists(path.join(folderPath, fileExtension ? `${fileName}${fileExtension}` : fileName)))) {
-            return fileName;
-        }
-        count += 1;
-    }
-    return undefined;
-}
-
 export function getRandomHexString(length: number = 10): string {
     const buffer: Buffer = crypto.randomBytes(Math.ceil(length / 2));
     return buffer.toString('hex').slice(0, length);


### PR DESCRIPTION
I moved `getUniqueFsPath` into `FunctionNameStepBase` since the `1` behavior is somewhat unique to function name. Plus it's better not to use "utils" if there's a better place for it.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1787