### PR TITLE
Clean up output when creating function app/slot

### DIFF
--- a/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
+++ b/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
@@ -3,11 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAppServiceWizardContext } from 'vscode-azureappservice';
+import { IAppServiceWizardContext, SiteClient } from 'vscode-azureappservice';
 import { FuncVersion } from '../../FuncVersion';
 
 export interface IFunctionAppWizardContext extends IAppServiceWizardContext {
     version: FuncVersion;
     language: string | undefined;
     runtimeFilter?: string;
+    siteClient?: SiteClient;
 }

--- a/src/commands/createFunctionApp/createFunctionApp.ts
+++ b/src/commands/createFunctionApp/createFunctionApp.ts
@@ -8,6 +8,7 @@ import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { ProductionSlotTreeItem } from '../../tree/ProductionSlotTreeItem';
 import { ICreateFuntionAppContext, SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
+import { ISiteCreatedOptions } from './showSiteCreated';
 
 export async function createFunctionApp(context: IActionContext & Partial<ICreateFuntionAppContext>, subscription?: AzureParentTreeItem | string, newResourceGroupName?: string): Promise<string> {
     let node: AzureParentTreeItem | undefined;
@@ -23,9 +24,8 @@ export async function createFunctionApp(context: IActionContext & Partial<ICreat
     }
 
     context.newResourceGroupName = newResourceGroupName;
+    (<ISiteCreatedOptions>context).showCreatedNotification = true;
     const funcAppNode: ProductionSlotTreeItem = await node.createChild(context);
-    funcAppNode.showCreatedOutput();
-
     return funcAppNode.fullId;
 }
 

--- a/src/commands/createFunctionApp/showSiteCreated.ts
+++ b/src/commands/createFunctionApp/showSiteCreated.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MessageItem, window } from 'vscode';
+import { SiteClient } from 'vscode-azureappservice';
+import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../extensionVariables';
+import { localize } from '../../localize';
+
+export interface ISiteCreatedOptions extends IActionContext {
+    showCreatedNotification?: boolean;
+}
+
+export function showSiteCreated(client: SiteClient, context: ISiteCreatedOptions): void {
+    const message: string = client.isSlot ?
+        localize('createdNewSlot', 'Successfully created slot "{0}": {1}', client.fullName, client.defaultHostUrl) :
+        localize('createdNewApp', 'Successfully created function app "{0}": {1}', client.fullName, client.defaultHostUrl);
+
+    ext.outputChannel.appendLog(message);
+
+    if (context.showCreatedNotification) {
+        const viewOutput: MessageItem = { title: localize('viewOutput', 'View Output') };
+        // don't wait
+        window.showInformationMessage(message, viewOutput).then(async result => {
+            if (result === viewOutput) {
+                ext.outputChannel.show();
+            }
+        });
+    }
+}

--- a/src/commands/createSlot.ts
+++ b/src/commands/createSlot.ts
@@ -7,14 +7,14 @@ import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { SlotsTreeItem } from '../tree/SlotsTreeItem';
 import { SlotTreeItem } from '../tree/SlotTreeItem';
+import { ISiteCreatedOptions } from './createFunctionApp/showSiteCreated';
 
 export async function createSlot(context: IActionContext, node?: SlotsTreeItem): Promise<string> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<SlotsTreeItem>(SlotsTreeItem.contextValue, context);
     }
 
+    (<ISiteCreatedOptions>context).showCreatedNotification = true;
     const slotNode: SlotTreeItem = await node.createChild(context);
-    slotNode.showCreatedOutput();
-
     return slotNode.fullId;
 }

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -4,14 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementModels } from 'azure-arm-website';
-import { MessageItem, window } from 'vscode';
 import { AppSettingsTreeItem, AppSettingTreeItem, deleteSite, DeploymentsTreeItem, DeploymentTreeItem, ISiteTreeRoot, LogFilesTreeItem, SiteClient, SiteFilesTreeItem } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem, TreeItemIconPath } from 'vscode-azureextensionui';
 import { KuduClient } from 'vscode-azurekudu';
-import { ext } from '../extensionVariables';
 import { IParsedHostJson, parseHostJson } from '../funcConfig/host';
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersion';
-import { localize } from '../localize';
 import { treeUtils } from '../utils/treeUtils';
 import { ApplicationSettings, IProjectTreeItem } from './IProjectTreeItem';
 import { matchesAnyPart, ProjectResource, ProjectSource } from './projectContextValues';
