### PR TITLE
Add cred scan to nightly build

### DIFF
--- a/.azure-pipelines/compliance/CredScanSuppressions.json
+++ b/.azure-pipelines/compliance/CredScanSuppressions.json
@@ -1,0 +1,13 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "folder": "node_modules\\",
+            "_justification": "No need to scan external node modules."
+        },
+        {
+            "folder": "resources\\backupTemplates\\",
+            "_justification": "No need to scan backup templates."
+        }
+    ]
+}

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -7,6 +7,16 @@ steps:
   continueOnError: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    toolMajorVersion: V2
+    suppressionsFile: '$(Build.SourcesDirectory)/.azure-pipelines/compliance/CredScanSuppressions.json'
+    debugMode: true # Needed to suppress folders
+    folderSuppression: true
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
   displayName: 'Publish Security Analysis Logs'
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')


### PR DESCRIPTION
Part of compliance work we need to do before we can GA. This tool helps ensure we're not storing credentials (passwords, private certificate stuff, etc.) in source control