### PR TITLE
Durable templates should always be associated with a bundle

### DIFF
--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -56,7 +56,7 @@ export namespace bundleFeedUtils {
     }
 
     export function isBundleTemplate(template: IFunctionTemplate | IBindingTemplate): boolean {
-        return !template.isHttpTrigger && !template.isTimerTrigger;
+        return (!template.isHttpTrigger && !template.isTimerTrigger) || isDurableTemplate(template);
     }
 
     export async function getLatestVersionRange(): Promise<string> {
@@ -76,6 +76,10 @@ export namespace bundleFeedUtils {
             id: defaultBundleId,
             version: versionRange
         };
+    }
+
+    function isDurableTemplate(template: Partial<IFunctionTemplate>): boolean {
+        return !!template.id?.toLowerCase().includes('durable');
     }
 
     async function getBundleFeed(bundleMetadata: IBundleMetadata | undefined): Promise<IBundleFeed> {


### PR DESCRIPTION
Durable has 3 templates that all work together. While 1 of them (Http starter) is technically just an http trigger, it will always go with the other two templates, which require a bundle. I updated `isBundleTemplate` so that all three return `true`, so that we always gets the three templates from the same source.

<img width="311" alt="Screen Shot 2020-04-07 at 5 19 08 PM" src="https://user-images.githubusercontent.com/11282622/78731213-ec981f80-78f3-11ea-9bbb-37ed6f72d91f.png">