### PR TITLE
Fix bug where C# debugging doesn't attach after a failed task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,9 +247,9 @@
             }
         },
         "@azure/core-http": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.0.tgz",
-            "integrity": "sha512-SQmyI1tpstWKePNmTseEUp8PMq1uNBslvGBrYF2zNM/fEfLD1q64XCatoH8nDQtSmDydEPsqlyyLSjjnuXrlOQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.1.tgz",
+            "integrity": "sha512-vPHIQXjLVs4iin2BUaj7/sqIAfGq3MW1TLEc3yYKFNpi/sBQn2KI0g+Ow0EQYvAkkHhTHGArA7JKhcjsnJMGLw==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.1.3",
@@ -302,9 +302,9 @@
                     "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
                 },
                 "uuid": {
-                    "version": "8.3.1",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-                    "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
@@ -9815,9 +9815,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.72.0",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.72.0.tgz",
-            "integrity": "sha512-BPulvBG0cpEmBqwi3WyDCYyQFoll/3k1vili7CG+JUsm9CZN4fIW8oL25Br8eotfkUYfDtOKbMGNhMqPtQ47Rw==",
+            "version": "0.72.1",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.72.1.tgz",
+            "integrity": "sha512-QqXgT+4nOzaangImxMZXYHo93NrlFHRZh1cC3NA3WuwHYkeac7libHLbbPxXctwnP1kiw63Z0BMns9nu7A/6MA==",
             "requires": {
                 "@azure/arm-appinsights": "^2.1.0",
                 "@azure/arm-appservice": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1126,7 +1126,7 @@
         "portfinder": "^1.0.23",
         "ps-tree": "^1.1.1",
         "semver": "^5.7.1",
-        "vscode-azureappservice": "^0.72.0",
+        "vscode-azureappservice": "^0.72.1",
         "vscode-azureextensionui": "^0.38.1",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -10,7 +10,7 @@ import { createGenericClient, IActionContext, UserCancelledError } from 'vscode-
 import { hostStartTaskName } from '../constants';
 import { IPreDebugValidateResult, preDebugValidate } from '../debug/validatePreDebug';
 import { ext } from '../extensionVariables';
-import { IRunningFuncTask, isFuncHostTask, runningFuncTaskMap, stopFuncTaskIfRunning } from '../funcCoreTools/funcHostTask';
+import { failedFuncExecutionMap, IRunningFuncTask, isFuncHostTask, runningFuncTaskMap, stopFuncTaskIfRunning } from '../funcCoreTools/funcHostTask';
 import { localize } from '../localize';
 import { delay } from '../utils/delay';
 import { taskUtils } from '../utils/taskUtils';
@@ -74,9 +74,12 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
     });
 
     try {
+        // NOTE: Can't use taskUtils.executeIfNotActive because of this issue: https://github.com/microsoft/vscode/issues/112247
         // The "IfNotActive" part helps when the user starts, stops and restarts debugging quickly in succession. We want to use the already-active task to avoid two func tasks causing a port conflict error
         // The most common case we hit this is if the "clean" or "build" task is running when we get here. It's unlikely the "func host start" task is active, since we would've stopped it in `waitForPrevFuncTaskToStop` above
-        await taskUtils.executeIfNotActive(funcTask);
+        if (!vscode.tasks.taskExecutions.find(t => taskUtils.isTaskEqual(t.task, funcTask) && !failedFuncExecutionMap.get(workspaceFolder))) {
+            await vscode.tasks.executeTask(funcTask);
+        }
 
         const intervalMs: number = 500;
         const client: ServiceClient = await createGenericClient();

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -13,6 +13,11 @@ export interface IRunningFuncTask {
 
 export const runningFuncTaskMap: Map<vscode.WorkspaceFolder | vscode.TaskScope, IRunningFuncTask> = new Map();
 
+/**
+ * Need to track failed tasks to workaround this issue: https://github.com/microsoft/vscode/issues/112247
+ */
+export const failedFuncExecutionMap: Map<vscode.WorkspaceFolder | vscode.TaskScope, boolean> = new Map();
+
 export function isFuncHostTask(task: vscode.Task): boolean {
     const commandLine: string | undefined = task.execution && (<vscode.ShellExecution>task.execution).commandLine;
     // tslint:disable-next-line: strict-boolean-expressions
@@ -23,16 +28,26 @@ export function registerFuncHostTaskEvents(): void {
     registerEvent('azureFunctions.onDidStartTask', vscode.tasks.onDidStartTaskProcess, async (context: IActionContext, e: vscode.TaskProcessStartEvent) => {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
-        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
-            runningFuncTaskMap.set(e.execution.task.scope, { processId: e.processId });
+        if (e.execution.task.scope !== undefined) {
+            failedFuncExecutionMap.set(e.execution.task.scope, false);
+
+            if (isFuncHostTask(e.execution.task)) {
+                runningFuncTaskMap.set(e.execution.task.scope, { processId: e.processId });
+            }
         }
     });
 
     registerEvent('azureFunctions.onDidEndTask', vscode.tasks.onDidEndTaskProcess, async (context: IActionContext, e: vscode.TaskProcessEndEvent) => {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
-        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
-            runningFuncTaskMap.delete(e.execution.task.scope);
+        if (e.execution.task.scope !== undefined) {
+            if (e.exitCode !== 0) {
+                failedFuncExecutionMap.set(e.execution.task.scope, true);
+            }
+
+            if (isFuncHostTask(e.execution.task)) {
+                runningFuncTaskMap.delete(e.execution.task.scope);
+            }
         }
     });
 


### PR DESCRIPTION
I filed a bug on VS Code and implemented this workaround because `taskExecutions` doesn't seem to be entirely accurate - meaning we don't execute the "func host start" task sometimes when we should