### PR TITLE
Fixing regex to allow C# projects with the word 'extensions' at the end of their name

### DIFF
--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -19,7 +19,7 @@ export namespace dotnetUtils {
     export async function getProjFiles(projectLanguage: ProjectLanguage, projectPath: string): Promise<string[]> {
         const regexp: RegExp = projectLanguage === ProjectLanguage.FSharp ? /\.fsproj$/i : /\.csproj$/i;
         const files: string[] = await fse.readdir(projectPath);
-        return files.filter((f: string) => regexp.test(f) && !/extensions\.csproj$/i.test(f));
+        return files.filter((f: string) => regexp.test(f) && !/^extensions\.csproj$/i.test(f));
     }
 
     export async function getTargetFramework(projFilePath: string): Promise<string> {


### PR DESCRIPTION
The `getProjFiles` function in [dotnetUtils.ts](https://github.com/microsoft/vscode-azurefunctions/blob/main/src/utils/dotnetUtils.ts) is called when creating a new C# Azure Functions project. According to a comment right above it, "extensions.csproj" has a special meaning for the func cli, so this function explicitly excludes it. However, the regex used to do this is actually excluding anything that ends in "extensions.csproj" (case-insensitive). Consequently, trying to create a project called "MyAwesomeExtensions", for example, would generate a file named `MyAwesomeExtensions.csproj`, and then the operation would fail because of this check. This change fixes the regex to strictly match `extensions.csproj`.