### PR TITLE
Move timer trigger up in function list

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -196,17 +196,21 @@ async function promptForTemplateFilter(): Promise<TemplateFilter> {
 }
 
 /**
- * If templateFilter is verified, puts HttpTrigger at the top since it's the most popular
+ * If templateFilter is verified, puts HttpTrigger/TimerTrigger at the top since they're the most popular
  * Otherwise sort alphabetically
  */
 function sortTemplates(a: IFunctionTemplate, b: IFunctionTemplate, templateFilter: TemplateFilter): number {
     if (templateFilter === TemplateFilter.Verified) {
-        const regExp: RegExp = /httptrigger($|[^a-z])/i;
-        if (regExp.test(a.id)) {
-            return -1;
-        } else if (regExp.test(b.id)) {
-            return 1;
+        function getPriority(id: string): number {
+            if (/\bhttptrigger\b/i.test(id)) {
+                return 1;
+            } else if (/\btimertrigger\b/i.test(id)) {
+                return 2;
+            } else {
+                return 3;
+            }
         }
+        return getPriority(a.id) - getPriority(b.id);
     }
 
     return a.name.localeCompare(b.name);


### PR DESCRIPTION
We already move HttpTrigger up to the top automatically, and I think we should move TimerTrigger up as well. They're by far the most popular and right now TimerTrigger is basically at the bottom of the list because all the "Azure" templates are sorted first alphabetically

<img width="319" alt="Screen Shot 2020-10-09 at 11 30 00 AM" src="https://user-images.githubusercontent.com/11282622/95619048-cd08bd80-0a22-11eb-9f56-f2ec5c2b17fa.png">
