### PR TITLE
Defer to language worker environment variable if defined

### DIFF
--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -3,19 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, WorkspaceFolder } from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { isFunctionProject } from '../commands/createNewProject/verifyIsProject';
 import { hostStartTaskName } from '../constants';
 import { IPreDebugValidateResult, preDebugValidate } from './validatePreDebug';
 
 export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
+    public abstract workerArgKey: string;
     protected abstract defaultPortOrPipeName: number | string;
     protected abstract debugConfig: DebugConfiguration;
 
     private readonly _debugPorts: Map<WorkspaceFolder | undefined, number | undefined> = new Map();
 
-    public abstract getExecutionOptions(folder: WorkspaceFolder): Promise<ShellExecutionOptions>;
+    public abstract getWorkerArgValue(folder: WorkspaceFolder): Promise<string>;
 
     public async provideDebugConfigurations(folder: WorkspaceFolder | undefined, _token?: CancellationToken): Promise<DebugConfiguration[]> {
         const configs: DebugConfiguration[] | undefined = await callWithTelemetryAndErrorHandling('provideDebugConfigurations', async (context: IActionContext) => {

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as process from 'process';
 import { isNullOrUndefined } from 'util';
 import { CancellationToken, ShellExecution, ShellExecutionOptions, Task, TaskDefinition, TaskProvider, TaskScope, workspace, WorkspaceFolder } from 'vscode';
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
@@ -142,7 +143,8 @@ export class FuncTaskProvider implements TaskProvider {
                 return undefined;
         }
 
-        return await debugProvider.getExecutionOptions(folder);
+        // Defer to process.env (aka return undefined) if the workerArg variable is already defined
+        return process.env[debugProvider.workerArgKey] ? undefined : { env: { [debugProvider.workerArgKey]: await debugProvider.getWorkerArgValue(folder) } };
     }
 }
 

--- a/src/debug/JavaDebugProvider.ts
+++ b/src/debug/JavaDebugProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DebugConfiguration, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, WorkspaceFolder } from 'vscode';
 import { hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -20,11 +20,12 @@ export const javaDebugConfig: DebugConfiguration = {
 };
 
 export class JavaDebugProvider extends FuncDebugProviderBase {
+    public readonly workerArgKey: string = 'languageWorkers__java__arguments';
     protected readonly defaultPortOrPipeName: number = defaultJavaDebugPort;
     protected readonly debugConfig: DebugConfiguration = javaDebugConfig;
 
-    public async getExecutionOptions(folder: WorkspaceFolder): Promise<ShellExecutionOptions> {
+    public async getWorkerArgValue(folder: WorkspaceFolder): Promise<string> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
-        return { env: { languageWorkers__java__arguments: `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${port}` } };
+        return `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${port}`;
     }
 }

--- a/src/debug/NodeDebugProvider.ts
+++ b/src/debug/NodeDebugProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DebugConfiguration, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, WorkspaceFolder } from 'vscode';
 import { hostStartTaskName } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -19,11 +19,12 @@ export const nodeDebugConfig: DebugConfiguration = {
 };
 
 export class NodeDebugProvider extends FuncDebugProviderBase {
+    public readonly workerArgKey: string = 'languageWorkers__node__arguments';
     protected readonly defaultPortOrPipeName: number = defaultNodeDebugPort;
     protected readonly debugConfig: DebugConfiguration = nodeDebugConfig;
 
-    public async getExecutionOptions(folder: WorkspaceFolder): Promise<ShellExecutionOptions> {
+    public async getWorkerArgValue(folder: WorkspaceFolder): Promise<string> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
-        return { env: { languageWorkers__node__arguments: `--inspect=${port}` } };
+        return `--inspect=${port}`;
     }
 }

--- a/src/debug/PowerShellDebugProvider.ts
+++ b/src/debug/PowerShellDebugProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DebugConfiguration, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, WorkspaceFolder } from 'vscode';
 import { hostStartTaskName } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -20,11 +20,12 @@ export const powershellDebugConfig: DebugConfiguration = {
 };
 
 export class PowerShellDebugProvider extends FuncDebugProviderBase {
+    public readonly workerArgKey: string = 'PSWorkerCustomPipeName';
     protected defaultPortOrPipeName: string | number = defaultCustomPipeName;
     protected readonly debugConfig: DebugConfiguration = powershellDebugConfig;
 
-    public async getExecutionOptions(folder: WorkspaceFolder): Promise<ShellExecutionOptions> {
+    public async getWorkerArgValue(folder: WorkspaceFolder): Promise<string> {
         const port: string | number = this.getDebugPortOrPipeName(folder);
-        return { env: { PSWorkerCustomPipeName: `${port}` } };
+        return String(port);
     }
 }

--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DebugConfiguration, Extension, extensions, ShellExecutionOptions, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, Extension, extensions, WorkspaceFolder } from 'vscode';
 import { hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
@@ -19,12 +19,13 @@ export const pythonDebugConfig: DebugConfiguration = {
 };
 
 export class PythonDebugProvider extends FuncDebugProviderBase {
+    public readonly workerArgKey: string = 'languageWorkers__python__arguments';
     protected readonly defaultPortOrPipeName: number = defaultPythonDebugPort;
     protected readonly debugConfig: DebugConfiguration = pythonDebugConfig;
 
-    public async getExecutionOptions(folder: WorkspaceFolder): Promise<ShellExecutionOptions> {
+    public async getWorkerArgValue(folder: WorkspaceFolder): Promise<string> {
         const port: number = <number>this.getDebugPortOrPipeName(folder);
-        return { env: { languageWorkers__python__arguments: await getPythonCommand(localhost, port) } };
+        return await getPythonCommand(localhost, port);
     }
 }
 


### PR DESCRIPTION
Basically just want to make it easier for users to overwrite the environment variable we set during debugging.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2350