### PR TITLE
Clean up logic for getting feeds

### DIFF
--- a/src/utils/feedUtils.ts
+++ b/src/utils/feedUtils.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { HttpOperationResponse } from '@azure/ms-rest-js';
+import { nonNullProp } from './nonNull';
+import { parseJson } from './parseJson';
 import { requestUtils } from './requestUtils';
 
 export namespace feedUtils {
@@ -23,7 +25,8 @@ export namespace feedUtils {
         let cachedFeed: ICachedFeed | undefined = cachedFeeds.get(url);
         if (!cachedFeed || Date.now() > cachedFeed.nextRefreshTime) {
             const response: HttpOperationResponse = await requestUtils.sendRequestWithTimeout({ method: 'GET', url });
-            cachedFeed = { data: <T>response.parsedBody, nextRefreshTime: Date.now() + 10 * 60 * 1000 };
+            // NOTE: r.parsedBody doesn't work because these feeds sometimes return with a BOM char or incorrect content-type
+            cachedFeed = { data: parseJson(nonNullProp(response, 'bodyAsText')), nextRefreshTime: Date.now() + 10 * 60 * 1000 };
             cachedFeeds.set(url, cachedFeed);
         }
 

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -26,7 +26,7 @@ export namespace requestUtils {
 
         try {
             const client: ServiceClient = createGenericClient();
-            return await client.sendRequest(options);
+            return await client.sendRequest(request);
         } catch (error) {
             if (parseError(error).errorType === 'REQUEST_ABORTED_ERROR') {
                 throw new Error(localize('timeoutFeed', 'Request timed out. Modify setting "{0}.{1}" if you want to extend the timeout.', ext.prefix, timeoutKey));


### PR DESCRIPTION
There was a problem with the staging bundle feed causing tests to fail. Turns out the functions team will fix it on their end, but I did some investigating in the mean time and came up with a little bit of code cleanup on our side, mainly consolidating around feedUtils for all feeds.