### PR TITLE
Adding Stencil Python requirements update and better error reporting

### DIFF
--- a/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
+++ b/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
@@ -69,8 +69,7 @@ export class OpenAPICreateStep extends AzureWizardExecuteStep<IFunctionWizardCon
             try {
                 await cpUtils.executeCommand(ext.outputChannel, undefined, 'autorest', ...args);
             } catch (error) {
-                const message: string = localize('autorestNotRunSuccessfully',
-                    `Failed to run "autorest.${pluginRunPrefix}-${pluginRun}" | Click "Report an Issue" to report the error.`);
+                const message: string = localize('autorestNotRunSuccessfully', `Failed to run "autorest.${pluginRunPrefix}-${pluginRun}" | Click "Report an Issue" to report the error.`);
                 if (!wizardContext.errorHandling.suppressDisplay) {
                     window.showErrorMessage(message, DialogResponses.reportAnIssue).then(async result => {
                         if (result === DialogResponses.reportAnIssue) {

--- a/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
+++ b/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
@@ -3,14 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
 import * as path from 'path';
 import { ProgressLocation, Uri, window } from "vscode";
 import { AzureWizardExecuteStep, DialogResponses, IActionContext } from 'vscode-azureextensionui';
-import { ProjectLanguage } from "../../../constants";
+import { ProjectLanguage, requirementsFileName } from "../../../constants";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";
 import { cpUtils } from "../../../utils/cpUtils";
-import { confirmEditJsonFile } from '../../../utils/fs';
+import { confirmEditJsonFile, confirmOverwriteFile } from '../../../utils/fs';
 import { nonNullProp } from '../../../utils/nonNull';
 import { openUrl } from '../../../utils/openUrl';
 import { IJavaProjectWizardContext } from '../../createNewProject/javaSteps/IJavaProjectWizardContext';
@@ -29,46 +30,69 @@ export class OpenAPICreateStep extends AzureWizardExecuteStep<IFunctionWizardCon
         const uris: Uri[] = nonNullProp(wizardContext, 'openApiSpecificationFile');
         const uri: Uri = uris[0];
         const args: string[] = [];
-
-        args.push(`--input-file:${cpUtils.wrapArgInQuotes(uri.fsPath)}`);
-        args.push(`--version:3.0.6320`);
+        const pluginRunPrefix: string = 'azure-functions';
+        let pluginRun: string = '';
 
         switch (wizardContext.language) {
             case ProjectLanguage.TypeScript:
-                args.push('--azure-functions-typescript');
+                pluginRun = 'typescript';
                 args.push('--no-namespace-folders:True');
                 break;
             case ProjectLanguage.CSharp:
+                pluginRun = 'csharp';
                 args.push(`--namespace:${nonNullProp(wizardContext, 'namespace')}`);
-                args.push('--azure-functions-csharp');
                 break;
             case ProjectLanguage.Java:
+                pluginRun = 'java';
                 args.push(`--namespace:${nonNullProp(wizardContext, 'javaPackageName')}`);
-                args.push('--azure-functions-java');
                 break;
             case ProjectLanguage.Python:
-                args.push('--azure-functions-python');
-                args.push('--no-namespace-folders:True');
+                pluginRun = 'python';
                 args.push('--no-async');
+                args.push('--no-namespace-folders:True');
                 break;
             default:
                 throw new Error(localize('notSupported', 'Not a supported language. We currently support C#, Java, Python, and Typescript'));
-                break;
         }
 
-        args.push('--generate-metadata:false');
+        args.push(`--${pluginRunPrefix}-${pluginRun}`);
+        args.push(`--input-file:${cpUtils.wrapArgInQuotes(uri.fsPath)}`);
         args.push(`--output-folder:${cpUtils.wrapArgInQuotes(wizardContext.projectPath)}`);
+        args.push('--generate-metadata:false');
+        args.push(`--version:3.0.6320`);
 
         ext.outputChannel.appendLog(localize('statutoryWarning', 'Using the plugin could overwrite your custom changes to the functions.\nIf autorest fails, you can run the script on your command-line, or try resetting autorest (autorest --reset) and try again.'));
-        const title: string = localize('generatingFunctions', 'Generating from OpenAPI...Check [output window](command:{0}) for status.', ext.prefix + '.showOutputChannel');
+        ext.outputChannel.appendLog(localize('urlsForIssues', 'If there are any issues, please visit https://aka.ms/stencil for usage information or report issues at https://aka.ms/stencil/issues.'));
+        const title: string = localize('generatingFunctions', 'Generating from OpenAPI Specification...Check [output window](command:{0}) for status.', ext.prefix + '.showOutputChannel');
 
         await window.withProgress({ location: ProgressLocation.Notification, title }, async () => {
-            await cpUtils.executeCommand(ext.outputChannel, undefined, 'autorest', ...args);
+            try {
+                await cpUtils.executeCommand(ext.outputChannel, undefined, 'autorest', ...args);
+            } catch (error) {
+                const message: string = localize('autorestNotRunSuccessfully',
+                    `Failed to run "autorest.${pluginRunPrefix}-${pluginRun}" | Click "Report an Issue" to report the error.`);
+                if (!wizardContext.errorHandling.suppressDisplay) {
+                    window.showErrorMessage(message, DialogResponses.reportAnIssue).then(async result => {
+                        if (result === DialogResponses.reportAnIssue) {
+                            await openUrl('https://aka.ms/stencil/issues');
+                        }
+                    });
+                    wizardContext.errorHandling.suppressDisplay = true;
+                }
+
+                throw new Error(message);
+            }
         });
 
-        if (wizardContext.language === ProjectLanguage.TypeScript) {
-            // Change the package.json only when the autorest successfully ran.
-            await addAutorestSpecificTypescriptDependencies(wizardContext);
+        switch (wizardContext.language) {
+            case ProjectLanguage.TypeScript:
+                await addAutorestSpecificTypescriptDependencies(wizardContext);
+                break;
+            case ProjectLanguage.Python:
+                await addAutorestSpecificPythonDependencies(wizardContext);
+                break;
+            default:
+                break;
         }
     }
 
@@ -108,4 +132,34 @@ async function addAutorestSpecificTypescriptDependencies(context: IFunctionWizar
         }
         return data;
     });
+}
+
+async function addAutorestSpecificPythonDependencies(context: IFunctionWizardContext): Promise<void> {
+
+    let oldRequirements: string = '';
+    let newRequirements: string = '';
+    const requirementsPath: string = path.join(context.projectPath, requirementsFileName);
+
+    // Current list of dependencies to be added to support stencil generated projects.
+    const dependenciesToAddArray: string[] = ['msrest'];
+
+    // Some custom requirements might not have newline character added already.
+    const dependenciesToAdd: string = `\n${dependenciesToAddArray.join('\n')}\n`;
+
+    if (await fse.pathExists(requirementsPath)) {
+        try {
+            oldRequirements = (await fse.readFile(requirementsPath)).toString();
+            newRequirements = oldRequirements.concat(dependenciesToAdd);
+        } catch (error) {
+            // If we failed to parse or edit the existing file, just ask to overwrite the file completely
+            if (await confirmOverwriteFile(requirementsPath)) {
+                newRequirements = dependenciesToAdd;
+            } else {
+                return;
+            }
+        }
+    } else {
+        newRequirements = dependenciesToAdd;
+    }
+    await fse.writeFile(requirementsPath, newRequirements);
 }

--- a/src/commands/createFunction/openAPISteps/OpenApiUtils.ts
+++ b/src/commands/createFunction/openAPISteps/OpenApiUtils.ts
@@ -1,0 +1,153 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import { EOL } from 'os';
+import * as path from 'path';
+import { window } from "vscode";
+import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { requirementsFileName } from "../../../constants";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../localize";
+import { getDotnetInstalled } from "../../../templates/dotnet/executeDotnetTemplateCommand";
+import { cpUtils } from "../../../utils/cpUtils";
+import { confirmEditJsonFile } from '../../../utils/fs';
+import { openUrl } from "../../../utils/openUrl";
+import { IFunctionWizardContext } from '../IFunctionWizardContext';
+
+export namespace openApiUtils {
+    export async function validateAutorestInstalled(context: IActionContext): Promise<void> {
+        try {
+            await cpUtils.executeCommand(undefined, undefined, 'autorest', '--version');
+        } catch (error) {
+            const message: string = localize('autorestNotFound', 'Failed to find "autorest" | Extension needs AutoRest to generate a function app from an OpenAPI specification. Click "Learn more" for more details on installation steps.');
+            if (!context.errorHandling.suppressDisplay) {
+                window.showErrorMessage(message, DialogResponses.learnMore).then(async result => {
+                    if (result === DialogResponses.learnMore) {
+                        await openUrl('https://aka.ms/autorest');
+                    }
+                });
+                context.errorHandling.suppressDisplay = true;
+            }
+
+            throw new Error(message);
+        }
+    }
+
+    export async function validateJavaForAutorestInstalled(context: IActionContext): Promise<void> {
+        try {
+            await cpUtils.executeCommand(undefined, undefined, 'java', '--version');
+        } catch (error) {
+            const message: string = localize('javaForAutorestNotFound', 'Failed to find "java" | Extension needs AutoRest, Java to generate a Java function app from an OpenAPI specification.');
+            if (!context.errorHandling.suppressDisplay) {
+                window.showErrorMessage(message, DialogResponses.learnMore).then(async result => {
+                    if (result === DialogResponses.learnMore) {
+                        await openUrl('https://aka.ms/stencil/java');
+                    }
+                });
+                context.errorHandling.suppressDisplay = true;
+            }
+
+            throw new Error(message);
+        }
+    }
+    export async function validateDotnetForAutorestInstalled(context: IActionContext): Promise<void> {
+        try {
+            const installedFramework: string = await getDotnetInstalled(context);
+
+            // https://aka.ms/stencil/csharp only works on dotnet 3.0+
+            if (installedFramework !== `netcoreapp3.0`) {
+                throw new Error();
+            }
+        } catch (error) {
+            const message: string = localize('csharpForAutorestNotFound', 'You must have the [.NET Core SDK](https://aka.ms/AA4ac70) installed to perform this operation. See [here](https://aka.ms/stencil/csharp) for supported versions.');
+            if (!context.errorHandling.suppressDisplay) {
+                window.showErrorMessage(message, DialogResponses.learnMore).then(async result => {
+                    if (result === DialogResponses.learnMore) {
+                        await openUrl('https://aka.ms/stencil/csharp');
+                    }
+                });
+                context.errorHandling.suppressDisplay = true;
+            }
+            throw new Error(message);
+        }
+    }
+
+    export async function validatePythonForAutorestInstalled(context: IActionContext): Promise<void> {
+        try {
+            await cpUtils.executeCommand(undefined, undefined, 'python', '--version');
+        } catch (error) {
+            const message: string = localize('pythonForAutorestNotFound', 'Failed to find "python" | Extension needs AutoRest, Python to generate a Python function app from an OpenAPI specification.');
+            if (!context.errorHandling.suppressDisplay) {
+                window.showErrorMessage(message, DialogResponses.learnMore).then(async result => {
+                    if (result === DialogResponses.learnMore) {
+                        await openUrl('https://aka.ms/stencil/python');
+                    }
+                });
+                context.errorHandling.suppressDisplay = true;
+            }
+
+            throw new Error(message);
+        }
+    }
+
+    export async function addAutorestSpecificTypescriptDependencies(context: IFunctionWizardContext): Promise<void> {
+        const coreHttp: string = '@azure/core-http';
+        const coreHttpVersion: string = '^1.1.4';
+        const packagePath: string = path.join(context.projectPath, 'package.json');
+
+        await confirmEditJsonFile(packagePath, (data: { devDependencies?: { [key: string]: string } }): {} => {
+            // tslint:disable-next-line: strict-boolean-expressions
+            data.devDependencies = data.devDependencies || {};
+            if (!data.devDependencies[coreHttp]) {
+                data.devDependencies[coreHttp] = coreHttpVersion;
+            }
+            return data;
+        });
+    }
+
+    async function checkDependenciesDoNotExist(oldRequirements: string[], dependenciesToAddArray: string[]): Promise<string[]> {
+        const finalDependencies: string[] = [];
+        dependenciesToAddArray.forEach(dep => {
+            const filteredArray: string[] = oldRequirements.filter(req => req.startsWith(dep));
+            if (filteredArray.length === 0) {
+                finalDependencies.push(dep);
+            }
+        });
+
+        return finalDependencies;
+    }
+
+    async function prepareDependencies(dependencies: string[]): Promise<string> {
+        return `${EOL}${dependencies.join(EOL)}${EOL}`;
+    }
+
+    export async function addAutorestSpecificPythonDependencies(context: IFunctionWizardContext): Promise<void> {
+        let oldRequirements: string[];
+        let newRequirements: string = '';
+        const requirementsPath: string = path.join(context.projectPath, requirementsFileName);
+
+        // Current list of dependencies to be added to support stencil generated projects.
+        const dependenciesToAddArray: string[] = ['# DO NOT include azure-functions-worker in this file', '# The Python Worker is managed by Azure Functions platform', '# Manually managing azure-functions-worker may cause unexpected issues', 'azure-functions', 'msrest'];
+
+        if (await fse.pathExists(requirementsPath)) {
+            try {
+                oldRequirements = (await fse.readFile(requirementsPath)).toString().split(EOL);
+                const dependenciesRequired: string[] = await checkDependenciesDoNotExist(oldRequirements, dependenciesToAddArray);
+                const newRequirementsArray: string[] = oldRequirements.concat(dependenciesRequired).filter(req => req !== '');  // Removing empty lines that get introduced due to the split and joins.
+
+                newRequirements = await prepareDependencies(newRequirementsArray);
+            } catch (error) {
+                // If we failed to parse or edit the existing file, inform the user of the same.
+                ext.outputChannel.appendLog(localize('cannotAddPythonDependencies', `Could not add ${dependenciesToAddArray.join()} to requirements.txt file. Please make sure you add the dependencies to the requirements.txt.`));
+                return;
+            }
+        } else {
+            newRequirements = await prepareDependencies(dependenciesToAddArray);
+        }
+
+        await fse.writeFile(requirementsPath, newRequirements);
+    }
+}

--- a/src/templates/dotnet/executeDotnetTemplateCommand.ts
+++ b/src/templates/dotnet/executeDotnetTemplateCommand.ts
@@ -45,6 +45,10 @@ export async function validateDotnetInstalled(context: IActionContext): Promise<
     await getFramework(context, undefined);
 }
 
+export async function getDotnetInstalled(context: IActionContext): Promise<string> {
+    return getFramework(context, undefined);
+}
+
 let cachedFramework: string | undefined;
 async function getFramework(context: IActionContext, workingDirectory: string | undefined): Promise<string> {
     if (!cachedFramework) {


### PR DESCRIPTION
Following changes in the PR:

- Fixed Python's requirements for Stencil generated apps - They require `msrest` requirements for the models generated. That dependency will be added to the `requirments.txt` file for the Python HTTP Trigger functions generated by Stencil.
- Added relevant URLs in the logs and error pop-ups such that users can easily find links to the documentation or for reporting errors when either `autorest` or a specific plugin fails to generate functions.

/cc: @skylerah, @EricJizbaMSFT, @fiveisprime 