### PR TITLE
Don't throw error if there are comments in local.settings.json

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -40,6 +40,7 @@ export * from './src/utils/envUtils';
 export * from './src/utils/fs';
 export * from './src/utils/nonNull';
 export * from './src/utils/nugetUtils';
+export * from './src/utils/parseJson';
 export * from './src/utils/requestUtils';
 export * from './src/utils/venvUtils';
 export * from './src/vsCodeConfig/extensions';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5655,6 +5655,11 @@
                 "minimist": "^1.2.5"
             }
         },
+        "jsonc-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+        },
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1069,6 +1069,7 @@
         "escape-string-regexp": "^4.0.0",
         "extract-zip": "^1.6.6",
         "fs-extra": "^4.0.2",
+        "jsonc-parser": "^2.3.1",
         "opn": "^6.0.0",
         "p-retry": "^4.1.0",
         "portfinder": "^1.0.23",

--- a/src/utils/parseJson.ts
+++ b/src/utils/parseJson.ts
@@ -3,12 +3,40 @@
  *  Licensed under the MIT License. See License.md in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as jsonc from 'jsonc-parser';
+import { localize } from '../localize';
+
 /**
- * Has extra logic to remove a BOM character if it exists
+ * Has extra logic to remove a BOM character if it exists and handle comments
  */
 export function parseJson<T extends object>(data: string): T {
     if (data.charCodeAt(0) === 0xFEFF) {
         data = data.slice(1);
     }
-    return <T>JSON.parse(data);
+
+    const errors: jsonc.ParseError[] = [];
+    const result: T = <T>jsonc.parse(data, errors, { allowTrailingComma: true });
+    if (errors.length > 0) {
+        const [line, column]: [number, number] = getLineAndColumnFromOffset(data, errors[0].offset);
+        throw new Error(localize('jsonParseError', '{0} near line "{1}", column "{2}"', jsonc.printParseErrorCode(errors[0].error), line, column));
+    } else {
+        return result;
+    }
+}
+
+export function getLineAndColumnFromOffset(data: string, offset: number): [number, number] {
+    const lines: string[] = data.split('\n');
+    let charCount: number = 0;
+    let lineCount: number = 0;
+    let column: number = 0;
+    for (const line of lines) {
+        lineCount += 1;
+        const lineLength: number = line.length + 1;
+        charCount += lineLength;
+        if (charCount >= offset) {
+            column = offset - (charCount - lineLength);
+            break;
+        }
+    }
+    return [lineCount, column];
 }

--- a/test/parseJson.test.ts
+++ b/test/parseJson.test.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { getLineAndColumnFromOffset } from '../extension.bundle';
+import { parseJson } from '../src/utils/parseJson';
+
+suite('parseJson', () => {
+    test('Valid json', () => {
+        const data: string = '{"a": "1"}';
+        assert.deepStrictEqual(parseJson(data), { a: '1' });
+    });
+
+    test('Trailing comma', () => {
+        const data: string = '{"a": "1",}';
+        assert.deepStrictEqual(parseJson(data), { a: '1' });
+    });
+
+    test('With comment', () => {
+        const data: string = '{"a": /*comment*/"1"}';
+        assert.deepStrictEqual(parseJson(data), { a: '1' });
+    });
+
+    test('Invalid json', () => {
+        const data: string = '{"a": "1}';
+        assert.throws(() => parseJson(data));
+    });
+});
+
+suite('getLineAndColumnFromOffset', () => {
+    const data: string = `{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}`;
+
+    test('First character', () => {
+        assert.deepStrictEqual(getLineAndColumnFromOffset(data, 1), [1, 1]);
+    });
+    test('Middle of random line', () => {
+        assert.deepStrictEqual(getLineAndColumnFromOffset(data, 28), [3, 4]);
+    });
+    test('End of random line', () => {
+        assert.deepStrictEqual(getLineAndColumnFromOffset(data, 74), [4, 33]);
+    });
+    test('Last character', () => {
+        assert.deepStrictEqual(getLineAndColumnFromOffset(data, 221), [11, 1]);
+    });
+});

--- a/test/parseJson.test.ts
+++ b/test/parseJson.test.ts
@@ -4,8 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { getLineAndColumnFromOffset } from '../extension.bundle';
-import { parseJson } from '../src/utils/parseJson';
+import { getLineAndColumnFromOffset, parseJson } from '../extension.bundle';
 
 suite('parseJson', () => {
     test('Valid json', () => {


### PR DESCRIPTION
The only downside of the jsonc parser that I'm using (which is actually maintained by a VS Code dev) is I have to handle errors myself. I feel like the new message is at least as good as the old message, which is all that I care about.

Old:
<img width="593" alt="Screen Shot 2020-09-29 at 5 43 39 PM" src="https://user-images.githubusercontent.com/11282622/94846030-5b52c300-03d5-11eb-83d3-fc3e26c8fa76.png">

New:
<img width="467" alt="Screen Shot 2020-09-29 at 5 41 33 PM" src="https://user-images.githubusercontent.com/11282622/94846025-5a219600-03d5-11eb-868b-33e4437fc7d1.png">

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2359