### PR TITLE
Easier debugging in a webpacked world 🕸📦🌎

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,6 @@
             ],
             "preLaunchTask": "npm: compile",
             "env": {
-                "AZCODE_FUNCTIONS_IGNORE_BUNDLE": "1",
                 "DEBUGTELEMETRY": "v",
                 "NODE_DEBUG": ""
             }
@@ -58,7 +57,6 @@
             ],
             "preLaunchTask": "npm: compile",
             "env": {
-                "AZCODE_FUNCTIONS_IGNORE_BUNDLE": "1",
                 "MOCHA_grep": "", // RegExp of tests to run (empty for all)
                 "MOCHA_enableTimeouts": "0", // Disable time-outs
                 "DEBUGTELEMETRY": "v",

--- a/main.js
+++ b/main.js
@@ -16,12 +16,10 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const ignoreBundle = !/^(false|0)?$/i.test(process.env.AZCODE_FUNCTIONS_IGNORE_BUNDLE || '');
-const extensionPath = ignoreBundle ? "./out/src/extension" : "./dist/extension.bundle";
-const extension = require(extensionPath);
+const extension = require('./out/src/extension');
 
 async function activate(ctx) {
-    return await extension.activateInternal(ctx, perfStats);
+    return await extension.activateInternal(ctx, perfStats, true /* ignoreBundle */);
 }
 
 async function deactivate(ctx) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,8 +26,9 @@ import { CentralTemplateProvider } from './templates/CentralTemplateProvider';
 import { AzureAccountTreeItemWithProjects } from './tree/AzureAccountTreeItemWithProjects';
 import { verifyVSCodeConfigOnActivate } from './vsCodeConfig/verifyVSCodeConfigOnActivate';
 
-export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }): Promise<AzureExtensionApiProvider> {
+export async function activateInternal(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<AzureExtensionApiProvider> {
     ext.context = context;
+    ext.ignoreBundle = ignoreBundle;
     ext.reporter = createTelemetryReporter(context);
     ext.outputChannel = createAzExtOutputChannel('Azure Functions', ext.prefix);
     context.subscriptions.push(ext.outputChannel);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -22,8 +22,7 @@ export namespace ext {
     export let templateProvider: CentralTemplateProvider;
     export let reporter: ITelemetryReporter;
     export let funcCliPath: string = func;
-    // tslint:disable-next-line: strict-boolean-expressions
-    export let ignoreBundle: boolean = !/^(false|0)?$/i.test(process.env.AZCODE_FUNCTIONS_IGNORE_BUNDLE || '');
+    export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'azureFunctions';
 }
 


### PR DESCRIPTION
This should fix the following error that I'm sure we've all seen when debugging:

> Activating extension 'ms-azuretools.vscode-azurefunctions' failed: Cannot find module './dist/extension.bundle' 

The problem is environment variables don't carry over when you open a new folder. My solution will instead modify "main.js" before every webpack. That means you'll have to be mindful not to commit the changes to "main.js" if you test webpack locally, but worst case you'll only break the F5 experience of other devs on your team (aka not the vsix we ship). I almost never debug with webpack and would gladly deal with that minor annoyance over the existing experience.

cc @StephenWeatherford @philliphoff @bwateratmsft since this could help y'all on ARM/Docker, too