### PR TITLE
Debugging with .NET 5

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ServiceClient, WebResource } from '@azure/ms-rest-js';
+import { HttpOperationResponse, ServiceClient, WebResource } from '@azure/ms-rest-js';
 import * as unixPsTree from 'ps-tree';
 import * as vscode from 'vscode';
 import { createGenericClient, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
@@ -86,8 +86,11 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
             if (taskInfo) {
                 try {
                     // wait for status url to indicate functions host is running
-                    await client.sendRequest(statusRequest);
-                    return taskInfo.processId.toString();
+                    const response: HttpOperationResponse = await client.sendRequest(statusRequest);
+                    // tslint:disable-next-line: no-unsafe-any
+                    if (response.parsedBody.state.toLowerCase() === 'running') {
+                        return taskInfo.processId.toString();
+                    }
                 } catch {
                     // ignore
                 }

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -8,7 +8,6 @@ import { IActionContext, registerEvent } from 'vscode-azureextensionui';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 
 export interface IRunningFuncTask {
-    startTime: number;
     processId: number;
 }
 
@@ -25,7 +24,7 @@ export function registerFuncHostTaskEvents(): void {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
         if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
-            runningFuncTaskMap.set(e.execution.task.scope, { startTime: Date.now(), processId: e.processId });
+            runningFuncTaskMap.set(e.execution.task.scope, { processId: e.processId });
         }
     });
 

--- a/src/utils/windowsProcessTree.ts
+++ b/src/utils/windowsProcessTree.ts
@@ -16,14 +16,36 @@ export function getWindowsProcessTree(): IWindowsProcessTree {
     return windowsProcessTree;
 }
 
-export interface IWindowsProcessTree {
-    getProcessTree(rootPid: number, callback: (tree: IProcessTreeNode | undefined) => void): void;
+// https://github.com/microsoft/vscode-windows-process-tree/blob/b7efc9fb4567d552ef95c7449058b6f634a82df8/typings/windows-process-tree.d.ts
+
+export enum ProcessDataFlag {
+    None = 0,
+    Memory = 1,
+    CommandLine = 2
 }
 
-export interface IProcessTreeNode {
+export interface IProcessInfo {
     pid: number;
+    ppid: number;
     name: string;
+
+    /**
+     * The working set size of the process, in bytes.
+     */
     memory?: number;
+
+    /**
+     * The string returned is at most 512 chars, strings exceeding this length are truncated.
+     */
     commandLine?: string;
-    children: IProcessTreeNode[];
+}
+
+export interface IWindowsProcessTree {
+    /**
+     * Returns a list of processes containing the rootPid process and all of its descendants.
+     * @param rootPid - The pid of the process of interest.
+     * @param callback - The callback to use with the returned set of processes.
+     * @param flags - The flags for what process data should be included.
+     */
+    getProcessList(rootPid: number, callback: (processList: IProcessInfo[]) => void, flags?: ProcessDataFlag): void;
 }


### PR DESCRIPTION
.NET 5 support for Azure Functions will be in a separate worker process and I ran into two main problems with our "pickProcess" command when trying to get it to work:
1. We would return a process id before the child worker process had even started. My fix here was to replace some existing "waiting" logic with a loop that pings "admin/host/status" to see if the app is running
1. The innermost child process with .NET 5 seemed to be something like "conhost.exe" on Windows, which is not what we want to attach to. Now, I filter to only "dotnet" or "func" processes

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2550