### PR TITLE
Update Json CLI tool to work with .NET 5

### DIFF
--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -26,6 +26,11 @@ jobs:
     inputs:
       version: 3.0.x
 
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 5.0.x'
+    inputs:
+      version: 5.0.x
+
   - task: NuGetCommand@2
     displayName: 'restore'
     inputs:
@@ -56,6 +61,16 @@ jobs:
       publishWebProjects: false
       projects: '$(ProjectPath)'
       arguments: '--configuration $(BuildConfiguration) --framework netcoreapp3.0 --no-build'
+      zipAfterPublish: false
+      modifyOutputPath: false
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 5.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework net5.0 --no-build'
       zipAfterPublish: false
       modifyOutputPath: false
 

--- a/tools/JsonCli/.vscode/tasks.json
+++ b/tools/JsonCli/.vscode/tasks.json
@@ -42,6 +42,22 @@
                 "${workspaceFolder}/src/Microsoft.TemplateEngine.JsonCli.csproj"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish (5.0)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "--configuration",
+                "Release",
+                "--framework",
+                "net5.0",
+                "--output",
+                "${workspaceFolder}/../../resources/dotnetJsonCli/net5.0/",
+                "${workspaceFolder}/src/Microsoft.TemplateEngine.JsonCli.csproj"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
+++ b/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\resources\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
         <DelaySign>true</DelaySign>

--- a/tools/JsonCli/src/Signing.csproj
+++ b/tools/JsonCli/src/Signing.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0</TargetFrameworks>
         <!-- Since this project is just for signing, we don't want to actually build anything -->
         <DefaultItemExcludes>$(DefaultItemExcludes);**/*.cs</DefaultItemExcludes>
     </PropertyGroup>

--- a/tools/JsonCli/src/nuget.config
+++ b/tools/JsonCli/src/nuget.config
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="Dotnet Template Feed" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
-    <add key="Dotnet Core Feed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <clear />
+    <!-- based off of this repo's nuget config https://github.com/dotnet/sdk/blob/master/NuGet.config -->
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <!-- used for signing -->
     <add key="MicroBuild Feed" value="https://devdiv.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
1. Add .NET 5 to the target frameworks
2. Fix the problem where this tool uses incorrect templates when switching between .NET Core 3.1 and .NET 5. The problem is that it uses the same cache location in all cases (`~/.templateengine/AzureFunctions-VSCodeExtension/`). I added a "templateDir" parameter that should be unique per-case and will be used for both the cache and nuget packages. Here is what an example path would look like: `/Users/erijiz/Library/Application Support/Code/User/globalStorage/ms-azuretools.vscode-azurefunctions/~3/net5.0-isolated/`