### PR TITLE
Only include GA versions for .NET "getFramework"

### DIFF
--- a/src/templates/dotnet/executeDotnetTemplateCommand.ts
+++ b/src/templates/dotnet/executeDotnetTemplateCommand.ts
@@ -60,7 +60,8 @@ async function getFramework(context: IActionContext, workingDirectory: string | 
 
         const majorVersions: number[] = [5, 3, 2];
         for (const majorVersion of majorVersions) {
-            const regExp: RegExp = new RegExp(`^\\s*${majorVersion}\\.`, 'm');
+            // NOTE: We only want GA versions (i.e. 1.0.0), not preview versions (i.e. 1.0.0-alpha)
+            const regExp: RegExp = new RegExp(`^\\s*${majorVersion}\\.[0-9]+\\.[0-9]+(\\s|$)`, 'm');
             if (regExp.test(versions)) {
                 cachedFramework = `net${majorVersion < 4 ? 'coreapp' : ''}${majorVersion}.0`;
                 break;


### PR DESCRIPTION
I got an error using the JsonCLI tool because it tried to use .NET 5, but I only had preview versions installed on that machine. I think that's a fair error, so I'll exclude preview versions from our "getFramework" logic. My new regex basically just looks for a GA version followed by either EOL or whitespace (which would exclude a hyphen)

Typical values for "versions" look like this:
```
5.0.103
```
```
2.1.807 [/usr/local/share/dotnet/sdk]
3.1.403 [/usr/local/share/dotnet/sdk]
5.0.100-rc.2.20479.15 [/usr/local/share/dotnet/sdk]
5.0.103 [/usr/local/share/dotnet/sdk]
```