### PR TITLE
Fix timing issues with pickProcess

### DIFF
--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Task, tasks as codeTasks, TaskScope, WorkspaceFolder } from "vscode";
-import { isPathEqual, isSubpath } from "./fs";
+import { Task, tasks as codeTasks, WorkspaceFolder } from "vscode";
+import { isPathEqual } from "./fs";
 
 export namespace taskUtils {
     export function getFsPathFromTask(task: Task): string | undefined {
@@ -13,18 +13,6 @@ export namespace taskUtils {
             return workspaceFolder.uri?.fsPath;
         } else {
             return undefined;
-        }
-    }
-
-    /**
-     * Returns true if the task's scope is a workspace folder matching the given path or if the task is not associated with a path
-     */
-    export function isTaskInScopeOfPath(task: Task, fsPath: string): boolean {
-        if (task.scope === TaskScope.Global || task.scope === TaskScope.Workspace) {
-            return true;
-        } else {
-            const taskPath: string | undefined = getFsPathFromTask(task);
-            return !!taskPath && (isPathEqual(taskPath, fsPath) || isSubpath(taskPath, fsPath));
         }
     }
 

--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Task, tasks as codeTasks, TaskScope, WorkspaceFolder } from "vscode";
+import { isPathEqual, isSubpath } from "./fs";
+
+export namespace taskUtils {
+    export function getFsPathFromTask(task: Task): string | undefined {
+        if (typeof task.scope === 'object') {
+            const workspaceFolder: Partial<WorkspaceFolder> = task.scope;
+            return workspaceFolder.uri?.fsPath;
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * Returns true if the task's scope is a workspace folder matching the given path or if the task is not associated with a path
+     */
+    export function isTaskInScopeOfPath(task: Task, fsPath: string): boolean {
+        if (task.scope === TaskScope.Global || task.scope === TaskScope.Workspace) {
+            return true;
+        } else {
+            const taskPath: string | undefined = getFsPathFromTask(task);
+            return !!taskPath && (isPathEqual(taskPath, fsPath) || isSubpath(taskPath, fsPath));
+        }
+    }
+
+    export function isTaskScopeEqual(task1: Task, task2: Task): boolean {
+        if (task1.scope === task2.scope) { // handles the case where the scopes are not associated with a path
+            return true;
+        } else {
+            const task1Path: string | undefined = getFsPathFromTask(task1);
+            const task2Path: string | undefined = getFsPathFromTask(task2);
+            return !!task1Path && !!task2Path && isPathEqual(task1Path, task2Path);
+        }
+    }
+
+    export function isTaskEqual(task1: Task, task2: Task): boolean {
+        return isTaskScopeEqual(task1, task2) && task1.name === task2.name && task1.source === task2.source && task1.definition.type === task2.definition.type;
+    }
+
+    /**
+     * Handles condition where we don't need to start the task because it's already running
+     */
+    export async function executeIfNotActive(task: Task): Promise<void> {
+        if (!codeTasks.taskExecutions.find(t => isTaskEqual(t.task, task))) {
+            await codeTasks.executeTask(task);
+        }
+    }
+}


### PR DESCRIPTION
Fixed two problems that can happen if you mash the "stop debugging" and "start debugging" buttons:
1. It never stops the previous func task and you get an error like "Failed to stop previous running Functions host"
    1. Solved this by adding `stopFuncTaskIfRunning` to `waitForPrevFuncTaskToStop`. Previously it would only stop it if the "onDidTerminateDebugSession" event was fired
1. It starts a second func task and you get a port conflict error
    1. Solved this by using `executeIfNotActive` (taskUtils copied from [here](https://github.com/microsoft/vscode-azuretools/blob/main/appservice/src/utils/taskUtils.ts))