### PR TITLE
ms-vscode.csharp now ms-dotnettools.csharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ See [here](https://aka.ms/Dqur4e) for more installation options and the latest i
 
 ### .NET
 
-* [VS Code Debugger for C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [VS Code Debugger for C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * .NET Core Sdk [2.x](https://dotnet.microsoft.com/download/dotnet-core/2.2) or [3.x](https://dotnet.microsoft.com/download/dotnet-core/3.0)
 
 > **NOTE**: The default experience for C# uses class libraries (&ast;.cs files), which provide superior performance, scalability, and versatility over C# Scripts (&ast;.csx files). If you want to use C# Scripts, you may change your `azureFunctions.projectLanguage` user setting to `C#Script`.

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
@@ -33,7 +33,7 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
 
     protected getRecommendedExtensions(language: ProjectLanguage): string[] {
         // The csharp extension is really a 'dotnet' extension because it provides debugging for both
-        const recs: string[] = ['ms-vscode.csharp'];
+        const recs: string[] = ['ms-dotnettools.csharp'];
         if (language === ProjectLanguage.FSharp) {
             recs.push('ionide.ionide-fsharp');
         }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetScriptInitVSCodeStep.ts
@@ -19,6 +19,6 @@ export class DotnetScriptInitVSCodeStep extends ScriptInitVSCodeStep {
     }
 
     protected getRecommendedExtensions(): string[] {
-        return ['ms-vscode.csharp'];
+        return ['ms-dotnettools.csharp'];
     }
 }

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -85,7 +85,7 @@ export function getCSharpValidateOptions(projectName: string, targetFramework: s
             `${projectName}.csproj`
         ],
         expectedExtensionRecs: [
-            'ms-vscode.csharp'
+            'ms-dotnettools.csharp'
         ],
         excludedPaths: [
             '.funcignore'
@@ -118,7 +118,7 @@ export function getFSharpValidateOptions(projectName: string, targetFramework: s
             `${projectName}.fsproj`
         ],
         expectedExtensionRecs: [
-            'ms-vscode.csharp',
+            'ms-dotnettools.csharp',
             'ionide.ionide-fsharp'
         ],
         excludedPaths: [
@@ -212,7 +212,7 @@ export function getDotnetScriptValidateOptions(language: ProjectLanguage, versio
         expectedPaths: [
         ],
         expectedExtensionRecs: [
-            'ms-vscode.csharp'
+            'ms-dotnettools.csharp'
         ],
         expectedDebugConfigs: [
             'Attach to .NET Script Functions'

--- a/tools/JsonCli/.vscode/extensions.json
+++ b/tools/JsonCli/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ms-vscode.csharp"
+        "ms-dotnettools.csharp"
     ]
 }

--- a/tools/JsonCli/README.md
+++ b/tools/JsonCli/README.md
@@ -54,7 +54,7 @@ This will create the template with the specified identity. The `require` paramet
 
 ## Contributing
 
-In order to work on this tool, make sure to install the [VS Code Debugger for C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp). You must also make sure to open the `JsonCli` folder _and only_ the `JsonCli` folder in VS Code. The source code has been excluded from VS Code when the root of this repo is open so that it doesn't display a bunch of warnings/errors/notifications while working on the extension itself.
+In order to work on this tool, make sure to install the [VS Code Debugger for C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp). You must also make sure to open the `JsonCli` folder _and only_ the `JsonCli` folder in VS Code. The source code has been excluded from VS Code when the root of this repo is open so that it doesn't display a bunch of warnings/errors/notifications while working on the extension itself.
 
 ### Debug
 


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)
