### PR TITLE
Rename JavaVersion -> JavaProjectVersion

### DIFF
--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -17,7 +17,7 @@ import { JavaAppNameStep } from './javaSteps/JavaAppNameStep';
 import { JavaArtifactIdStep } from './javaSteps/JavaArtifactIdStep';
 import { JavaGroupIdStep } from './javaSteps/JavaGroupIdStep';
 import { JavaPackageNameStep } from './javaSteps/JavaPackageNameStep';
-import { JavaVersionStep } from './javaSteps/JavaVersionStep';
+import { JavaProjectVersionStep } from './javaSteps/JavaProjectVersionStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
 import { JavaProjectCreateStep } from './ProjectCreateStep/JavaProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
@@ -95,7 +95,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 executeSteps.push(new PowerShellProjectCreateStep());
                 break;
             case ProjectLanguage.Java:
-                promptSteps.push(new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
+                promptSteps.push(new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
                 executeSteps.push(await JavaProjectCreateStep.createStep(context));
                 break;
             default:

--- a/src/commands/createNewProject/ProjectCreateStep/JavaProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaProjectCreateStep.ts
@@ -40,7 +40,7 @@ export class JavaProjectCreateStep extends ProjectCreateStepBase {
                 mavenUtils.formatMavenArg('DarchetypeArtifactId', 'azure-functions-archetype'),
                 mavenUtils.formatMavenArg('DgroupId', nonNullProp(context, 'javaGroupId')),
                 mavenUtils.formatMavenArg('DartifactId', artifactId),
-                mavenUtils.formatMavenArg('Dversion', nonNullProp(context, 'javaVersion')),
+                mavenUtils.formatMavenArg('Dversion', nonNullProp(context, 'javaProjectVersion')),
                 mavenUtils.formatMavenArg('Dpackage', nonNullProp(context, 'javaPackageName')),
                 mavenUtils.formatMavenArg('DappName', nonNullProp(context, 'javaAppName')),
                 '-B' // in Batch Mode

--- a/src/commands/createNewProject/javaSteps/IJavaProjectWizardContext.ts
+++ b/src/commands/createNewProject/javaSteps/IJavaProjectWizardContext.ts
@@ -10,7 +10,7 @@ import { IProjectWizardContext } from "../IProjectWizardContext";
 export interface IJavaProjectWizardContext extends IProjectWizardContext {
     javaGroupId?: string;
     javaArtifactId?: string;
-    javaVersion?: string;
+    javaProjectVersion?: string;
     javaPackageName?: string;
     javaAppName?: string;
 }

--- a/src/commands/createNewProject/javaSteps/JavaProjectVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaProjectVersionStep.ts
@@ -9,17 +9,17 @@ import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
 
-export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
+export class JavaProjectVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
     public async prompt(context: IJavaProjectWizardContext): Promise<void> {
         const options: InputBoxOptions = {
             placeHolder: localize('versionPlaceHolder', 'Version'),
-            prompt: localize('versionPrompt', 'Provide a version'),
+            prompt: localize('versionPrompt', 'Provide a version for your project'),
             value: '1.0-SNAPSHOT'
         };
-        context.javaVersion = await ext.ui.showInputBox(options);
+        context.javaProjectVersion = await ext.ui.showInputBox(options);
     }
 
     public shouldPrompt(context: IJavaProjectWizardContext): boolean {
-        return !context.javaVersion;
+        return !context.javaProjectVersion;
     }
 }


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurefunctions/issues/2033, I will soon need to prompt for the Java Version (aka Java 8 or Java 11), so I want to rename the existing "JavaVersion" to make clear it's the version of the project, not java itself.