### PR TITLE
Update "func-watch" to reflect new message

### DIFF
--- a/package.json
+++ b/package.json
@@ -790,7 +790,7 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
-                    "endsPattern": "^.*Host lock lease acquired by instance ID.*$"
+                    "endsPattern": "^.*(Worker process started and initialized|Host lock lease acquired by instance ID).*$"
                 },
                 "severity": "error"
             }


### PR DESCRIPTION
See https://github.com/Azure/azure-functions-host/issues/4384 - the new message is a more accurate/reliable representation of when we can attach the debugger. It should always print _before_ the "host lock lease" message, so easy enough to check for both and maintain backwards compatibility.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1841
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1492