### PR TITLE
Use npm ci instead of npm install to freeze dependencies

### DIFF
--- a/.azure-pipelines/common/build.yml
+++ b/.azure-pipelines/common/build.yml
@@ -5,7 +5,9 @@ steps:
     versionSpec: 10.x
 
 - task: Npm@1
-  displayName: 'npm install'
+  displayName: 'npm ci'
+  inputs:
+    command: ci
 
 - task: Npm@1
   displayName: 'Build'


### PR DESCRIPTION
I assume the intention of checking in the package-lock.json file is to freeze the dependencies the build pipeline does however not honor this file since `npm install` is used. See npm documentation: https://docs.npmjs.com/cli/ci.html