### PR TITLE
Use less risky way to workaround inaccurate taskExecutions

### DIFF
--- a/src/utils/taskUtils.ts
+++ b/src/utils/taskUtils.ts
@@ -34,8 +34,9 @@ export namespace taskUtils {
      * Handles condition where we don't need to start the task because it's already running
      */
     export async function executeIfNotActive(task: Task): Promise<void> {
-        if (!codeTasks.taskExecutions.find(t => isTaskEqual(t.task, task))) {
-            await codeTasks.executeTask(task);
-        }
+        // Temporarily disable this behavior because it's not worth the trouble caused by https://github.com/microsoft/vscode/issues/112247
+        // if (!codeTasks.taskExecutions.find(t => isTaskEqual(t.task, task))) {
+        await codeTasks.executeTask(task);
+        // }
     }
 }


### PR DESCRIPTION
We've got two options to deal with the VS Code bug for this release:
1. Try to maintain `executeIfNotActive` behavior and workaround the VS Code bug
    1. If we do this incorrectly - we risk a case where that task is _not_ active, we think it is so we don't execute it, and the user sees nothing for 60-ish seconds until a timeout error occurs. Also, there's no way to get out of this state except to reload VS Code. I ran into at least one edge case where this happened.
1. Revert back to behavior before `executeIfNotActive`
    1. This means users can run into errors if they mash the "debug" and "stop debugging" buttons (the problem I was trying to fix in https://github.com/microsoft/vscode-azurefunctions/pull/2583). But the errors happen quickly, users can fix this by manually stopping all terminals running the "func host start" task, and they can avoid the problem altogether if they just don't mash those buttons

I'm sad I'm not fixing the original timing issues, but that behavior has been around for a while and I just think option 2 is way less risky.