### PR TITLE
Allow skipping staging template source in CI ⏭

### DIFF
--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { TestInput } from 'vscode-azureextensiondev';
 import { CentralTemplateProvider, FuncVersion, IFunctionTemplate, ProjectLanguage, TemplateFilter, TemplateSource } from '../extension.bundle';
-import { cleanTestWorkspace, createTestActionContext, longRunningTestsEnabled, runForTemplateSource, testUserInput, testWorkspacePath } from './global.test';
+import { cleanTestWorkspace, createTestActionContext, longRunningTestsEnabled, runForTemplateSource, skipStagingTemplateSource, testUserInput, testWorkspacePath } from './global.test';
 
 addSuite(undefined);
 addSuite(TemplateSource.Latest);
@@ -38,6 +38,10 @@ function addSuite(source: TemplateSource | undefined): void {
 
         for (const [language, version, expectedCount] of cases) {
             test(`${language} ${version}`, async function (this: Mocha.Context): Promise<void> {
+                if (source === TemplateSource.Staging && skipStagingTemplateSource) {
+                    this.skip();
+                }
+
                 if (language === ProjectLanguage.Java) {
                     await javaPreTest(this);
                 }


### PR DESCRIPTION
I like having test failures to kind of "notify" me when the staging templates have changes that affect us, but I don't want to update the tests until the staging templates move to production, which can take a little while. Hopefully adding this environment variable will be a nice middle ground where I can actually get successful builds in the meantime