### PR TITLE
Add AppInsights sampling excluded types to host.json

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -79,7 +79,15 @@ local.settings.json`));
             return {};
         } else {
             const hostJson: IHostJsonV2 = {
-                version: '2.0'
+                version: '2.0',
+                logging: {
+                    applicationInsights: {
+                        samplingSettings: {
+                            isEnabled: true,
+                            excludedTypes: 'Request'
+                        }
+                    }
+                }
             };
 
             await bundleFeedUtils.addDefaultBundle(hostJson);

--- a/src/funcConfig/host.ts
+++ b/src/funcConfig/host.ts
@@ -7,6 +7,7 @@ import { FuncVersion } from "../FuncVersion";
 
 export interface IHostJsonV2 {
     version?: string;
+    // https://github.com/Azure/azure-functions-templates/issues/906
     logging?: {
         applicationInsights?: {
             samplingSettings?: {

--- a/src/funcConfig/host.ts
+++ b/src/funcConfig/host.ts
@@ -10,11 +10,11 @@ export interface IHostJsonV2 {
     logging?: {
         applicationInsights?: {
             samplingSettings?: {
-                isEnabled?: boolean,
-                excludedTypes?: string
-            }
-        }
-    },
+                isEnabled?: boolean;
+                excludedTypes?: string;
+            };
+        };
+    };
     managedDependency?: {
         enabled?: boolean;
     };

--- a/src/funcConfig/host.ts
+++ b/src/funcConfig/host.ts
@@ -7,6 +7,14 @@ import { FuncVersion } from "../FuncVersion";
 
 export interface IHostJsonV2 {
     version?: string;
+    logging?: {
+        applicationInsights?: {
+            samplingSettings?: {
+                isEnabled?: boolean,
+                excludedTypes?: string
+            }
+        }
+    },
     managedDependency?: {
         enabled?: boolean;
     };


### PR DESCRIPTION
Update host.json to exclude requests from sampling by default. Matches changes made to [Core Tools](https://github.com/Azure/azure-functions-core-tools/blob/5b0d1c25fa10adcc9a235579d159d7c3e4cf98ff/src/Azure.Functions.Cli/StaticResources/host.json).