### PR TITLE
Use "readonly" on needs-more-info bot temporarily

### DIFF
--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -24,3 +24,4 @@ jobs:
           label: needs more info
           closeDays: 14
           closeComment: "This issue has been closed automatically because it needs more information and has not had recent activity. See also our [issue reporting](https://aka.ms/azcodeissuereporting) guidelines.\n\nHappy Coding!"
+          readonly: true


### PR DESCRIPTION
The bot [isn't quite doing](https://github.com/microsoft/vscode-azurefunctions/actions/runs/488728389) what I thought it would and I think this flag will let it log more about what it _would_ do without actually doing anything.