### PR TITLE
Improve how we handle extensions.csproj

### DIFF
--- a/package.json
+++ b/package.json
@@ -919,6 +919,11 @@
                         "description": "%azureFunctions.showTargetFrameworkWarning%",
                         "default": true
                     },
+                    "azureFunctions.showExtensionsCsprojWarning": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.showExtensionsCsprojWarning%",
+                        "default": true
+                    },
                     "azureFunctions.pickProcessTimeout": {
                         "type": "integer",
                         "description": "%azureFunctions.pickProcessTimeout%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -67,6 +67,7 @@
     "azureFunctions.showProjectWarning": "Show a warning when an Azure Functions project was detected that has not been initialized for use in VS Code.",
     "azureFunctions.showPythonVenvWarning": "Show a warning when an Azure Functions Python project was detected that does not have a virtual environment.",
     "azureFunctions.showTargetFrameworkWarning": "Show a warning when an Azure Functions .NET project was detected that has mismatched target frameworks.",
+    "azureFunctions.showExtensionsCsprojWarning": "Show a warning when an Azure Functions project was detected that has mismatched \"extensions.csproj\" configuration.",
     "azureFunctions.startFunctionApp": "Start",
     "azureFunctions.startJavaRemoteDebug": "Attach Debugger",
     "azureFunctions.startRemoteDebug": "Start Remote Debugging",

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as semver from 'semver';
 import { TaskDefinition } from 'vscode';
-import { extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand } from '../../../constants';
+import { extensionsCsprojFileName, extInstallTaskName, func, funcWatchProblemMatcher, hostStartCommand } from '../../../constants';
 import { getLocalFuncCoreToolsVersion } from '../../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { FuncVersion } from '../../../FuncVersion';
 import { IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
@@ -33,7 +33,7 @@ export class ScriptInitVSCodeStep extends InitVSCodeStepBase {
 
     protected async executeCore(context: IProjectWizardContext): Promise<void> {
         try {
-            const extensionsCsprojPath: string = path.join(context.projectPath, 'extensions.csproj');
+            const extensionsCsprojPath: string = path.join(context.projectPath, extensionsCsprojFileName);
             if (await fse.pathExists(extensionsCsprojPath)) {
                 this.useFuncExtensionsInstall = true;
                 context.telemetry.properties.hasExtensionsCsproj = 'true';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,7 @@ export const settingsFileName: string = 'settings.json';
 export const vscodeFolderName: string = '.vscode';
 export const gitignoreFileName: string = '.gitignore';
 export const requirementsFileName: string = 'requirements.txt';
+export const extensionsCsprojFileName: string = 'extensions.csproj';
 
 export enum PackageManager {
     npm = 'npm',

--- a/src/utils/verifyExtensionBundle.ts
+++ b/src/utils/verifyExtensionBundle.ts
@@ -29,7 +29,7 @@ export async function verifyExtensionBundle(context: IFunctionWizardContext | IB
         return;
     }
 
-    // Old projects setup to use "func extensions install" shouldn't use a bundle because it could lead to duplicate or conflicting binaries
+    // Don't use bundle if set up to use "extensions.csproj". More discussion here: https://github.com/microsoft/vscode-azurefunctions/issues/1698
     if (await hasExtensionsVSCodeConfig(context, context.workspacePath) || await hasExtensionsCsproj(context, context.projectPath)) {
         context.telemetry.properties.bundleResult = 'hasExtensionsConfig';
     } else {

--- a/src/utils/verifyExtensionBundle.ts
+++ b/src/utils/verifyExtensionBundle.ts
@@ -5,20 +5,34 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { parseError } from 'vscode-azureextensionui';
+import { IActionContext, parseError } from 'vscode-azureextensionui';
 import { IBindingWizardContext } from '../commands/addBinding/IBindingWizardContext';
 import { IFunctionWizardContext } from '../commands/createFunction/IFunctionWizardContext';
-import { extInstallCommand, hostFileName, ProjectLanguage, settingsFileName, tasksFileName, vscodeFolderName } from '../constants';
+import { extensionsCsprojFileName, extInstallCommand, hostFileName, ProjectLanguage, settingsFileName, tasksFileName, vscodeFolderName } from '../constants';
 import { IHostJsonV2 } from '../funcConfig/host';
 import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { IBindingTemplate } from '../templates/IBindingTemplate';
 import { IFunctionTemplate } from '../templates/IFunctionTemplate';
+import { promptToReinitializeProject } from '../vsCodeConfig/promptToReinitializeProject';
 import { bundleFeedUtils } from './bundleFeedUtils';
 import { writeFormattedJson } from './fs';
 
 export async function verifyExtensionBundle(context: IFunctionWizardContext | IBindingWizardContext, template: IFunctionTemplate | IBindingTemplate): Promise<void> {
-    if (await shouldUseExtensionBundle(context, template)) {
+    // v1 doesn't support bundles
+    // http and timer triggers don't need a bundle
+    // F# and C# specify extensions as dependencies in their proj file instead of using a bundle
+    if (context.version === FuncVersion.v1 ||
+        !bundleFeedUtils.isBundleTemplate(template) ||
+        context.language === ProjectLanguage.CSharp || context.language === ProjectLanguage.FSharp) {
+        context.telemetry.properties.bundleResult = 'n/a';
+        return;
+    }
+
+    // Old projects setup to use "func extensions install" shouldn't use a bundle because it could lead to duplicate or conflicting binaries
+    if (await hasExtensionsVSCodeConfig(context, context.workspacePath) || await hasExtensionsCsproj(context, context.projectPath)) {
+        context.telemetry.properties.bundleResult = 'hasExtensionsConfig';
+    } else {
         const hostFilePath: string = path.join(context.projectPath, hostFileName);
         let hostJson: IHostJsonV2;
         try {
@@ -28,37 +42,52 @@ export async function verifyExtensionBundle(context: IFunctionWizardContext | IB
         }
 
         if (!hostJson.extensionBundle) {
+            context.telemetry.properties.bundleResult = 'addedBundle';
             await bundleFeedUtils.addDefaultBundle(hostJson);
             await writeFormattedJson(hostFilePath, hostJson);
+        } else {
+            context.telemetry.properties.bundleResult = 'alreadyHasBundle';
         }
     }
 }
 
-async function shouldUseExtensionBundle(context: IFunctionWizardContext, template: IFunctionTemplate | IBindingTemplate): Promise<boolean> {
-    // v1 doesn't support bundles
-    // http and timer triggers don't need a bundle
-    // F# and C# specify extensions as dependencies in their proj file instead of using a bundle
-    if (context.version === FuncVersion.v1 ||
-        !bundleFeedUtils.isBundleTemplate(template) ||
-        context.language === ProjectLanguage.CSharp || context.language === ProjectLanguage.FSharp) {
-        return false;
+export async function verifyExtensionsConfig(context: IActionContext, workspacePath: string, projectPath: string): Promise<void> {
+    if (await hasExtensionsCsproj(context, projectPath) && !await hasExtensionsVSCodeConfig(context, workspacePath)) {
+        const message: string = localize('mismatchExtensionsCsproj', 'Your project is not configured to work with "extensions.csproj".');
+        await promptToReinitializeProject(projectPath, 'showExtensionsCsprojWarning', message, 'https://aka.ms/AA8wo2c', context);
     }
+}
 
-    // Old projects setup to use "func extensions install" shouldn't use a bundle because it could lead to duplicate or conflicting binaries
+async function hasExtensionsVSCodeConfig(context: IActionContext, workspacePath: string): Promise<boolean> {
+    let result: boolean = false;
     try {
         const filesToCheck: string[] = [tasksFileName, settingsFileName];
         for (const file of filesToCheck) {
-            const filePath: string = path.join(context.workspacePath, vscodeFolderName, file);
+            const filePath: string = path.join(workspacePath, vscodeFolderName, file);
             if (await fse.pathExists(filePath)) {
                 const contents: string = (await fse.readFile(filePath)).toString();
                 if (contents.includes(extInstallCommand)) {
-                    return false;
+                    result = true;
+                    break;
                 }
             }
         }
     } catch {
-        // ignore and use bundles (the default for new projects)
+        // ignore and use default
     }
 
-    return true;
+    context.telemetry.properties.hasExtensionsVSCodeConfig = String(result);
+    return result;
+}
+
+async function hasExtensionsCsproj(context: IActionContext, projectPath: string): Promise<boolean> {
+    let result: boolean = false;
+    try {
+        result = await fse.pathExists(path.join(projectPath, extensionsCsprojFileName));
+    } catch {
+        // ignore and use default
+    }
+
+    context.telemetry.properties.hasExtensionsCsproj = String(result);
+    return result;
 }

--- a/src/vsCodeConfig/promptToReinitializeProject.ts
+++ b/src/vsCodeConfig/promptToReinitializeProject.ts
@@ -5,11 +5,12 @@
 
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { initProjectForVSCode } from '../commands/initProjectForVSCode/initProjectForVSCode';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
 import { getWorkspaceSetting, updateWorkspaceSetting } from './settings';
 
-export async function promptToReinitializeProject(fsPath: string, settingKey: string, message: string, learnMoreLink: string, context: IActionContext): Promise<boolean> {
+export async function promptToReinitializeProject(fsPath: string, settingKey: string, message: string, learnMoreLink: string, context: IActionContext): Promise<void> {
     if (getWorkspaceSetting<boolean>(settingKey)) {
         const updateConfig: vscode.MessageItem = { title: localize('reinit', 'Reinitialize Project') };
         const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, { learnMoreLink }, updateConfig, DialogResponses.dontWarnAgain);
@@ -18,11 +19,9 @@ export async function promptToReinitializeProject(fsPath: string, settingKey: st
             await updateWorkspaceSetting(settingKey, false, fsPath);
         } else {
             context.telemetry.properties.verifyConfigResult = 'update';
-            return true;
+            await initProjectForVSCode(context, fsPath);
         }
     } else {
         context.telemetry.properties.verifyConfigResult = 'suppressed';
     }
-
-    return false;
 }

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -12,6 +12,7 @@ import { funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../
 import { ext } from '../extensionVariables';
 import { FuncVersion, tryParseFuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
+import { verifyExtensionsConfig } from '../utils/verifyExtensionBundle';
 import { getWorkspaceSetting, updateGlobalSetting } from './settings';
 import { verifyPythonVenv } from './verifyPythonVenv';
 import { verifyTargetFramework } from './verifyTargetFramework';
@@ -39,6 +40,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
                         await ext.templateProvider.getFunctionTemplates(templatesContext, projectPath, language, version);
                     });
 
+                    let isDotnet: boolean = false;
                     const projectLanguage: string | undefined = getWorkspaceSetting(projectLanguageSetting, workspacePath);
                     context.telemetry.properties.projectLanguage = projectLanguage;
                     switch (projectLanguage) {
@@ -47,9 +49,14 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
                             break;
                         case ProjectLanguage.CSharp:
                         case ProjectLanguage.FSharp:
+                            isDotnet = true;
                             await verifyTargetFramework(projectLanguage, folder, projectPath, context);
                             break;
                         default:
+                    }
+
+                    if (!isDotnet) {
+                        await verifyExtensionsConfig(context, workspacePath, projectPath);
                     }
                 } else {
                     await promptToInitializeProject(workspacePath, context);


### PR DESCRIPTION
1. Don't add extension bundle during 'Create Function' if 'extensions.csproj' exists
1. Prompt users to update their VS Code config if they have 'extensions.csproj', but the config doesn't reflect that

Also added some telemetry to just get more info on this situation.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1698