### PR TITLE
Add PoliCheck to build definition

### DIFF
--- a/.azure-pipelines/compliance/PoliCheckExclusions.xml
+++ b/.azure-pipelines/compliance/PoliCheckExclusions.xml
@@ -1,0 +1,10 @@
+<PoliCheckExclusions>
+    <!--Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
+    <Exclusion Type="FolderPathFull">NODE_MODULES|BACKUPTEMPLATES</Exclusion>
+    <!--Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
+    <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+    <!--Each of these file types will be completely skipped for the entire scan -->
+    <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+    <!--The specified file names will be skipped during the scan regardless which folder they are in -->
+    <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
+</PoliCheckExclusions>

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -1,0 +1,18 @@
+steps:
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F # search files and folders
+    optionsUEPATH: '$(Build.SourcesDirectory)/.azure-pipelines/compliance/PoliCheckExclusions.xml'
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: 'Post Analysis'
+  inputs:
+    AllTools: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -1,6 +1,7 @@
 variables:
   ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
     ENABLE_LONG_RUNNING_TESTS: true
+    ENABLE_COMPLIANCE: true
 
 jobs:
 - job: Windows
@@ -9,6 +10,7 @@ jobs:
   steps:
   - template: common/build.yml
   - template: common/lint.yml
+  - template: compliance/compliance.yml # Only works on Windows
   - template: common/test.yml
 
 - job: Linux


### PR DESCRIPTION
Part of compliance work we need to do before we can GA. This tool ensures we're not using bad words 😬 

I've got this off by default for PR/branch builds, and on by default for nightly builds.