### PR TITLE
Add restart to the launch config for nodejs projects

### DIFF
--- a/src/debug/NodeDebugProvider.ts
+++ b/src/debug/NodeDebugProvider.ts
@@ -15,7 +15,8 @@ export const nodeDebugConfig: DebugConfiguration = {
     type: 'node',
     request: 'attach',
     port: defaultNodeDebugPort,
-    preLaunchTask: hostStartTaskName
+    preLaunchTask: hostStartTaskName,
+    restart: true
 };
 
 export class NodeDebugProvider extends FuncDebugProviderBase {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/781
Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/573

Tracking for Python: https://github.com/microsoft/vscode-python/issues/15431

We discussed offline if we should retroactively ask users to alter their launch configurations for them, but we decided it was probably going to annoy most current users rather than help them.  It's pretty easy for a user to add the restart property to their own `launch.json`.