### PR TITLE
Add tool to update backup templates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,8 @@
                 "DEBUGTELEMETRY": "v",
                 "NODE_DEBUG": "",
                 "ENABLE_LONG_RUNNING_TESTS": "",
-                "FUNC_PATH": "func"
+                "FUNC_PATH": "func",
+                "AZFUNC_UPDATE_BACKUP_TEMPLATES": ""
             }
         },
         {

--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -31,6 +31,7 @@ export * from './src/FuncVersion';
 export * from './src/templates/CentralTemplateProvider';
 export * from './src/templates/IFunctionTemplate';
 export * from './src/templates/script/getScriptResourcesLanguage';
+export * from './src/templates/TemplateProviderBase';
 export * from './src/tree/AzureAccountTreeItemWithProjects';
 export * from './src/utils/cpUtils';
 export * from './src/utils/delay';

--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -26,7 +26,10 @@ interface IRawJavaTemplates {
  */
 export class JavaTemplateProvider extends ScriptTemplateProvider {
     public templateType: TemplateType = TemplateType.Java;
-    protected readonly _backupSubpath: string = 'backupJavaTemplates';
+
+    protected get backupSubpath(): string {
+        return path.join('java', this.version);
+    }
 
     public async getLatestTemplateVersion(): Promise<string> {
         const pomPath: string = path.join(this.getProjectPath(), 'pom.xml');

--- a/src/templates/script/ScriptBundleTemplateProvider.ts
+++ b/src/templates/script/ScriptBundleTemplateProvider.ts
@@ -16,12 +16,15 @@ import { IBindingTemplate } from '../IBindingTemplate';
 import { IFunctionTemplate } from '../IFunctionTemplate';
 import { ITemplates } from '../ITemplates';
 import { TemplateType } from '../TemplateProviderBase';
-import { getScriptResourcesLanguage } from './getScriptResourcesLanguage';
 import { parseScriptTemplates } from './parseScriptTemplates';
 import { ScriptTemplateProvider } from './ScriptTemplateProvider';
 
 export class ScriptBundleTemplateProvider extends ScriptTemplateProvider {
     public templateType: TemplateType = TemplateType.ScriptBundle;
+
+    protected get backupSubpath(): string {
+        return bundleFeedUtils.defaultBundleId;
+    }
 
     public async getLatestTemplateVersion(): Promise<string> {
         const bundleMetadata: IBundleMetadata | undefined = await this.getBundleInfo();
@@ -34,7 +37,7 @@ export class ScriptBundleTemplateProvider extends ScriptTemplateProvider {
 
         const bindingsRequest: requestUtils.Request = await requestUtils.getDefaultRequestWithTimeout(release.bindings);
 
-        const language: string = getScriptResourcesLanguage();
+        const language: string = this.getResourcesLanguage();
         const resourcesUrl: string = release.resources.replace('{locale}', language);
         const resourcesRequest: requestUtils.Request = await requestUtils.getDefaultRequestWithTimeout(resourcesUrl);
 

--- a/src/templates/script/getScriptResourcesLanguage.ts
+++ b/src/templates/script/getScriptResourcesLanguage.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 
 export const english: string = 'en-US';
-const supportedLanguages: string[] = [
+export const supportedLanguages: string[] = [
     'cs-CZ',
     'de-DE',
     english,
@@ -20,7 +20,6 @@ const supportedLanguages: string[] = [
     'pl-PL',
     'pt-BR',
     'pt-PT',
-    'qps-ploc',
     'ru-RU',
     'sv-SE',
     'tr-TR',

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,6 +6,7 @@
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
 import * as path from 'path';
+import { envUtils } from './utils/envUtils';
 
 // tslint:disable-next-line: export-name
 export async function run(): Promise<void> {
@@ -26,11 +27,16 @@ export async function run(): Promise<void> {
 
     const mocha = new Mocha(options);
 
-    const files: string[] = await new Promise((resolve, reject) => {
-        glob('**/**.test.js', { cwd: __dirname }, (err, result) => {
-            err ? reject(err) : resolve(result);
+    let files: string[];
+    if (envUtils.isEnvironmentVariableSet(process.env.AZFUNC_UPDATE_BACKUP_TEMPLATES)) {
+        files = ['updateBackupTemplates.js'];
+    } else {
+        files = await new Promise((resolve, reject) => {
+            glob('**/**.test.js', { cwd: __dirname }, (err, result) => {
+                err ? reject(err) : resolve(result);
+            });
         });
-    });
+    }
 
     files.forEach(f => mocha.addFile(path.resolve(__dirname, f)));
 

--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -4,12 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import * as fse from 'fs-extra';
-import * as path from 'path';
-import * as vscode from 'vscode';
-import { TestInput } from 'vscode-azureextensiondev';
 import { CentralTemplateProvider, FuncVersion, IFunctionTemplate, ProjectLanguage, TemplateFilter, TemplateSource } from '../extension.bundle';
-import { cleanTestWorkspace, createTestActionContext, longRunningTestsEnabled, runForTemplateSource, skipStagingTemplateSource, testUserInput, testWorkspacePath } from './global.test';
+import { createTestActionContext, longRunningTestsEnabled, runForTemplateSource, skipStagingTemplateSource, testWorkspacePath } from './global.test';
+import { javaUtils } from './utils/javaUtils';
 
 addSuite(undefined);
 addSuite(TemplateSource.Latest);
@@ -61,12 +58,5 @@ async function javaPreTest(testContext: Mocha.Context): Promise<void> {
     }
     testContext.timeout(120 * 1000);
 
-    // Java templates require you to have a project open, so create one here
-    if (!await fse.pathExists(path.join(testWorkspacePath, 'pom.xml'))) { // No need to create for every template source
-        const inputs: (string | TestInput | RegExp)[] = [testWorkspacePath, ProjectLanguage.Java, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, 'javaAppName'];
-        await cleanTestWorkspace();
-        await testUserInput.runWithInputs(inputs, async () => {
-            await vscode.commands.executeCommand('azureFunctions.createNewProject');
-        });
-    }
+    await javaUtils.addJavaProjectToWorkspace();
 }

--- a/test/updateBackupTemplates.ts
+++ b/test/updateBackupTemplates.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CentralTemplateProvider, FuncVersion, ProjectLanguage, supportedLanguages as resourceLanguages, TemplateProviderBase } from '../extension.bundle';
+import { createTestActionContext, testWorkspacePath, updateBackupTemplates } from './global.test';
+import { javaUtils } from './utils/javaUtils';
+
+/**
+ * This is not actually a test, but a tool for updating backup templates.
+ * The benefit of running as a test (as opposed to for example a gulp task) is that it can run within the context of VS Code and our extension
+ * Set the environment variable `AZFUNC_UPDATE_BACKUP_TEMPLATES` to `1` to run this
+ */
+suite('Backup templates', () => {
+    suiteSetup(async function (this: Mocha.Context): Promise<void> {
+        if (!updateBackupTemplates) {
+            this.skip();
+        }
+    });
+
+    test('Update', async () => {
+        await javaUtils.addJavaProjectToWorkspace();
+
+        const languages: ProjectLanguage[] = [ProjectLanguage.JavaScript, ProjectLanguage.CSharp, ProjectLanguage.Java];
+        for (const language of languages) {
+            for (const version of Object.values(FuncVersion)) {
+                if (language === ProjectLanguage.Java && version === FuncVersion.v1) {
+                    // not supported
+                    continue;
+                }
+
+                const providers: TemplateProviderBase[] = CentralTemplateProvider.getProviders(testWorkspacePath, language, version);
+
+                for (const provider of providers) {
+                    const templateVersion: string = await provider.getLatestTemplateVersion();
+
+                    async function updateBackupTemplatesInternal(): Promise<void> {
+                        await provider.getLatestTemplates(createTestActionContext(), templateVersion);
+                        await provider.updateBackupTemplates();
+                    }
+
+                    if (language === ProjectLanguage.JavaScript) {
+                        for (const resourcesLanguage of resourceLanguages) {
+                            provider.resourcesLanguage = resourcesLanguage;
+                            await updateBackupTemplatesInternal();
+                        }
+                    } else {
+                        await updateBackupTemplatesInternal();
+                    }
+
+                    await provider.updateBackupTemplateVersion(templateVersion);
+                }
+            }
+        }
+    });
+});

--- a/test/utils/envUtils.ts
+++ b/test/utils/envUtils.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export namespace envUtils {
+    export function isEnvironmentVariableSet(val: string | undefined): boolean {
+        // tslint:disable-next-line: strict-boolean-expressions
+        return !/^(false|0)?$/i.test(val || '');
+    }
+}

--- a/test/utils/javaUtils.ts
+++ b/test/utils/javaUtils.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { TestInput } from 'vscode-azureextensiondev';
+import { ProjectLanguage } from '../../extension.bundle';
+import { cleanTestWorkspace, testUserInput, testWorkspacePath } from '../global.test';
+
+export namespace javaUtils {
+    export async function addJavaProjectToWorkspace(): Promise<void> {
+        // Java templates require you to have a project open, so create one here
+        if (!await fse.pathExists(path.join(testWorkspacePath, 'pom.xml'))) { // no need if the project is already created
+            const inputs: (string | TestInput | RegExp)[] = [testWorkspacePath, ProjectLanguage.Java, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, 'javaAppName'];
+            await cleanTestWorkspace();
+            await testUserInput.runWithInputs(inputs, async () => {
+                await vscode.commands.executeCommand('azureFunctions.createNewProject');
+            });
+        }
+    }
+}


### PR DESCRIPTION
Two main problems I'm trying to fix here:
1. Make the process of updating backup templates more automatic
1. Make the backup templates more accurately reflect the latest templates (For example, right now backup templates have no concept of bundles)

To do that, I created a tool. It's a bit weird TBH, but it works haha. You run the test suite with an environment variable set and it updates all backup templates from the latest template sources (instead of actually running tests). Since it's running _in_ the extension, I get access to all the existing code around templates and it was easy to make backup templates like _the exact same thing_ as latest templates.

The result of this tool is here: https://github.com/microsoft/vscode-azurefunctions/pull/2113