### PR TITLE
Include "IsEncrypted" in local.settings.json by default

### DIFF
--- a/src/funcConfig/local.settings.ts
+++ b/src/funcConfig/local.settings.ts
@@ -91,5 +91,7 @@ export async function getLocalSettingsJson(localSettingsPath: string, allowOverw
         }
     }
 
-    return {};
+    return {
+        IsEncrypted: false // Include this by default otherwise the func cli assumes settings are encrypted and fails to run
+    };
 }


### PR DESCRIPTION
This was changed in https://github.com/microsoft/vscode-azurefunctions/pull/2443 to remove an empty "AzureWebJobsStorage" by default, but we still want "IsEncrypted" otherwise I'm seeing this error:
> Failed to decrypt settings. Encrypted settings only be edited through 'func settings add'.