### PR TITLE
Suppress "report issue" for a few errors

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -43,7 +43,8 @@ async function deploy(context: IActionContext, target: vscode.Uri | string | Slo
     context.telemetry.properties.projectRuntime = version;
 
     if (language === ProjectLanguage.Python && !node.root.client.isLinux) {
-        throw new Error(localize('pythonNotAvailableOnWindows', 'Python projects are not supported on Windows Function Apps.  Deploy to a Linux Function App instead.'));
+        context.errorHandling.suppressReportIssue = true;
+        throw new Error(localize('pythonNotAvailableOnWindows', 'Python projects are not supported on Windows Function Apps. Deploy to a Linux Function App instead.'));
     }
 
     await validateRemoteBuild(context, node.root.client, workspaceFolder.uri.fsPath, language);

--- a/src/commands/initProjectForVSCode/detectProjectLanguage.ts
+++ b/src/commands/initProjectForVSCode/detectProjectLanguage.ts
@@ -6,8 +6,8 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { ProjectLanguage } from '../../constants';
+import { dotnetUtils } from '../../utils/dotnetUtils';
 import { getScriptFileNameFromLanguage } from '../createFunction/scriptSteps/ScriptFunctionCreateStep';
-import { tryGetCsprojFile, tryGetFsprojFile } from './InitVSCodeStep/DotnetInitVSCodeStep';
 
 /**
  * Returns the project language if we can uniquely detect it for this folder, otherwise returns undefined
@@ -35,11 +35,11 @@ async function isJavaProject(projectPath: string): Promise<boolean> {
 }
 
 async function isCSharpProject(projectPath: string): Promise<boolean> {
-    return !!await tryGetCsprojFile(projectPath);
+    return (await dotnetUtils.getProjFiles(ProjectLanguage.CSharp, projectPath)).length === 1;
 }
 
 async function isFSharpProject(projectPath: string): Promise<boolean> {
-    return !!await tryGetFsprojFile(projectPath);
+    return (await dotnetUtils.getProjFiles(ProjectLanguage.FSharp, projectPath)).length === 1;
 }
 
 /**

--- a/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
+++ b/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureQuickPickItem } from 'vscode-azureextensionui';
+import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { PackageManager } from '../constants';
 import { ext } from '../extensionVariables';
 import { FuncVersion, promptForFuncVersion } from '../FuncVersion';
@@ -14,11 +14,12 @@ import { tryGetLocalFuncVersion } from './tryGetLocalFuncVersion';
 import { updateFuncCoreTools } from './updateFuncCoreTools';
 import { funcToolsInstalled } from './validateFuncCoreToolsInstalled';
 
-export async function installOrUpdateFuncCoreTools(): Promise<void> {
+export async function installOrUpdateFuncCoreTools(context: IActionContext): Promise<void> {
     const isFuncInstalled: boolean = await funcToolsInstalled();
     const packageManagers: PackageManager[] = await getFuncPackageManagers(isFuncInstalled);
     if (packageManagers.length === 0) {
-        throw new Error(localize('installNotSupported', 'Install or update is only supported for brew or npm.'));
+        context.errorHandling.suppressReportIssue = true;
+        throw new Error(localize('installNotSupported', 'Failed to install or update. Follow [these instructions](https://aka.ms/Dqur4e) to install manually.'));
     }
 
     if (isFuncInstalled) {

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -3,8 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from "vscode-azureextensionui";
+import { ProjectLanguage } from '../constants';
 import { localize } from "../localize";
 import { cpUtils } from "./cpUtils";
 import { openUrl } from './openUrl';
@@ -34,6 +37,34 @@ export namespace dotnetUtils {
             }
 
             throw new Error(message);
+        }
+    }
+
+    export function getDotnetDebugSubpath(targetFramework: string): string {
+        return path.posix.join('bin', 'Debug', targetFramework);
+    }
+
+    /**
+     * NOTE: 'extensions.csproj' is excluded as it has special meaning for the func cli
+     */
+    export async function getProjFiles(projectLanguage: ProjectLanguage, projectPath: string): Promise<string[]> {
+        const regexp: RegExp = projectLanguage === ProjectLanguage.FSharp ? /\.fsproj$/i : /\.csproj$/i;
+        const files: string[] = await fse.readdir(projectPath);
+        return files.filter((f: string) => regexp.test(f) && !/extensions\.csproj$/i.test(f));
+    }
+
+    export async function getTargetFramework(projFilePath: string): Promise<string> {
+        return await getPropertyInProjFile(projFilePath, 'TargetFramework');
+    }
+
+    export async function getPropertyInProjFile(projFilePath: string, prop: string): Promise<string> {
+        const projContents: string = (await fse.readFile(projFilePath)).toString();
+        const regExp: RegExp = new RegExp(`<${prop}>(.*)<\\/${prop}>`);
+        const matches: RegExpMatchArray | null = projContents.match(regExp);
+        if (!matches) {
+            throw new Error(localize('failedToFindProp', 'Failed to find "{0}" in project file "{1}".', prop, projFilePath));
+        } else {
+            return matches[1];
         }
     }
 }

