### PR TITLE
Fix .NET sdk version check

### DIFF
--- a/src/templates/dotnet/executeDotnetTemplateCommand.ts
+++ b/src/templates/dotnet/executeDotnetTemplateCommand.ts
@@ -63,7 +63,7 @@ async function getFramework(context: IActionContext, workingDirectory: string | 
 
         const majorVersions: string[] = ['3', '2'];
         for (const majorVersion of majorVersions) {
-            const regExp: RegExp = new RegExp(`^\\s*${majorVersion}\\.`);
+            const regExp: RegExp = new RegExp(`^\\s*${majorVersion}\\.`, 'm');
             if (regExp.test(versions)) {
                 cachedFramework = `netcoreapp${majorVersion}.0`;
                 break;


### PR DESCRIPTION
Turns out we were just checking the first line of `versions`, which is problematic now that there's a new major version we don't support yet (.NET 5 preview). Here's an example of what versions would look like:
```
5.0.100-preview.5.20279.10
3.1.201 [/usr/local/share/dotnet/sdk]
5.0.100-preview.5.20279.10 [/usr/local/share/dotnet/sdk]
```

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2153