### PR TITLE
Explicitly specify triggers in pipelines yaml

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,3 +1,7 @@
+variables:
+  ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+  ENABLE_LONG_RUNNING_TESTS: true
+
 jobs:
 - job: Windows
   pool:
@@ -23,3 +27,21 @@ jobs:
   - template: common/build.yml
   - template: common/lint.yml
   - template: common/test.yml
+
+trigger:
+  branches:
+    include:
+    - '*'
+
+pr:
+  branches:
+    include:
+    - '*'
+
+schedules:
+- cron: "30 7 * * *"
+  displayName: Nightly at 12:30 PT
+  always: true # Run even when there are no code changes
+  branches:
+    include:
+    - master

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,6 +1,6 @@
 variables:
   ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-  ENABLE_LONG_RUNNING_TESTS: true
+    ENABLE_LONG_RUNNING_TESTS: true
 
 jobs:
 - job: Windows


### PR DESCRIPTION
Two pieces:
1. Azure Pipelines was having problems and the suggested workaround was to explicitly specify the `pr` and `trigger` sections. Even though the fix is coming soon, I don't think it'll hurt to add this
1. I wanted to consolidate the nightly build definition into the regular definition, so I added a `schedules` section and set `ENABLE_LONG_RUNNING_TESTS` to true for this case