### PR TITLE
Fix open in portal for deployment node

### DIFF
--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureTreeItem, IActionContext } from 'vscode-azureextensionui';
+import { AzureTreeItem, IActionContext, openInPortal as uiOpenInPortal } from 'vscode-azureextensionui';
 import { ext } from '../extensionVariables';
 import { ProductionSlotTreeItem } from '../tree/ProductionSlotTreeItem';
 
@@ -12,5 +12,5 @@ export async function openInPortal(context: IActionContext, node?: AzureTreeItem
         node = await ext.tree.showTreeItemPicker<AzureTreeItem>(ProductionSlotTreeItem.contextValue, context);
     }
 
-    await node.openInPortal();
+    await uiOpenInPortal(node, node.fullId);
 }


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/724, DeploymentTreeItem isn't an AzureTreeItem anymore, so openInPortal doesn't exist on it

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2274