### PR TITLE
Search entire workspace for "host.json" in activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
         "onCommand:azureFunctions.addBinding",
         "onCommand:azureFunctions.setAzureWebJobsStorage",
         "onCommand:azureFunctions.reportIssue",
-        "workspaceContains:host.json",
-        "workspaceContains:*/host.json",
+        "workspaceContains:**/host.json",
         "onView:azFuncTree",
         "onDebugInitialConfigurations"
     ],


### PR DESCRIPTION
We initially chose to only search the root and one level down for performance reasons. However, VS Code had a bug where they would actually search the whole workspace even though we didn't specify it. They fixed that bug in the latest release and it seems like some users have come to rely on that behavior.

I looked into other activation events, but didn't find any that would work. I feel like we should make this change to get us back to the previous behavior, but we could always do more investigating in the future to help with startup performance.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2654