### PR TITLE
Add build definition for JsonCli tool

### DIFF
--- a/tools/JsonCli/.azure-pipelines/compliance.yml
+++ b/tools/JsonCli/.azure-pipelines/compliance.yml
@@ -1,0 +1,30 @@
+steps:
+- task: MSBuild@1
+  displayName: 'build (needed for roslyn)'
+  inputs:
+    solution: '$(ProjectPath)'
+    configuration: '$(BuildConfiguration)'
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  displayName: 'Run BinSkim'
+  inputs:
+    InputType: Basic
+    AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\*.dll;$(Build.ArtifactStagingDirectory)\*.exe'
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+  displayName: 'Run Roslyn Analyzers'
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs'
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  displayName: 'Post Analysis'
+  inputs:
+    AllTools: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -1,0 +1,56 @@
+jobs:
+- job: Windows
+  pool:
+    name: VSEng-MicroBuildVS2019
+  variables:
+    ProjectPath: 'tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj'
+  steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk 2.0.x'
+    inputs:
+      version: 2.0.x
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk 3.0.x'
+    inputs:
+      version: 3.0.x
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 2.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework netcoreapp2.0'
+      zipAfterPublish: false
+      modifyOutputPath: false
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 3.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework netcoreapp3.0'
+      zipAfterPublish: false
+      modifyOutputPath: false
+
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+    inputs:
+      SourceFolder: '$(system.defaultworkingdirectory)/tools/JsonCli/src/'
+      Contents: 'bin/**/publish/**'
+      TargetFolder: '$(build.artifactstagingdirectory)'
+    condition: succeededOrFailed()
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    inputs:
+      PathtoPublish: '$(build.artifactstagingdirectory)'
+    condition: succeededOrFailed()
+
+  - template: compliance.yml
+
+trigger: none
+
+pr: none

--- a/tools/JsonCli/README.md
+++ b/tools/JsonCli/README.md
@@ -1,5 +1,7 @@
 # .NET Template JSON CLI
 
+[![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/Azure%20Tools/vscode-azurefunctions-jsoncli?branchName=main)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=13600&branchName=main)
+
 This tool is leveraged by the Functions extension at the root of this repo. It provides a JSON-based way to interact with .NET Templates. It also allows us to use templates directly from a nuget package, rather than forcing the user to install the templates machine-wide.
 
 ## Prerequisites

--- a/tools/JsonCli/src/nuget.config
+++ b/tools/JsonCli/src/nuget.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="Dotnet Template Feed" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
+    <add key="Dotnet Core Feed" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
I made a separate build definition for the [JsonCli tool](https://github.com/microsoft/vscode-azurefunctions/blob/main/tools/JsonCli/README.md) because we hardly ever change it and it needs to run on a different build pool to get signing (which will be in a separate PR). I turned all triggers off for this definition and we can do one-off builds every time we need it, and just copy the build results [here](https://github.com/microsoft/vscode-azurefunctions/tree/main/resources/dotnetJsonCli).