### PR TITLE
Pull in latest function stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -849,7 +849,8 @@
                             "JavaScript",
                             "PowerShell",
                             "Python",
-                            "TypeScript"
+                            "TypeScript",
+                            "Custom"
                         ],
                         "description": "%azureFunctions.projectLanguage%",
                         "enumDescriptions": [
@@ -861,7 +862,8 @@
                             "",
                             "",
                             "",
-                            ""
+                            "",
+                            "%azureFunctions.projectLanguage.preview%"
                         ]
                     },
                     "azureFunctions.deploySubpath": {

--- a/src/commands/createFunctionApp/functionStacks.ts
+++ b/src/commands/createFunctionApp/functionStacks.ts
@@ -21,6 +21,8 @@ export interface IFunctionStackMajorVersion {
     runtimeVersion: string | undefined;
     appSettingsDictionary: { [key: string]: string };
     siteConfigPropertiesDictionary: {};
+    isDeprecated: boolean;
+    isPreview: boolean;
     isHidden: boolean;
 }
 
@@ -226,6 +228,41 @@ const linuxFunctionsStacks: string = `{
                             "linuxFxVersion": "Python|3.8"
                         },
                         "isPreview": false,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
+            "name": "Custom",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=LinuxFunctions",
+            "properties": {
+                "name": "Custom",
+                "display": "Custom",
+                "dependency": null,
+                "majorVersions": [
+                    {
+                        "displayVersion": "Custom Handler",
+                        "runtimeVersion": "",
+                        "supportedFunctionsExtensionVersions": [
+                            "~2",
+                            "~3"
+                        ],
+                        "isDefault": false,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "custom"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": false,
+                            "linuxFxVersion": ""
+                        },
+                        "isPreview": true,
                         "isDeprecated": false,
                         "isHidden": false
                     }
@@ -474,6 +511,39 @@ const windowsFunctionsStacks: string = `{
         },
         {
             "id": null,
+            "name": "custom",
+            "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
+            "properties": {
+                "name": "Custom",
+                "display": "Custom",
+                "dependency": null,
+                "majorVersions": [
+                    {
+                        "displayVersion": "Custom Handler",
+                        "runtimeVersion": "Custom",
+                        "supportedFunctionsExtensionVersions": [
+                            "~3", "~2"
+                        ],
+                        "isDefault": true,
+                        "minorVersions": [],
+                        "applicationInsights": true,
+                        "appSettingsDictionary": {
+                            "FUNCTIONS_WORKER_RUNTIME": "custom"
+                        },
+                        "siteConfigPropertiesDictionary": {
+                            "use32BitWorkerProcess": true
+                        },
+                        "isPreview": true,
+                        "isDeprecated": false,
+                        "isHidden": false
+                    }
+                ],
+                "frameworks": [],
+                "isDeprecated": null
+            }
+        },
+        {
+            "id": null,
             "name": "java",
             "type": "Microsoft.Web/availableStacks?osTypeSelected=WindowsFunctions",
             "properties": {
@@ -554,7 +624,7 @@ const windowsFunctionsStacks: string = `{
                             "use32BitWorkerProcess": true
                         },
                         "isPreview": false,
-                        "isDeprecated": false,
+                        "isDeprecated": true,
                         "isHidden": false
                     },
                     {

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -32,7 +32,8 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.JavaScript },
             { label: ProjectLanguage.PowerShell },
             { label: ProjectLanguage.Python },
-            { label: ProjectLanguage.TypeScript }
+            { label: ProjectLanguage.TypeScript },
+            { label: ProjectLanguage.Custom }
         ];
 
         const options: QuickPickOptions = { placeHolder: localize('selectLanguage', "Select your project's language") };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,8 @@ export enum ProjectLanguage {
     JavaScript = 'JavaScript',
     PowerShell = 'PowerShell',
     Python = 'Python',
-    TypeScript = 'TypeScript'
+    TypeScript = 'TypeScript',
+    Custom = 'Custom'
 }
 
 export enum TemplateFilter {

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -76,6 +76,8 @@ export function getFunctionsWorkerRuntime(language: string | undefined): string 
             return 'python';
         case ProjectLanguage.PowerShell:
             return 'powershell';
+        case ProjectLanguage.Custom:
+            return 'custom';
         default:
             return undefined;
     }


### PR DESCRIPTION
Pulled over the latest stacks from here: https://github.com/pragnagopa/azure-functions-supported-runtime-stacks

It has two main changes:
1. PowerShell 6 is marked as deprecated. I added logic to show "(Deprecated)" in the quick pick. Related to https://github.com/microsoft/vscode-azurefunctions/issues/2266
1. Added Custom Handlers. I added logic to unblock users from deploying these types of project. Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2175 (I tested with the app mentioned in that issue). This experience is still marked as Preview and the "New Project" support is tracked separately (https://github.com/microsoft/vscode-azurefunctions/issues/2176)

If user does Advanced create, they will see all these options:
<img width="472" alt="Screen Shot 2020-08-20 at 2 07 31 PM" src="https://user-images.githubusercontent.com/11282622/90825968-8df5a000-e2ee-11ea-9d84-6d0b80a860f1.png">