### PR TITLE
Bump app service package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9219,9 +9219,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.57.3",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.57.3.tgz",
-            "integrity": "sha512-HesKjGeb3m5f353+e7NY00UdevODdCGjfP+4ONLBo1fQNWrX5YFW8WIOKIoCERU5ECBstD8EFGHTZoewIOHpDA==",
+            "version": "0.57.4",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.57.4.tgz",
+            "integrity": "sha512-4fOtQT6YJAS8O/kdYjocuKZ54Ww73dUbLNe4txIgIc+fpQzQnbE4QYV6o7gs6W82iBf9dky9xUVoNRgQIqceog==",
             "requires": {
                 "archiver": "^3.1.1",
                 "azure-arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1029,7 +1029,7 @@
         "ps-tree": "^1.1.1",
         "request-promise": "^4.2.4",
         "semver": "^5.7.1",
-        "vscode-azureappservice": "^0.57.3",
+        "vscode-azureappservice": "^0.57.4",
         "vscode-azureextensionui": "^0.29.12",
         "vscode-azurekudu": "^0.1.8",
         "vscode-nls": "^4.1.1",


### PR DESCRIPTION
Added a setting in https://github.com/microsoft/vscode-azuretools/pull/678 to suppress md5 validation when doing storage account deploy. I want this as a workaround for people, but I don't want to encourage it - so I'm going to leave it out of package.json as an "official" setting for now. It should still work without that