### PR TITLE
Update profile.ps1 template to set Disable-AzContextAutosave scope to process instead of current user

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -31,7 +31,7 @@ const profileps1: string = `# Azure Functions profile.ps1
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2371

By default, `Disable-AzContextAutosave` cmdlet call in the profile.ps1 defaults to scope user. We need to set this option for the process, so adding `-Scope Process`. Also, adding Out-Null to omit the cmdlet output. 

cc: @anirudhgarg @AnatoliB @stefanushinardi