### PR TITLE
Update TypeScript project default dependencies

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -20,8 +20,8 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
     };
 
     protected packageJsonDevDeps: { [key: string]: string } = {
-        '@azure/functions': '^1.0.2-beta2',
-        typescript: '^3.3.3'
+        '@azure/functions': '^1.2.3',
+        typescript: '^4.0.0'
     };
 
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {


### PR DESCRIPTION
- Update users to TypeScript 4 since it's been out a while and there's [supposedly](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/) "no major breaking changes"
- Update `@azure/functions` just so the minimum isn't referencing a beta version (Users already get the latest 1.* version after they do `npm install`, so this is not a functional change)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2708