### PR TITLE
Support "Execute Function" for all binding types

### DIFF
--- a/package.json
+++ b/package.json
@@ -540,7 +540,7 @@
                 },
                 {
                     "command": "azureFunctions.executeFunction",
-                    "when": "view == azFuncTree && viewItem =~ /Function;Timer;/i",
+                    "when": "view == azFuncTree && viewItem =~ /Function;/i",
                     "group": "1@1"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -33,7 +33,7 @@
     "azureFunctions.enableJavaRemoteDebugging": "Enable remote debugging for Java Functions Apps running on Windows. (experimental)",
     "azureFunctions.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "azureFunctions.enableRemoteDebugging": "Enable remote debugging for Node.js Function Apps running on Linux App Service plans. Consumption plans are not supported. (experimental)",
-    "azureFunctions.executeFunction": "Execute Function Now",
+    "azureFunctions.executeFunction": "Execute Function Now...",
     "azureFunctions.initProjectForVSCode": "Initialize Project for Use with VS Code...",
     "azureFunctions.installOrUpdateFuncCoreTools": "Install or Update Azure Functions Core Tools",
     "azureFunctions.loadMore": "Load More",

--- a/src/commands/addBinding/settingSteps/BindingSettingStepBase.ts
+++ b/src/commands/addBinding/settingSteps/BindingSettingStepBase.ts
@@ -9,6 +9,8 @@ import { getBindingSetting, setBindingSetting } from "../../createFunction/IFunc
 import { IBindingWizardContext } from "../IBindingWizardContext";
 
 export abstract class BindingSettingStepBase extends AzureWizardPromptStep<IBindingWizardContext> {
+    public supportsDuplicateSteps: boolean = true;
+
     protected readonly _setting: IBindingSetting;
 
     constructor(setting: IBindingSetting) {

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -22,14 +22,16 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
     }
 
     const client: SiteClient | undefined = node instanceof RemoteFunctionTreeItem ? node.parent.parent.root.client : undefined;
+    const triggerBindingType: string | undefined = node.config.triggerBinding?.type;
+    context.telemetry.properties.triggerBindingType = triggerBindingType;
 
     let functionInput: string | {} = '';
     if (!node.config.isTimerTrigger) {
         const prompt: string = localize('enterRequestBody', 'Enter request body');
         let value: string | undefined;
-        if (node.config.triggerBinding?.type) {
+        if (triggerBindingType) {
             const version: FuncVersion = await node.parent.parent.getVersion();
-            value = await ext.templateProvider.tryGetSampleData(context, version, node.config.triggerBinding?.type);
+            value = await ext.templateProvider.tryGetSampleData(context, version, triggerBindingType);
             if (value) {
                 // Clean up the whitespace to make it more friendly for a one-line input box
                 value = value.replace(/[\r\n\t]/g, ' ');

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -55,6 +55,7 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
         method = 'GET';
         body = functionInput;
     } else {
+        // https://docs.microsoft.com/azure/azure-functions/functions-manually-run-non-http
         url = `${node.parent.parent.hostUrl}/admin/functions/${node.name}`;
         method = 'POST';
         body = { input: functionInput };
@@ -62,7 +63,6 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
 
     let response: string | undefined;
     await node.runWithTemporaryDescription(localize('executing', 'Executing...'), async () => {
-        // https://docs.microsoft.com/azure/azure-functions/functions-manually-run-non-http
         const request: requestUtils.Request = await requestUtils.getDefaultRequestWithTimeout(url, undefined, method);
         if (client) {
             request.headers['x-functions-key'] = (await client.listHostKeys()).masterKey;

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -3,35 +3,73 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { HttpMethods } from 'ms-rest';
 import { window } from 'vscode';
 import { SiteClient } from 'vscode-azureappservice';
 import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
+import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { FunctionTreeItemBase } from '../tree/FunctionTreeItemBase';
 import { RemoteFunctionTreeItem } from '../tree/remoteProject/RemoteFunctionTreeItem';
+import { nonNullProp } from '../utils/nonNull';
 import { requestUtils } from '../utils/requestUtils';
 
 export async function executeFunction(context: IActionContext, node?: FunctionTreeItemBase): Promise<void> {
     if (!node) {
-        const noItemFoundErrorMessage: string = localize('noTimerFunctions', 'No timer functions found.');
-        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;Timer;/i, { ...context, noItemFoundErrorMessage });
+        const noItemFoundErrorMessage: string = localize('noFunctions', 'No functions found.');
+        node = await ext.tree.showTreeItemPicker<FunctionTreeItemBase>(/Function;/i, { ...context, noItemFoundErrorMessage });
     }
 
-    const name: string = node.name;
     const client: SiteClient | undefined = node instanceof RemoteFunctionTreeItem ? node.parent.parent.root.client : undefined;
-    const hostUrl: string = node.parent.parent.hostUrl;
+
+    let functionInput: string | {} = '';
+    if (!node.config.isTimerTrigger) {
+        const prompt: string = localize('enterRequestBody', 'Enter request body');
+        let value: string | undefined;
+        if (node.config.triggerBinding?.type) {
+            const version: FuncVersion = await node.parent.parent.getVersion();
+            value = await ext.templateProvider.tryGetSampleData(context, version, node.config.triggerBinding?.type);
+            if (value) {
+                // Clean up the whitespace to make it more friendly for a one-line input box
+                value = value.replace(/[\r\n\t]/g, ' ');
+                value = value.replace(/ +/g, ' ');
+            }
+        }
+
+        const data: string = await ext.ui.showInputBox({ prompt, value });
+        try {
+            functionInput = <{}>JSON.parse(data);
+        } catch {
+            functionInput = data;
+        }
+    }
+
+    let url: string;
+    let method: HttpMethods;
+    let body: {};
+    if (node.config.isHttpTrigger) {
+        url = nonNullProp(node, 'triggerUrl');
+        method = 'GET';
+        body = functionInput;
+    } else {
+        url = `${node.parent.parent.hostUrl}/admin/functions/${node.name}`;
+        method = 'POST';
+        body = { input: functionInput };
+    }
+
+    let response: string | undefined;
     await node.runWithTemporaryDescription(localize('executing', 'Executing...'), async () => {
         // https://docs.microsoft.com/azure/azure-functions/functions-manually-run-non-http
-        const request: requestUtils.Request = await requestUtils.getDefaultRequestWithTimeout(`${hostUrl}/admin/functions/${name}`, undefined, 'POST');
+        const request: requestUtils.Request = await requestUtils.getDefaultRequestWithTimeout(url, undefined, method);
         if (client) {
             request.headers['x-functions-key'] = (await client.listHostKeys()).masterKey;
         }
         request.headers['Content-Type'] = 'application/json';
-        request.body = { input: '' };
+        request.body = body;
         request.json = true;
         try {
-            await requestUtils.sendRequest(request);
+            response = await requestUtils.sendRequest(request);
         } catch (error) {
             if (!client && parseError(error).errorType === 'ECONNREFUSED') {
                 context.errorHandling.suppressReportIssue = true;
@@ -42,5 +80,6 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
         }
     });
 
-    window.showInformationMessage(localize('executed', 'Executed function "{0}"', name));
+    const message: string = response ? localize('executedWithResponse', 'Executed function "{0}". Response: "{1}"', node.name, response) : localize('executed', 'Executed function "{0}"', node.name);
+    window.showInformationMessage(message);
 }

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -16,6 +16,7 @@ import { ITemplates } from './ITemplates';
 import { getJavaVerifiedTemplateIds } from './java/getJavaVerifiedTemplateIds';
 import { JavaTemplateProvider } from './java/JavaTemplateProvider';
 import { getScriptVerifiedTemplateIds } from './script/getScriptVerifiedTemplateIds';
+import { IScriptFunctionTemplate } from './script/parseScriptTemplates';
 import { ScriptBundleTemplateProvider } from './script/ScriptBundleTemplateProvider';
 import { ScriptTemplateProvider } from './script/ScriptTemplateProvider';
 import { TemplateProviderBase } from './TemplateProviderBase';
@@ -66,6 +67,16 @@ export class CentralTemplateProvider {
     public async getBindingTemplates(context: IActionContext, projectPath: string | undefined, language: ProjectLanguage, version: FuncVersion): Promise<IBindingTemplate[]> {
         const templates: ITemplates = await this.getTemplates(context, projectPath, language, version);
         return templates.bindingTemplates;
+    }
+
+    public async tryGetSampleData(context: IActionContext, version: FuncVersion, triggerBindingType: string): Promise<string | undefined> {
+        try {
+            const templates: IScriptFunctionTemplate[] = <IScriptFunctionTemplate[]>await this.getFunctionTemplates(context, undefined, ProjectLanguage.JavaScript, version, TemplateFilter.All);
+            const template: IScriptFunctionTemplate | undefined = templates.find(t => t.functionJson.triggerBinding?.type?.toLowerCase() === triggerBindingType.toLowerCase());
+            return template?.templateFiles['sample.dat'];
+        } catch {
+            return undefined;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1390

We originally discussed leveraging ".http" files, but that gets a bit dicey in terms of authentication - I don't want to put the key directly in the file as plain text and other methods (i.e. environment variables) were non-trivial. Instead, I followed the exact same pattern already established for timer triggers, just with a prompt for the request body. The default value comes from the "sample.dat" file included with each template. The biggest downside is the input box itself (since it can't display much content), but I think it's OK for the time being. People can always copy/paste the value into a file to edit more easily.

Here's a few examples with the default value from "sample.dat":

Http Trigger:
<img width="229" alt="Screen Shot 2020-06-29 at 2 45 03 PM" src="https://user-images.githubusercontent.com/11282622/86060384-78b07380-ba19-11ea-8420-7979aa3e4877.png">
<img width="456" alt="Screen Shot 2020-06-29 at 2 46 02 PM" src="https://user-images.githubusercontent.com/11282622/86060388-79490a00-ba19-11ea-9890-24333d0c65f4.png">

Blob trigger (the path to the blob):
<img width="349" alt="Screen Shot 2020-06-29 at 2 44 38 PM" src="https://user-images.githubusercontent.com/11282622/86060375-764e1980-ba19-11ea-8071-db868d9b6ff5.png">

Cosmos DB Trigger (an array of documents):
<img width="271" alt="Screen Shot 2020-06-29 at 2 44 46 PM" src="https://user-images.githubusercontent.com/11282622/86060378-777f4680-ba19-11ea-9afe-b3c5e5356c50.png">

Event grid trigger (as mentioned - not the best for an input box):
<img width="632" alt="Screen Shot 2020-06-29 at 2 44 57 PM" src="https://user-images.githubusercontent.com/11282622/86060381-7817dd00-ba19-11ea-9d36-2229520b8590.png">