--- a/src/vsCodeConfig/verifyTargetFramework.ts
+++ b/src/vsCodeConfig/verifyTargetFramework.ts
@@ -6,10 +6,10 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
-import { getTargetFramework, tryGetCsprojFile, tryGetFsprojFile } from '../commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep';
 import { deploySubpathSetting, ProjectLanguage } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
+import { dotnetUtils } from '../utils/dotnetUtils';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './settings';
 import { getTasks, ITask, updateTasks } from './tasks';
 
@@ -17,12 +17,12 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, fo
     const settingKey: string = 'showTargetFrameworkWarning';
     if (getWorkspaceSetting<boolean>(settingKey)) {
 
-        const projFileName: string | undefined = projectLanguage === ProjectLanguage.CSharp ? await tryGetCsprojFile(projectPath) : await tryGetFsprojFile(projectPath);
-        if (projFileName) {
+        const projFiles: string[] = await dotnetUtils.getProjFiles(projectLanguage, projectPath);
+        if (projFiles.length === 1) {
 
             let targetFramework: string;
             try {
-                targetFramework = await getTargetFramework(path.join(projectPath, projFileName));
+                targetFramework = await dotnetUtils.getTargetFramework(path.join(projectPath, projFiles[0]));
             } catch {
                 // ignore
                 return;


### PR DESCRIPTION
And improve the wording on a few. The biggest code changes came when I wanted to modify the error in `DotnetInitVSCodeStep` to separate out the "zero" and "multiple" cases and had to refactor to make that work.

Here are the errors:
![Screen Shot 2020-03-06 at 1 23 48 PM](https://user-images.githubusercontent.com/11282622/76123937-86e00d00-5fae-11ea-8860-36fc957c91c0.png)
![Screen Shot 2020-03-06 at 1 26 35 PM](https://user-images.githubusercontent.com/11282622/76123938-86e00d00-5fae-11ea-8761-c5e876b5f23e.png)
![Screen Shot 2020-03-06 at 1 22 58 PM](https://user-images.githubusercontent.com/11282622/76123933-85aee000-5fae-11ea-87fb-762dd2044f45.png)
![Screen Shot 2020-03-06 at 1 23 08 PM](https://user-images.githubusercontent.com/11282622/76123935-86477680-5fae-11ea-974b-53251173857e.png)
![Screen Shot 2020-03-06 at 1 23 20 PM](https://user-images.githubusercontent.com/11282622/76123936-86477680-5fae-11ea-9568-3b0c9ac23ec1.png)

The wording of the last error was modeled after VS Code core:
![Screen Shot 2020-03-06 at 1 30 47 PM](https://user-images.githubusercontent.com/11282622/76124026-b4c55180-5fae-11ea-80c3-9aba83c79a91.png)