### PR TITLE
Allow users to hide project functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -999,6 +999,12 @@
                         "scope": "resource",
                         "type": "string",
                         "description": "The default function app to use when deploying, represented by its full Azure id.  Every subsequent deployment of this workspace will deploy to this function app or slot."
+                    },
+                    "azureFunctions.suppressProject": {
+                        "scope": "resource",
+                        "type": "boolean",
+                        "description": "%azureFunctions.suppressProject%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,6 +52,7 @@
     "azureFunctions.projectRuntime": "The default version of the Azure Functions runtime to use when performing operations like \"Create New Function\".",
     "azureFunctions.projectSubpath": "The default subpath of a workspace folder to use for project operations. This is only necessary if you have multiple projects in one workspace. See https://aka.ms/AA4nmfy for more information.",
     "azureFunctions.pythonVenv": "The name of the Python virtual environment used for your project. A virtual environment is required to debug and deploy Python functions.",
+    "azureFunctions.suppressProject": "Set to true if this should not be recognized as an Azure Functions project and you want to hide related functionality.",
     "azureFunctions.redeploy": "Redeploy",
     "azureFunctions.refresh": "Refresh",
     "azureFunctions.requestTimeout": "The timeout (in seconds) to be used when making requests, for example getting the latest templates.",

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -27,7 +27,9 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 export async function tryGetFunctionProjectRoot(folderPath: string, suppressPrompt: boolean = false): Promise<string | undefined> {
     let subpath: string | undefined = getWorkspaceSetting(projectSubpathSetting, folderPath);
     if (!subpath) {
-        if (!(await fse.pathExists(folderPath))) {
+        if (getWorkspaceSetting<boolean>('suppressProject', folderPath)) {
+            return undefined;
+        } else if (!(await fse.pathExists(folderPath))) {
             return undefined;
         } else if (await isFunctionProject(folderPath)) {
             return folderPath;


### PR DESCRIPTION
For cases where our detection logic thinks it's a functions project because it has a host.json, but it's actually not (for example Logic Apps)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2405