### PR TITLE
Switch to GitHub Actions for 'needs more info' bot

### DIFF
--- a/.github/needs_more_info.yml
+++ b/.github/needs_more_info.yml
@@ -1,6 +1,0 @@
-{
-    daysUntilClose: 21,
-    needsMoreInfoLabel: 'needs more info',
-    perform: true,
-    closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"
-}

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -1,0 +1,26 @@
+name: Needs More Info Closer
+on:
+  schedule:
+    - cron: 30 5 * * * # 10:30pm PT
+  repository_dispatch:
+    types: [trigger-needs-more-info]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          path: ./actions
+          ref: v42
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Needs More Info Closer
+        uses: ./actions/needs-more-info-closer
+        with:
+          token: ${{secrets.AZCODE_BOT_PAT}}
+          label: needs more info
+          closeDays: 14
+          closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"


### PR DESCRIPTION
The locker action worked last night: https://github.com/microsoft/vscode-azurefunctions/actions/runs/484603743

And I have a bot setup: https://github.com/AzCode-Bot

Let's see if this works, too!