### PR TITLE
Use main branch when packaging vsix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1044,7 +1044,7 @@
         "build": "tsc",
         "compile": "tsc -watch",
         "cleanReadme": "gulp cleanReadme",
-        "package": "vsce package",
+        "package": "vsce package --githubBranch main",
         "lint": "tslint --project tsconfig.json -t verbose",
         "lint-fix": "tslint --project tsconfig.json -t verbose --fix",
         "pretest": "npm run webpack-prod && gulp preTest",


### PR DESCRIPTION
Right now it's defaulting to "master" when generating the urls used for images in our README