### PR TITLE
Add option to reload templates and clear cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1045,6 +1045,11 @@
                         "type": "boolean",
                         "description": "%azureFunctions.showHiddenStacks%",
                         "default": false
+                    },
+                    "azureFunctions.showReloadTemplates": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.showReloadTemplates%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -76,6 +76,7 @@
     "azureFunctions.showPythonVenvWarning": "Show a warning when an Azure Functions Python project was detected that does not have a virtual environment.",
     "azureFunctions.showTargetFrameworkWarning": "Show a warning when an Azure Functions .NET project was detected that has mismatched target frameworks.",
     "azureFunctions.showExtensionsCsprojWarning": "Show a warning when an Azure Functions project was detected that has mismatched \"extensions.csproj\" configuration.",
+    "azureFunctions.showReloadTemplates": "Show an option to reload templates when creating a function. This will clear the template cache.",
     "azureFunctions.startFunctionApp": "Start",
     "azureFunctions.startJavaRemoteDebug": "Attach Debugger",
     "azureFunctions.startRemoteDebug": "Start Remote Debugging",

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -162,6 +162,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             } else if (result === 'openAPI') {
                 context.generateFromOpenAPI = true;
                 break;
+            } else if (result === 'reloadTemplates') {
+                await ext.templateProvider.clearTemplateCache(context.projectPath, nonNullProp(context, 'language'), nonNullProp(context, 'version'));
             } else {
                 context.functionTemplate = result;
             }
@@ -205,6 +207,14 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             suppressPersistence: true
         });
 
+        if (getWorkspaceSetting<boolean>('showReloadTemplates')) {
+            picks.push({
+                label: localize('reloadTemplates', '$(sync) Reload templates'),
+                data: 'reloadTemplates',
+                suppressPersistence: true
+            });
+        }
+
         return picks;
     }
 }
@@ -215,7 +225,7 @@ interface IFunctionListStepOptions {
     functionSettings: { [key: string]: string | undefined } | undefined;
 }
 
-type TemplatePromptResult = 'changeFilter' | 'skipForNow' | 'openAPI';
+type TemplatePromptResult = 'changeFilter' | 'skipForNow' | 'openAPI' | 'reloadTemplates';
 
 async function promptForTemplateFilter(context: IActionContext): Promise<TemplateFilter> {
     const picks: IAzureQuickPickItem<TemplateFilter>[] = [

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -38,6 +38,10 @@ export abstract class TemplateProviderBase {
         ext.context.globalState.update(await this.getCacheKey(key), value);
     }
 
+    public async deleteCachedValue(key: string): Promise<void> {
+        ext.context.globalState.update(await this.getCacheKey(key), undefined);
+    }
+
     public async getCachedValue<T>(key: string): Promise<T | undefined> {
         return ext.context.globalState.get<T>(await this.getCacheKey(key));
     }
@@ -47,6 +51,7 @@ export abstract class TemplateProviderBase {
     public abstract getCachedTemplates(context: IActionContext): Promise<ITemplates | undefined>;
     public abstract getBackupTemplates(context: IActionContext): Promise<ITemplates>;
     public abstract cacheTemplates(): Promise<void>;
+    public abstract clearCache(): Promise<void>;
     public abstract updateBackupTemplates(): Promise<void>;
 
     /**

--- a/src/templates/dotnet/DotnetTemplateProvider.ts
+++ b/src/templates/dotnet/DotnetTemplateProvider.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as fse from 'fs-extra';
+import { homedir } from 'os';
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
 import { cliFeedUtils } from '../../utils/cliFeedUtils';
@@ -11,7 +12,7 @@ import { parseJson } from '../../utils/parseJson';
 import { requestUtils } from '../../utils/requestUtils';
 import { ITemplates } from '../ITemplates';
 import { TemplateProviderBase, TemplateType } from '../TemplateProviderBase';
-import { executeDotnetTemplateCommand, getDotnetItemTemplatePath, getDotnetProjectTemplatePath, validateDotnetInstalled } from './executeDotnetTemplateCommand';
+import { executeDotnetTemplateCommand, getDotnetItemTemplatePath, getDotnetProjectTemplatePath, getDotnetTemplatesPath, validateDotnetInstalled } from './executeDotnetTemplateCommand';
 import { parseDotnetTemplates } from './parseDotnetTemplates';
 
 export class DotnetTemplateProvider extends TemplateProviderBase {
@@ -79,6 +80,14 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
 
     public async cacheTemplates(): Promise<void> {
         await this.updateCachedValue(this._dotnetTemplatesKey, this._rawTemplates);
+    }
+
+    public async clearCache(): Promise<void> {
+        await this.deleteCachedValue(this._dotnetTemplatesKey);
+        const templateEnginePath: string = path.join(homedir(), '.templateengine', 'AzureFunctions-VSCodeExtension'); // This is used by the JsonCli tool
+        for (const dir of [getDotnetTemplatesPath(), templateEnginePath]) {
+            await fse.remove(dir);
+        }
     }
 
     private async parseTemplates(context: IActionContext): Promise<ITemplates> {

--- a/src/templates/script/ScriptTemplateProvider.ts
+++ b/src/templates/script/ScriptTemplateProvider.ts
@@ -96,6 +96,12 @@ export class ScriptTemplateProvider extends TemplateProviderBase {
         await this.updateCachedValue(this._resourcesKey, this._rawResources);
     }
 
+    public async clearCache(): Promise<void> {
+        await this.deleteCachedValue(this._templatesKey);
+        await this.deleteCachedValue(this._bindingsKey);
+        await this.deleteCachedValue(this._resourcesKey);
+    }
+
     public includeTemplate(template: IFunctionTemplate | IBindingTemplate): boolean {
         return this.version === FuncVersion.v1 || !bundleFeedUtils.isBundleTemplate(template);
     }


### PR DESCRIPTION
We've run into a few bugs with the templates where it would be nice to give users an option to clear the cache, for example https://github.com/Azure/azure-functions-core-tools/issues/2338

I added an option to the end of the "Create Function" quick pick because it's easiest to clear the cache if I know what language/project/version to clear (as opposed to like a separate command palette command). But I also thought it was ugly and didn't want it to show it all the time, so I hid it behind a setting
<img width="408" alt="Screen Shot 2020-12-09 at 6 00 14 PM" src="https://user-images.githubusercontent.com/11282622/101711741-0bcdea80-3a49-11eb-8cf1-30fe18629f21.png">

Related to https://github.com/microsoft/vscode-azurefunctions/issues/2547