### PR TITLE
Use bots from azuretools repo instead of VS Code's repo

### DIFF
--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -2,23 +2,22 @@ name: Locker
 on:
   schedule:
     - cron: 0 5 * * * # 10:00pm PT
-  repository_dispatch:
-    types: [trigger-locker]
+  workflow_dispatch:
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
+      - name: Checkout triage-actions
         uses: actions/checkout@v2
         with:
-          repository: "microsoft/vscode-github-triage-actions"
-          path: ./actions
-          ref: v42
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
+          repository: "microsoft/vscode-azuretools"
+          path: ./azuretools
+          ref: main
+      - name: npm install
+        run: npm install --production --prefix ./azuretools/triage-actions
       - name: Run Locker
-        uses: ./actions/locker
+        uses: ./azuretools/triage-actions/locker
         with:
           daysSinceClose: 45
           daysSinceUpdate: 7

--- a/.github/workflows/needs-more-info-closer.yml
+++ b/.github/workflows/needs-more-info-closer.yml
@@ -2,23 +2,22 @@ name: Needs More Info Closer
 on:
   schedule:
     - cron: 30 5 * * * # 10:30pm PT
-  repository_dispatch:
-    types: [trigger-needs-more-info]
+  workflow_dispatch:
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Actions
+      - name: Checkout triage-actions
         uses: actions/checkout@v2
         with:
-          repository: "microsoft/vscode-github-triage-actions"
-          path: ./actions
-          ref: v42
-      - name: Install Actions
-        run: npm install --production --prefix ./actions
+          repository: "microsoft/vscode-azuretools"
+          path: ./azuretools
+          ref: main
+      - name: npm install
+        run: npm install --production --prefix ./azuretools/triage-actions
       - name: Run Needs More Info Closer
-        uses: ./actions/needs-more-info-closer
+        uses: ./azuretools/triage-actions/needs-more-info-closer
         with:
           token: ${{secrets.AZCODE_BOT_PAT}}
           label: needs more info


### PR DESCRIPTION
Depends on https://github.com/microsoft/vscode-azuretools/pull/837

Also I switched out `repository_dispatch` for `workflow_dispatch`. The former requires me to manually send an http request to kick off the action and I think the latter should just give me a big ol' button that says "Run Workflow" in the web UI and should let me select a different branch, too (i.e. for testing purposes).