### PR TITLE
Improve "Install .NET Sdk" error message

### DIFF
--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
@@ -6,10 +6,9 @@
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
 import { FuncVersion } from '../../../FuncVersion';
-import { executeDotnetTemplateCommand } from '../../../templates/dotnet/executeDotnetTemplateCommand';
+import { executeDotnetTemplateCommand, validateDotnetInstalled } from '../../../templates/dotnet/executeDotnetTemplateCommand';
 import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
 import { cpUtils } from '../../../utils/cpUtils';
-import { dotnetUtils } from '../../../utils/dotnetUtils';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionCreateStepBase } from '../FunctionCreateStepBase';
 import { getBindingSetting } from '../IFunctionWizardContext';
@@ -21,7 +20,7 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
     }
 
     public static async createStep(context: IActionContext): Promise<DotnetFunctionCreateStep> {
-        await dotnetUtils.validateDotnetInstalled(context);
+        await validateDotnetInstalled(context);
         return new DotnetFunctionCreateStep();
     }
 
@@ -46,7 +45,7 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
         }
 
         const version: FuncVersion = nonNullProp(context, 'version');
-        await executeDotnetTemplateCommand(version, context.projectPath, 'create', '--identity', template.id, ...args);
+        await executeDotnetTemplateCommand(context, version, context.projectPath, 'create', '--identity', template.id, ...args);
 
         return path.join(context.projectPath, functionName + getFileExtension(context));
     }

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -11,9 +11,8 @@ import { ext } from '../../../extensionVariables';
 import { azureWebJobsStorageKey, MismatchBehavior, setLocalAppSetting } from '../../../funcConfig/local.settings';
 import { FuncVersion, getMajorVersion } from '../../../FuncVersion';
 import { localize } from "../../../localize";
-import { executeDotnetTemplateCommand } from '../../../templates/dotnet/executeDotnetTemplateCommand';
+import { executeDotnetTemplateCommand, validateDotnetInstalled } from '../../../templates/dotnet/executeDotnetTemplateCommand';
 import { cpUtils } from '../../../utils/cpUtils';
-import { dotnetUtils } from '../../../utils/dotnetUtils';
 import { nonNullProp } from '../../../utils/nonNull';
 import { IProjectWizardContext } from '../IProjectWizardContext';
 import { ProjectCreateStepBase } from './ProjectCreateStepBase';
@@ -24,7 +23,7 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
     }
 
     public static async createStep(context: IActionContext): Promise<DotnetProjectCreateStep> {
-        await dotnetUtils.validateDotnetInstalled(context);
+        await validateDotnetInstalled(context);
         return new DotnetProjectCreateStep();
     }
 
@@ -40,7 +39,7 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         const majorVersion: string = getMajorVersion(version);
         const identity: string = `Microsoft.AzureFunctions.ProjectTemplate.${templateLanguage}.${majorVersion}.x`;
         const functionsVersion: string = 'v' + majorVersion;
-        await executeDotnetTemplateCommand(version, context.projectPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);
+        await executeDotnetTemplateCommand(context, version, context.projectPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);
 
         await setLocalAppSetting(context.projectPath, azureWebJobsStorageKey, '', MismatchBehavior.Overwrite);
     }

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -172,7 +172,7 @@ export class CentralTemplateProvider {
         if (!this.templateSource) {
             try {
                 context.telemetry.properties.templateSource = 'cache';
-                return await provider.getCachedTemplates();
+                return await provider.getCachedTemplates(context);
             } catch (error) {
                 const errorMessage: string = parseError(error).message;
                 ext.outputChannel.appendLog(localize('cachedTemplatesError', 'Failed to get cached templates: {0}', errorMessage));
@@ -190,7 +190,7 @@ export class CentralTemplateProvider {
                 context.telemetry.properties.templateSource = 'backup';
                 const backupTemplateVersion: string = provider.getBackupTemplateVersion();
                 context.telemetry.properties.backupTemplateVersion = backupTemplateVersion;
-                const result: ITemplates = await provider.getBackupTemplates();
+                const result: ITemplates = await provider.getBackupTemplates(context);
                 ext.context.globalState.update(provider.getCacheKey(TemplateProviderBase.templateVersionKey), backupTemplateVersion);
                 await provider.cacheTemplates();
                 return result;

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -56,8 +56,8 @@ export abstract class TemplateProviderBase {
 
     public abstract getLatestTemplateVersion(): Promise<string>;
     public abstract getLatestTemplates(context: IActionContext, latestTemplateVersion: string): Promise<ITemplates>;
-    public abstract getCachedTemplates(): Promise<ITemplates | undefined>;
-    public abstract getBackupTemplates(): Promise<ITemplates>;
+    public abstract getCachedTemplates(context: IActionContext): Promise<ITemplates | undefined>;
+    public abstract getBackupTemplates(context: IActionContext): Promise<ITemplates>;
     public abstract cacheTemplates(): Promise<void>;
 
     /**

--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -5,41 +5,10 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import * as vscode from 'vscode';
-import { DialogResponses, IActionContext } from "vscode-azureextensionui";
 import { ProjectLanguage } from '../constants';
 import { localize } from "../localize";
-import { cpUtils } from "./cpUtils";
-import { openUrl } from './openUrl';
 
 export namespace dotnetUtils {
-    export async function isDotnetInstalled(): Promise<boolean> {
-        try {
-            await cpUtils.executeCommand(undefined, undefined, 'dotnet', '--version');
-            return true;
-        } catch (error) {
-            return false;
-        }
-    }
-
-    export async function validateDotnetInstalled(context: IActionContext): Promise<void> {
-        if (!await isDotnetInstalled()) {
-            const message: string = localize('dotnetNotInstalled', 'You must have the .NET CLI installed to perform this operation.');
-
-            if (!context.errorHandling.suppressDisplay) {
-                // don't wait
-                vscode.window.showErrorMessage(message, DialogResponses.learnMore).then(async (result) => {
-                    if (result === DialogResponses.learnMore) {
-                        await openUrl('https://aka.ms/AA4ac70');
-                    }
-                });
-                context.errorHandling.suppressDisplay = true;
-            }
-
-            throw new Error(message);
-        }
-    }
-
     export function getDotnetDebugSubpath(targetFramework: string): string {
         return path.posix.join('bin', 'Debug', targetFramework);
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1715, which asked for a way to open a link to download .net core sdk.

![Screen Shot 2020-03-31 at 2 31 29 PM](https://user-images.githubusercontent.com/11282622/78077318-074f1f00-735d-11ea-9869-a40353e1f5da.png)

I realized this had duplicate logic with `validateDotnetInstalled`, so I consolidated the two.
