### PR TITLE
Default new projects to PowerShell 7 and remove "Preview" flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -859,7 +859,7 @@
                             "%azureFunctions.projectLanguage.preview%",
                             "",
                             "",
-                            "%azureFunctions.projectLanguage.preview%",
+                            "",
                             "",
                             ""
                         ]

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -39,7 +39,6 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
     }
 
     public async prompt(context: IProjectWizardContext): Promise<void> {
-        const previewDescription: string = localize('previewDescription', '(Preview)');
         // Only display 'supported' languages that can be debugged in VS Code
         let languagePicks: IAzureQuickPickItem<ProjectLanguage | undefined>[] = [
             { label: ProjectLanguage.JavaScript, data: ProjectLanguage.JavaScript },
@@ -47,7 +46,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.CSharp, data: ProjectLanguage.CSharp },
             { label: ProjectLanguage.Python, data: ProjectLanguage.Python },
             { label: ProjectLanguage.Java, data: ProjectLanguage.Java },
-            { label: ProjectLanguage.PowerShell, description: previewDescription, data: ProjectLanguage.PowerShell }
+            { label: ProjectLanguage.PowerShell, data: ProjectLanguage.PowerShell }
         ];
 
         languagePicks.push({ label: localize('viewSamples', '$(link-external) View sample projects'), data: undefined, suppressPersistence: true });

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -6,9 +6,14 @@
 import { HttpOperationResponse } from '@azure/ms-rest-js';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import * as semver from 'semver';
 import { Progress } from 'vscode';
+import { workerRuntimeVersionKey } from '../../../constants';
+import { getLocalFuncCoreToolsVersion } from '../../../funcCoreTools/getLocalFuncCoreToolsVersion';
+import { FuncVersion } from '../../../FuncVersion';
 import { localize } from '../../../localize';
 import { confirmOverwriteFile } from "../../../utils/fs";
+import { nonNullProp } from '../../../utils/nonNull';
 import { requestUtils } from '../../../utils/requestUtils';
 import { IProjectWizardContext } from '../IProjectWizardContext';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
@@ -63,6 +68,11 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
     private readonly azModuleGalleryUrl: string = `https://aka.ms/PwshPackageInfo?id='${this.azModuleName}'`;
 
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        if (await this.supportsPowerShell7(context)) {
+            // tslint:disable-next-line:no-non-null-assertion
+            this.localSettingsJson.Values![workerRuntimeVersionKey] = '~7';
+        }
+
         await super.executeCore(context, progress);
 
         const profileps1Path: string = path.join(context.projectPath, profileps1FileName);
@@ -125,5 +135,24 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
 
         // If no version is found, throw exception
         throw new Error(`Failed to parse latest Az module version ${response.bodyAsText}`);
+    }
+
+    private async supportsPowerShell7(context: IProjectWizardContext): Promise<boolean> {
+        const version: FuncVersion = nonNullProp(context, 'version');
+        let supportsPs7: boolean = true;
+        if (version === FuncVersion.v1 || version === FuncVersion.v2) {
+            supportsPs7 = false;
+        } else if (version === FuncVersion.v3) {
+            try {
+                const localCliVersion: string | null = await getLocalFuncCoreToolsVersion();
+                if (localCliVersion) {
+                    supportsPs7 = semver.gte(localCliVersion, '3.0.2534');
+                }
+            } catch {
+                // use default
+            }
+        }
+
+        return supportsPs7;
     }
 }

--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -22,6 +22,12 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
     protected funcignore: string[] = ['.git*', '.vscode', 'local.settings.json', 'test'];
     protected gitignore: string = '';
     protected supportsManagedDependencies: boolean = false;
+    protected localSettingsJson: ILocalSettingsJson = {
+        IsEncrypted: false,
+        Values: {
+            AzureWebJobsStorage: ''
+        }
+    };
 
     public async executeCore(context: IProjectWizardContext, _progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const version: FuncVersion = nonNullProp(context, 'version');
@@ -33,20 +39,13 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
 
         const localSettingsJsonPath: string = path.join(context.projectPath, localSettingsFileName);
         if (await confirmOverwriteFile(localSettingsJsonPath)) {
-            const localSettingsJson: ILocalSettingsJson = {
-                IsEncrypted: false,
-                Values: {
-                    AzureWebJobsStorage: ''
-                }
-            };
-
             const functionsWorkerRuntime: string | undefined = getFunctionsWorkerRuntime(context.language);
             if (functionsWorkerRuntime) {
                 // tslint:disable-next-line:no-non-null-assertion
-                localSettingsJson.Values![workerRuntimeKey] = functionsWorkerRuntime;
+                this.localSettingsJson.Values![workerRuntimeKey] = functionsWorkerRuntime;
             }
 
-            await writeFormattedJson(localSettingsJsonPath, localSettingsJson);
+            await writeFormattedJson(localSettingsJsonPath, this.localSettingsJson);
         }
 
         const proxiesJsonPath: string = path.join(context.projectPath, proxiesFileName);

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -22,7 +22,6 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
     public hideStepCount: boolean = true;
 
     public async prompt(context: IProjectWizardContext): Promise<void> {
-        const previewDescription: string = localize('previewDescription', '(Preview)');
         // Display all languages, even if we don't have full support for them
         const languagePicks: QuickPickItem[] = [
             { label: ProjectLanguage.CSharp },
@@ -31,7 +30,7 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.FSharpScript },
             { label: ProjectLanguage.Java },
             { label: ProjectLanguage.JavaScript },
-            { label: ProjectLanguage.PowerShell, description: previewDescription },
+            { label: ProjectLanguage.PowerShell },
             { label: ProjectLanguage.Python },
             { label: ProjectLanguage.TypeScript }
         ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,6 +82,7 @@ export const tsConfigFileName: string = 'tsconfig.json';
 export const localEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
 
 export const workerRuntimeKey: string = 'FUNCTIONS_WORKER_RUNTIME';
+export const workerRuntimeVersionKey: string = 'FUNCTIONS_WORKER_RUNTIME_VERSION';
 export const extensionVersionKey: string = 'FUNCTIONS_EXTENSION_VERSION';
 export const runFromPackageKey: string = 'WEBSITE_RUN_FROM_PACKAGE';
 export const contentConnectionStringKey: string = 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING';


### PR DESCRIPTION
As long as their local func cli supports it - we want new projects on PowerShell 7. Also, I confirmed PowerShell 7 fixed our main concerns around debugging, so we can remove "Preview" from the "New Project" quick pick.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/1866
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1966
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1661
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/1660