### PR TITLE
Add "View Properties" to right click menu of function

### DIFF
--- a/package.json
+++ b/package.json
@@ -552,6 +552,11 @@
                     "group": "3@2"
                 },
                 {
+                    "command": "azureFunctions.viewProperties",
+                    "when": "view == azFuncTree && viewItem =~ /Remote;.*;Function;/i",
+                    "group": "4@1"
+                },
+                {
                     "command": "azureFunctions.appSettings.add",
                     "when": "view == azFuncTree && viewItem == applicationSettings",
                     "group": "1@1"


### PR DESCRIPTION
I removed it from the right click menu in https://github.com/microsoft/vscode-azurefunctions/pull/1875 in favor of the left click, but I think there's value in having it in both places - same thing we did for "View Deployment Logs" in https://github.com/microsoft/vscode-azurefunctions/pull/1935.