### PR TITLE
Unblock "dotnet-isolated" worker runtime

### DIFF
--- a/src/commands/deploy/verifyAppSettings.ts
+++ b/src/commands/deploy/verifyAppSettings.ts
@@ -12,7 +12,7 @@ import { ext } from '../../extensionVariables';
 import { FuncVersion, tryParseFuncVersion } from '../../FuncVersion';
 import { localize } from '../../localize';
 import { SlotTreeItemBase } from '../../tree/SlotTreeItemBase';
-import { getFunctionsWorkerRuntime } from '../../vsCodeConfig/settings';
+import { getFunctionsWorkerRuntime, isKnownWorkerRuntime } from '../../vsCodeConfig/settings';
 
 export async function verifyAppSettings(context: IActionContext, node: SlotTreeItemBase, version: FuncVersion, language: ProjectLanguage): Promise<void> {
     const appSettings: WebSiteManagementModels.StringDictionary = await node.root.client.listApplicationSettings();
@@ -45,7 +45,7 @@ export async function verifyVersionAndLanguage(context: IActionContext, siteName
     const azureWorkerRuntime: string | undefined = remoteProperties[workerRuntimeKey];
     context.telemetry.properties.remoteRuntime = azureWorkerRuntime;
     const localWorkerRuntime: string | undefined = getFunctionsWorkerRuntime(localLanguage);
-    if (localVersion !== FuncVersion.v1 && azureWorkerRuntime && localWorkerRuntime && azureWorkerRuntime !== localWorkerRuntime) {
+    if (localVersion !== FuncVersion.v1 && isKnownWorkerRuntime(azureWorkerRuntime) && isKnownWorkerRuntime(localWorkerRuntime) && azureWorkerRuntime !== localWorkerRuntime) {
         throw new Error(localize('incompatibleRuntime', 'The remote runtime "{0}" for function app "{1}" does not match your local runtime "{2}".', azureWorkerRuntime, siteName, localWorkerRuntime));
     }
 

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -83,6 +83,10 @@ export function getFunctionsWorkerRuntime(language: string | undefined): string 
     }
 }
 
+export function isKnownWorkerRuntime(runtime: string | undefined): boolean {
+    return !!runtime && ['node', 'dotnet', 'java', 'python', 'powershell', 'custom'].includes(runtime.toLowerCase());
+}
+
 export function getFuncWatchProblemMatcher(language: string | undefined): string {
     const runtime: string | undefined = getFunctionsWorkerRuntime(language);
     return runtime && runtime !== 'custom' ? `$func-${runtime}-watch` : '$func-watch';

--- a/test/verifyVersionAndLanguage.test.ts
+++ b/test/verifyVersionAndLanguage.test.ts
@@ -114,4 +114,20 @@ suite('verifyVersionAndLanguage', () => {
         };
         await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
     });
+
+    test('Local: ~2/C#, Remote: ~2/unknown', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~2',
+            FUNCTIONS_WORKER_RUNTIME: 'unknown'
+        };
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.CSharp, props);
+    });
+
+    test('Local: ~2/unknown, Remote: ~2/unknown', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~2',
+            FUNCTIONS_WORKER_RUNTIME: 'unknown'
+        };
+        await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
+    });
 });


### PR DESCRIPTION
.NET 5 is using a new value for `FUNCTIONS_WORKER_RUNTIME`: `dotnet-isolated`. This PR doesn't actually support the new value (because it could get complicated to differentiate `dotnet` and `dotnet-isolated`), but it does ensure the new value won't block users