### PR TITLE
Add workaround to skip validating func cli before debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -977,6 +977,11 @@
                         "description": "%azureFunctions.showDeployConfirmation%",
                         "default": true
                     },
+                    "azureFunctions.validateFuncCoreTools": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.validateFuncCoreTools%",
+                        "default": true
+                    },
                     "azureFunctions.requestTimeout": {
                         "type": "number",
                         "description": "%azureFunctions.requestTimeout%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -79,6 +79,7 @@
     "azureFunctions.templateVersion": "A runtime release version (any runtime) that species which templates will be used rather than the latest templates.  This version will be used for ALL runtimes. (Requires a restart of VS Code to take effect)",
     "azureFunctions.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
     "azureFunctions.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
+    "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",
     "azureFunctions.viewProperties": "View Properties"

--- a/src/funcCoreTools/validateFuncCoreToolsInstalled.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsInstalled.ts
@@ -23,7 +23,10 @@ export async function validateFuncCoreToolsInstalled(message: string, fsPath: st
     await callWithTelemetryAndErrorHandling('azureFunctions.validateFuncCoreToolsInstalled', async (context: IActionContext) => {
         context.errorHandling.suppressDisplay = true;
 
-        if (await funcToolsInstalled()) {
+        if (!getWorkspaceSetting<boolean>('validateFuncCoreTools', fsPath)) {
+            context.telemetry.properties.validateFuncCoreTools = 'false';
+            installed = true;
+        } else if (await funcToolsInstalled()) {
             installed = true;
         } else {
             const items: MessageItem[] = [];


### PR DESCRIPTION
Per https://github.com/microsoft/vscode-azurefunctions/issues/2019, there's an issue where the func cli is in the path for VS Code tasks (meaning debugging will actually work), but not in the PATH for the child process we use to validate. I don't have time to actually fix the bug for this release, but I can at least add an easy workaround for users