### PR TITLE
Fix AzureWebJobsStorage bug during download settings

### DIFF
--- a/src/funcConfig/local.settings.ts
+++ b/src/funcConfig/local.settings.ts
@@ -91,10 +91,5 @@ export async function getLocalSettingsJson(localSettingsPath: string, allowOverw
         }
     }
 
-    return {
-        IsEncrypted: false,
-        Values: {
-            AzureWebJobsStorage: ''
-        }
-    };
+    return {};
 }


### PR DESCRIPTION
I don't think we need these defaults in `getLocalSettingsJson` and it's causing the bug mentioned below. We already set them when creating projects [here](https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts#L24) and they're listed as optional on the type [here](https://github.com/microsoft/vscode-azurefunctions/blob/main/src/funcConfig/local.settings.ts#L17)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2389