### PR TITLE
Exclude dev sections from README in vsix

### DIFF
--- a/.azure-pipelines/common/publish-vsix.yml
+++ b/.azure-pipelines/common/publish-vsix.yml
@@ -1,5 +1,11 @@
 steps:
 - task: Npm@1
+  displayName: 'cleanReadme'
+  inputs:
+    command: custom
+    customCommand: run cleanReadme
+
+- task: Npm@1
   displayName: 'Package'
   inputs:
     command: custom

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Azure Functions for Visual Studio Code (Preview)
 
+<!-- region exclude-from-marketplace -->
+
 [![Version](https://vsmarketplacebadge.apphb.com/version/ms-azuretools.vscode-azurefunctions.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-azuretools.vscode-azurefunctions.svg)](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) [![Build Status](https://dev.azure.com/ms-azuretools/AzCode/_apis/build/status/vscode-azurefunctions)](https://dev.azure.com/ms-azuretools/AzCode/_build/latest?definitionId=2)
+
+<!-- endregion exclude-from-marketplace -->
 
 Use the Azure Functions extension to quickly create, debug, manage, and deploy serverless apps directly from VS Code. Check out the [Azure serverless community library](https://aka.ms/AA4ul9b) to view sample projects.
 
@@ -67,6 +71,8 @@ This extension integrates with the [Azure Functions Core Tools](https://docs.mic
     > TIP: Your url should look like this: `https://<function app name>.azurewebsites.net/api/HttpTrigger1?name=world`
 1. A response of "Hello world" is returned in the browser and you know your function worked!
 
+<!-- region exclude-from-marketplace -->
+
 ## Contributing
 
 There are a couple of ways you can contribute to this repo:
@@ -87,6 +93,8 @@ Before we can accept your pull request you will need to sign a **Contribution Li
 ### Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+<!-- endregion exclude-from-marketplace -->
 
 ## Telemetry
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -82,6 +82,14 @@ async function gulp_installPythonExtension() {
     return gulp_installVSCodeExtension('ms-python', 'python');
 }
 
+async function cleanReadme() {
+    const readmePath: string = path.join(__dirname, 'README.md');
+    let data: string = (await fse.readFile(readmePath)).toString();
+    data = data.replace(/<!-- region exclude-from-marketplace -->.*?<!-- endregion exclude-from-marketplace -->/gis, '');
+    await fse.writeFile(readmePath, data);
+}
+
 exports['webpack-dev'] = gulp.series(prepareForWebpack, () => gulp_webpack('development'));
 exports['webpack-prod'] = gulp.series(prepareForWebpack, () => gulp_webpack('production'));
 exports.preTest = gulp.series(gulp_installAzureAccount, gulp_installPythonExtension, getFuncLink, installFuncCli);
+exports.cleanReadme = cleanReadme;

--- a/package.json
+++ b/package.json
@@ -1007,6 +1007,7 @@
         "vscode:prepublish": "npm run webpack-prod",
         "build": "tsc",
         "compile": "tsc -watch",
+        "cleanReadme": "gulp cleanReadme",
         "package": "vsce package",
         "lint": "tslint --project tsconfig.json -t verbose",
         "lint-fix": "tslint --project tsconfig.json -t verbose --fix",


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azurefunctions/issues/2285 and https://github.com/microsoft/vscode-azurefunctions/issues/2286, we have some accessibility issues with the badges in the README. I like having those on GitHub, but we don't need them in the marketplace page. So rather than trying to fix the issues (which I doubt would happen since literally everyone uses these types of badges), I just came up with a way to remove them in the marketplace.