### PR TITLE
Fix call to get host settings on linux consumption

### DIFF
--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementModels } from 'azure-arm-website';
-import { AppSettingsTreeItem, AppSettingTreeItem, deleteSite, DeploymentsTreeItem, DeploymentTreeItem, ISiteTreeRoot, LogFilesTreeItem, SiteClient, SiteFilesTreeItem } from 'vscode-azureappservice';
+import { AppSettingsTreeItem, AppSettingTreeItem, deleteSite, DeploymentsTreeItem, DeploymentTreeItem, getFile, ISiteTreeRoot, LogFilesTreeItem, SiteClient, SiteFilesTreeItem } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureParentTreeItem, TreeItemIconPath } from 'vscode-azureextensionui';
-import { KuduClient } from 'vscode-azurekudu';
 import { IParsedHostJson, parseHostJson } from '../funcConfig/host';
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersion';
 import { treeUtils } from '../utils/treeUtils';
@@ -118,8 +117,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
             // tslint:disable-next-line: no-any
             let data: any;
             try {
-                const kuduClient: KuduClient = await this.root.client.getKuduClient();
-                data = await kuduClient.functionModel.getHostSettings();
+                data = JSON.parse((await getFile(this.client, 'site/wwwroot/host.json')).data);
             } catch {
                 // ignore and use default
             }


### PR DESCRIPTION
Linux consumption doesn't have full kudu support, so `getHostSettings` wasn't working. In combination with [this PR](https://github.com/microsoft/vscode-azuretools/pull/762), I can now just get the 'host.json' file directly and that should work for all plans. This fixes https://github.com/microsoft/vscode-azurefunctions/issues/2135, where we were always using the default route prefix ('api') for http trigger urls instead of reading the route prefix from the host settings.
