### PR TITLE
Fix slow C# debugging on mac/linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "ps-tree": "^1.1.1",
                 "semver": "^5.7.1",
                 "vscode-azureappservice": "^0.73.0",
-                "vscode-azureextensionui": "^0.39.2",
+                "vscode-azureextensionui": "^0.39.3",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1",
                 "websocket": "^1.0.29",
@@ -13171,9 +13171,9 @@
             }
         },
         "node_modules/vscode-azureextensionui": {
-            "version": "0.39.2",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.2.tgz",
-            "integrity": "sha512-ekDnGW4K60tracj4hjWrcvsduOfIeEI+i0soqSim67JeGmpji/zIBx82bPl5n9w6PnEOG8+UiKglOxK8//Z/YA==",
+            "version": "0.39.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.3.tgz",
+            "integrity": "sha512-n9vFbK8+ZY6QtJU2gNeWjp0YNsTxLuRHMFSZzVMs51DK1zpgMeFeWuCI/r8KaKclOyu3kV8O3rGgRLS5sA0T3Q==",
             "dependencies": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-storage": "^15.0.0",
@@ -25516,9 +25516,9 @@
             }
         },
         "vscode-azureextensionui": {
-            "version": "0.39.2",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.2.tgz",
-            "integrity": "sha512-ekDnGW4K60tracj4hjWrcvsduOfIeEI+i0soqSim67JeGmpji/zIBx82bPl5n9w6PnEOG8+UiKglOxK8//Z/YA==",
+            "version": "0.39.3",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.39.3.tgz",
+            "integrity": "sha512-n9vFbK8+ZY6QtJU2gNeWjp0YNsTxLuRHMFSZzVMs51DK1zpgMeFeWuCI/r8KaKclOyu3kV8O3rGgRLS5sA0T3Q==",
             "requires": {
                 "@azure/arm-resources": "^3.0.0",
                 "@azure/arm-storage": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "workspaceContains:**/host.json",
         "onView:azFuncTree",
         "onDebugInitialConfigurations",
-	  "onUri"
+        "onUri"
     ],
     "main": "./main.js",
     "contributes": {
@@ -1034,11 +1034,11 @@
                         "description": "%azureFunctions.showReloadTemplates%",
                         "default": false
                     },
-		      "azureFunctions.enableOpenFromPortal": {
-            		  "type": "boolean",
-            		  "description": "Enable download content and setup project feature using handle uri (experimental)",
-            		 "default": false
-          	      }
+                    "azureFunctions.enableOpenFromPortal": {
+                        "type": "boolean",
+                        "description": "Enable download content and setup project feature using handle uri (experimental)",
+                        "default": false
+                    }
                 }
             }
         ]

--- a/package.json
+++ b/package.json
@@ -1117,7 +1117,7 @@
         "ps-tree": "^1.1.1",
         "semver": "^5.7.1",
         "vscode-azureappservice": "^0.73.0",
-        "vscode-azureextensionui": "^0.39.2",
+        "vscode-azureextensionui": "^0.39.3",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",
         "websocket": "^1.0.29",

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -111,7 +111,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         });
 
         try {
-            const response: HttpOperationResponse = await requestUtils.sendRequestWithTimeout({ method: 'GET', url: this.azModuleGalleryUrl });
+            const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout({ method: 'GET', url: this.azModuleGalleryUrl });
             const versionResult: string = this.parseLatestAzModuleVersion(response);
             const [major]: string[] = versionResult.split('.');
             return parseInt(major);

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -64,7 +64,7 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
             headers['x-functions-key'] = (await client.listHostKeys()).masterKey;
         }
         try {
-            responseText = (await requestUtils.sendRequestWithTimeout({ method: 'POST', url, headers, body })).bodyAsText;
+            responseText = (await requestUtils.sendRequestWithExtTimeout({ method: 'POST', url, headers, body })).bodyAsText;
         } catch (error) {
             if (!client && parseError(error).errorType === 'ECONNREFUSED') {
                 context.errorHandling.suppressReportIssue = true;

--- a/src/funcCoreTools/getNpmDistTag.ts
+++ b/src/funcCoreTools/getNpmDistTag.ts
@@ -18,7 +18,7 @@ interface IPackageMetadata {
 }
 
 export async function getNpmDistTag(version: FuncVersion): Promise<INpmDistTag> {
-    const response: HttpOperationResponse = await requestUtils.sendRequestWithTimeout({ method: 'GET', url: npmRegistryUri });
+    const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout({ method: 'GET', url: npmRegistryUri });
     const packageMetadata: IPackageMetadata = <IPackageMetadata>response.parsedBody;
     const majorVersion: string = getMajorVersion(version);
 

--- a/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -108,7 +108,7 @@ async function getNewestFunctionRuntimeVersion(packageManager: PackageManager | 
         if (packageManager === PackageManager.brew) {
             const packageName: string = getBrewPackageName(versionFromSetting);
             const url: string = `https://raw.githubusercontent.com/Azure/homebrew-functions/master/Formula/${packageName}.rb`;
-            const response: HttpOperationResponse = await requestUtils.sendRequestWithTimeout({ method: 'GET', url });
+            const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout({ method: 'GET', url });
             const brewInfo: string = nonNullProp(response, 'bodyAsText');
             const matches: RegExpMatchArray | null = brewInfo.match(/version\s+["']([^"']+)["']/i);
             if (matches && matches.length > 1) {

--- a/src/utils/feedUtils.ts
+++ b/src/utils/feedUtils.ts
@@ -24,7 +24,7 @@ export namespace feedUtils {
     export async function getJsonFeed<T extends {}>(url: string): Promise<T> {
         let cachedFeed: ICachedFeed | undefined = cachedFeeds.get(url);
         if (!cachedFeed || Date.now() > cachedFeed.nextRefreshTime) {
-            const response: HttpOperationResponse = await requestUtils.sendRequestWithTimeout({ method: 'GET', url });
+            const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout({ method: 'GET', url });
             // NOTE: r.parsedBody doesn't work because these feeds sometimes return with a BOM char or incorrect content-type
             cachedFeed = { data: parseJson(nonNullProp(response, 'bodyAsText')), nextRefreshTime: Date.now() + 10 * 60 * 1000 };
             cachedFeeds.set(url, cachedFeed);


### PR DESCRIPTION
I noticed C# debugging was slow recently, and confirmed with telemetry that it got a lot slower in our 1.2.1 release (only for mac/linux, though - I have no idea why Windows was spared).

It's because ms-rest-js is _too good_ at retrying after [this fix](https://github.com/microsoft/vscode-azurefunctions/pull/2658). If it gets a single `ECONNREFUSED` from the status url request, it will wait their default retry interval (30 seconds) before retrying. We'll avoid that by just turning off the retry policies when we have a timeout.

Depends on https://github.com/microsoft/vscode-azuretools/pull/854