@@ -220,24 +217,5 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
 
     public async deleteTreeItemImpl(): Promise<void> {
         await deleteSite(this.root.client);
-    }
-
-    public showCreatedOutput(): void {
-        const slot: string = localize('createdNewSlot', 'Created new slot "{0}": {1}', this.root.client.fullName, `https://${this.root.client.defaultHostName}`);
-        const functionApp: string = localize('createdNewApp', 'Created new function app "{0}": {1}', this.root.client.fullName, `https://${this.root.client.defaultHostName}`);
-        const createdNewSlotTree: string = this.root.client.isSlot ? slot : functionApp;
-
-        ext.outputChannel.appendLog(createdNewSlotTree);
-        ext.outputChannel.appendLine('');
-        const viewOutput: MessageItem = {
-            title: localize('viewOutput', 'View Output')
-        };
-
-        // Note: intentionally not waiting for the result of this before returning
-        window.showInformationMessage(createdNewSlotTree, viewOutput).then(async (result: MessageItem | undefined) => {
-            if (result === viewOutput) {
-                ext.outputChannel.show();
-            }
-        });
     }
 }

--- a/src/tree/SlotsTreeItem.ts
+++ b/src/tree/SlotsTreeItem.ts
@@ -6,6 +6,7 @@
 import { WebSiteManagementClient, WebSiteManagementModels } from 'azure-arm-website';
 import { createSlot, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem, AzureTreeItem, createAzureClient, ICreateChildImplContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { showSiteCreated } from '../commands/createFunctionApp/showSiteCreated';
 import { localize } from '../localize';
 import { treeUtils } from '../utils/treeUtils';
 import { ProductionSlotTreeItem } from './ProductionSlotTreeItem';
@@ -64,6 +65,8 @@ export class SlotsTreeItem extends AzureParentTreeItem<ISiteTreeRoot> {
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzureTreeItem<ISiteTreeRoot>> {
         const existingSlots: SlotTreeItem[] = <SlotTreeItem[]>await this.getCachedChildren(context);
         const newSite: WebSiteManagementModels.Site = await createSlot(this.root, existingSlots, context);
-        return new SlotTreeItem(this, new SiteClient(newSite, this.root), newSite);
+        const siteClient: SiteClient = new SiteClient(newSite, this.root);
+        showSiteCreated(siteClient, context);
+        return new SlotTreeItem(this, siteClient, newSite);
     }
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -10,7 +10,6 @@ import { FunctionAppCreateStep } from '../commands/createFunctionApp/FunctionApp
 import { FunctionAppHostingPlanStep } from '../commands/createFunctionApp/FunctionAppHostingPlanStep';
 import { FunctionAppRuntimeStep } from '../commands/createFunctionApp/FunctionAppRuntimeStep';
 import { IFunctionAppWizardContext } from '../commands/createFunctionApp/IFunctionAppWizardContext';
-import { enableFileLogging } from '../commands/logstream/enableFileLogging';
 import { funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../constants';
 import { tryGetLocalFuncVersion } from '../funcCoreTools/tryGetLocalFuncVersion';
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersion';
@@ -156,19 +155,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         }
 
         await wizard.execute();
-        const site: WebSiteManagementModels.Site = nonNullProp(wizardContext, 'site');
 
-        const client: SiteClient = new SiteClient(site, this.root);
-        if (!client.isLinux) { // not supported on linux
-            try {
-                await enableFileLogging(client);
-            } catch (error) {
-                // optional part of creating function app, so not worth blocking on error
-                context.telemetry.properties.fileLoggingError = parseError(error).message;
-            }
-        }
-
-        return new ProductionSlotTreeItem(this, client, site);
+        return new ProductionSlotTreeItem(this, nonNullProp(wizardContext, 'siteClient'), nonNullProp(wizardContext, 'site'));
     }
 
     public isAncestorOfImpl(contextValue: string | RegExp): boolean {


### PR DESCRIPTION
We weren't displaying to the output when it successfully creating during a deploy. Fixes #2084

Also I moved the `enableFileLogging` code into the wizard so that the progress notification would still display while it's executing.