### PR TITLE
Use notifications for upload/download settings

### DIFF
--- a/src/commands/appSettings/downloadAppSettings.ts
+++ b/src/commands/appSettings/downloadAppSettings.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
 import { AppSettingsTreeItem, SiteClient } from "vscode-azureappservice";
 import { IActionContext } from "vscode-azureextensionui";
-import { localSettingsFileName } from "../../constants";
+import { localSettingsFileName, viewOutput } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { getLocalSettingsJson, ILocalSettingsJson } from "../../funcConfig/local.settings";
 import { localize } from "../../localize";
@@ -28,43 +28,45 @@ export async function downloadAppSettings(context: IActionContext, node?: AppSet
     const localSettingsPath: string = await getLocalSettingsFile(message);
     const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
 
-    await node.runWithTemporaryDescription(localize('downloading', 'Downloading...'), async () => {
-        ext.outputChannel.show(true);
-        ext.outputChannel.appendLog(localize('downloadStart', 'Downloading settings from "{0}"...', client.fullName));
-        let localSettings: ILocalSettingsJson = await getLocalSettingsJson(localSettingsPath, true /* allowOverwrite */);
+    let localSettings: ILocalSettingsJson = await getLocalSettingsJson(localSettingsPath, true /* allowOverwrite */);
 
-        const isEncrypted: boolean | undefined = localSettings.IsEncrypted;
-        if (localSettings.IsEncrypted) {
-            await decryptLocalSettings(context, localSettingsUri);
-            localSettings = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
+    const isEncrypted: boolean | undefined = localSettings.IsEncrypted;
+    if (localSettings.IsEncrypted) {
+        await decryptLocalSettings(context, localSettingsUri);
+        localSettings = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
+    }
+
+    try {
+        if (!localSettings.Values) {
+            localSettings.Values = {};
         }
 
-        try {
-            if (!localSettings.Values) {
-                localSettings.Values = {};
-            }
+        const remoteSettings: WebSiteManagementModels.StringDictionary = await client.listApplicationSettings();
 
-            const remoteSettings: WebSiteManagementModels.StringDictionary = await client.listApplicationSettings();
-            if (remoteSettings.properties) {
-                await confirmOverwriteSettings(remoteSettings.properties, localSettings.Values, localSettingsFileName);
-            }
+        ext.outputChannel.appendLog(localize('downloadingSettings', 'Downloading settings...'), { resourceName: client.fullName });
+        if (remoteSettings.properties) {
+            await confirmOverwriteSettings(remoteSettings.properties, localSettings.Values, localSettingsFileName);
+        }
 
+        await node.runWithTemporaryDescription(localize('downloading', 'Downloading...'), async () => {
             await fse.ensureFile(localSettingsPath);
             await fse.writeJson(localSettingsPath, localSettings, { spaces: 2 });
-        } finally {
-            if (isEncrypted) {
-                await encryptLocalSettings(context, localSettingsUri);
-            }
+        });
+    } finally {
+        if (isEncrypted) {
+            await encryptLocalSettings(context, localSettingsUri);
         }
-    });
+    }
 
-    const downloadedMessage: string = localize('downloadedSettings', `Successfully downloaded settings from "{0}".`, client.fullName);
+    ext.outputChannel.appendLog(localize('downloadedSettings', 'Successfully downloaded settings.'), { resourceName: client.fullName });
     const openFile: string = localize('openFile', 'Open File');
     // don't wait
-    vscode.window.showInformationMessage(downloadedMessage, openFile).then(async (result: string | undefined) => {
+    vscode.window.showInformationMessage(localize('downloadedSettingsFrom', 'Successfully downloaded settings from "{0}".', client.fullName), openFile, viewOutput).then(async result => {
         if (result === openFile) {
             const doc: vscode.TextDocument = await vscode.workspace.openTextDocument(localSettingsUri);
             await vscode.window.showTextDocument(doc);
+        } else if (result === viewOutput) {
+            ext.outputChannel.show();
         }
     });
 }

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import * as vscode from 'vscode';
 import { AppSettingsTreeItem, SiteClient } from "vscode-azureappservice";
 import { IActionContext } from "vscode-azureextensionui";
-import { localSettingsFileName } from "../../constants";
+import { localSettingsFileName, viewOutput } from "../../constants";
 import { ext } from "../../extensionVariables";
 import { ILocalSettingsJson } from "../../funcConfig/local.settings";
 import { localize } from "../../localize";
@@ -28,30 +28,39 @@ export async function uploadAppSettings(context: IActionContext, node?: AppSetti
 
     const client: SiteClient = node.root.client;
 
-    await node.runWithTemporaryDescription(localize('uploading', 'Uploading...'), async () => {
-        ext.outputChannel.show(true);
-        ext.outputChannel.appendLog(localize('uploadStart', 'Uploading settings to "{0}"...', client.fullName));
-        let localSettings: ILocalSettingsJson = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
-        if (localSettings.IsEncrypted) {
-            await decryptLocalSettings(context, localSettingsUri);
-            try {
-                localSettings = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
-            } finally {
-                await encryptLocalSettings(context, localSettingsUri);
-            }
+    let localSettings: ILocalSettingsJson = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
+    if (localSettings.IsEncrypted) {
+        await decryptLocalSettings(context, localSettingsUri);
+        try {
+            localSettings = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
+        } finally {
+            await encryptLocalSettings(context, localSettingsUri);
+        }
+    }
+
+    if (localSettings.Values) {
+        const remoteSettings: WebSiteManagementModels.StringDictionary = await client.listApplicationSettings();
+        if (!remoteSettings.properties) {
+            remoteSettings.properties = {};
         }
 
-        if (localSettings.Values) {
-            const remoteSettings: WebSiteManagementModels.StringDictionary = await client.listApplicationSettings();
-            if (!remoteSettings.properties) {
-                remoteSettings.properties = {};
+        ext.outputChannel.appendLog(localize('uploadingSettings', 'Uploading settings...'), { resourceName: client.fullName });
+        await confirmOverwriteSettings(localSettings.Values, remoteSettings.properties, client.fullName);
+
+        await node.runWithTemporaryDescription(localize('uploading', 'Uploading...'), async () => {
+            await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('uploadingSettingsTo', 'Uploading settings to "{0}"...', client.fullName) }, async () => {
+                await client.updateApplicationSettings(remoteSettings);
+            });
+        });
+
+        ext.outputChannel.appendLog(localize('uploadedSettings', 'Successfully uploaded settings.'), { resourceName: client.fullName });
+        // don't wait
+        vscode.window.showInformationMessage(localize('uploadedSettingsTo', 'Successfully uploaded settings to "{0}".', client.fullName), viewOutput).then(async result => {
+            if (result === viewOutput) {
+                ext.outputChannel.show();
             }
-
-            await confirmOverwriteSettings(localSettings.Values, remoteSettings.properties, client.fullName);
-
-            await client.updateApplicationSettings(remoteSettings);
-        } else {
-            throw new Error(localize('noSettings', 'No settings found in "{0}".', localSettingsFileName));
-        }
-    });
+        });
+    } else {
+        throw new Error(localize('noSettings', 'No settings found in "{0}".', localSettingsFileName));
+    }
 }

--- a/src/commands/createFunctionApp/showSiteCreated.ts
+++ b/src/commands/createFunctionApp/showSiteCreated.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MessageItem, window } from 'vscode';
+import { window } from 'vscode';
 import { SiteClient } from 'vscode-azureappservice';
 import { IActionContext } from 'vscode-azureextensionui';
+import { viewOutput } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 
@@ -21,7 +22,6 @@ export function showSiteCreated(client: SiteClient, context: ISiteCreatedOptions
     ext.outputChannel.appendLog(message);
 
     if (context.showCreatedNotification) {
-        const viewOutput: MessageItem = { title: localize('viewOutput', 'View Output') };
         // don't wait
         window.showInformationMessage(message, viewOutput).then(async result => {
             if (result === viewOutput) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { localize } from "./localize";
+
 export const projectLanguageSetting: string = 'projectLanguage';
 export const funcVersionSetting: string = 'projectRuntime'; // Using this name for the sake of backwards compatability even though it's not the most accurate
 export const templateFilterSetting: string = 'templateFilter';
@@ -79,3 +81,5 @@ export const localEmulatorConnectionString: string = 'UseDevelopmentStorage=true
 
 export const workerRuntimeKey: string = 'FUNCTIONS_WORKER_RUNTIME';
 export const extensionVersionKey: string = 'FUNCTIONS_EXTENSION_VERSION';
+
+export const viewOutput: string = localize('viewOutput', 'View Output');


### PR DESCRIPTION
instead of always popping up the output channel.

Suggest reviewing with whitespace off

Fixes #2088 - I feel like the only real missing piece in the logs was a completion message like "Successfully downloaded settings"