### PR TITLE
Turn off "readonly" for stale bot

### DIFF
--- a/.github/workflows/stale-closer.yml
+++ b/.github/workflows/stale-closer.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           token: ${{secrets.AZCODE_BOT_PAT}}
           closeDays: 240
-          closeComment: ':slightly_frowning_face: In the last 60 days, this issue has received less than 5 community upvotes and we closed it. Still a big Thank You to you for taking the time to create it! To learn more about how we handle issues, please see our [documentation](https://aka.ms/azcodeissuetriaging).\n\nHappy Coding!'
+          closeComment: ":slightly_frowning_face: In the last 60 days, this issue has received less than 5 community upvotes and we closed it. Still a big Thank You to you for taking the time to create it! To learn more about how we handle issues, please see our [documentation](https://aka.ms/azcodeissuetriaging).\n\nHappy Coding!"
           warnDays: 60
-          warnComment: 'This issue has become stale and is at risk of being closed. The community has 60 days to upvote the issue. If it receives 5 upvotes we will keep it open and take another look. If not, we will close it. To learn more about how we handle issues, please see our [documentation](https://aka.ms/azcodeissuetriaging).\n\nHappy Coding!'
+          warnComment: "This issue has become stale and is at risk of being closed. The community has 60 days to upvote the issue. If it receives 5 upvotes we will keep it open and take another look. If not, we will close it. To learn more about how we handle issues, please see our [documentation](https://aka.ms/azcodeissuetriaging).\n\nHappy Coding!"
           upvotesRequired: 5
           numCommentsOverride: 10
-          candidateMilestone: 'Backlog Candidates'
-          labelsToExclude: 'P0,P1'
-          staleLabel: 'out of scope'
+          candidateMilestone: "Backlog Candidates"
+          labelsToExclude: "P0,P1"
+          staleLabel: "out of scope"

--- a/.github/workflows/stale-closer.yml
+++ b/.github/workflows/stale-closer.yml
@@ -29,4 +29,3 @@ jobs:
           candidateMilestone: 'Backlog Candidates'
           labelsToExclude: 'P0,P1'
           staleLabel: 'out of scope'
-          readonly: true


### PR DESCRIPTION
I ran the bot without readonly and it seemed to work (aka it commented on the right issues)! I then ran it again _with_ readonly to make sure it wasn't going to _double_ comment, and that also worked. Now I feel like I can let it run nightly from main without the readonly flag.

Only minor problem was the "warnComment" didn't handle "\n" correctly. Apparently in yml I have to [use double quotes instead of single](https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml#:~:text=Single%20quotes%20let%20you%20put,as%20a%20line%20feed%20character.)