### PR TITLE
Add support for changing bundle uri with env var

### DIFF
--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -85,13 +85,15 @@ export namespace bundleFeedUtils {
     async function getBundleFeed(bundleMetadata: IBundleMetadata | undefined): Promise<IBundleFeed> {
         const bundleId: string = bundleMetadata && bundleMetadata.id || defaultBundleId;
 
+        const envVarUri: string | undefined = process.env.FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI;
         // Only use an aka.ms link for the most common case, otherwise we will dynamically construct the url
         let url: string;
-        if (bundleId === defaultBundleId && ext.templateProvider.templateSource !== TemplateSource.Staging) {
+        if (!envVarUri && bundleId === defaultBundleId && ext.templateProvider.templateSource !== TemplateSource.Staging) {
             url = 'https://aka.ms/AA66i2x';
         } else {
             const suffix: string = ext.templateProvider.templateSource === TemplateSource.Staging ? 'staging' : '';
-            url = `https://functionscdn${suffix}.azureedge.net/public/ExtensionBundles/${bundleId}/index-v2.json`;
+            const baseUrl: string = envVarUri || `https://functionscdn${suffix}.azureedge.net/public`;
+            url = `${baseUrl}/ExtensionBundles/${bundleId}/index-v2.json`;
         }
 
         return feedUtils.getJsonFeed(url);


### PR DESCRIPTION
A request from partner teams so that they can test custom bundle sources.This uses the same env var supported by the func cli. I considered adding a VS Code setting as well, but since it's only for testing purposes I decided that wasn't necessary.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1998