### PR TITLE
Show .NET 5 when creating function app

### DIFF
--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -40,11 +40,29 @@ export async function getStackPicks(context: IFunctionAppWizardContext): Promise
         }
     }
 
-    return picks;
+    return picks.sort((p1, p2) => {
+        return p1.data.stack.value !== p2.data.stack.value ?
+            0 : // keep order as-is if they're different stacks (i.e. Node.js vs. .NET)
+            getPriority(p1.data.minorVersion.stackSettings) - getPriority(p2.data.minorVersion.stackSettings); // otherwise sort based on priority
+    });
 }
 
-function isFlagSet(ss: FunctionAppRuntimes, key: 'isPreview' | 'isEarlyAccess'): boolean {
+function isFlagSet(ss: FunctionAppRuntimes, key: 'isHidden' | 'isDefault' | 'isPreview' | 'isEarlyAccess'): boolean {
     return !![ss.linuxRuntimeSettings, ss.windowsRuntimeSettings].find(s => s && s[key]);
+}
+
+function getPriority(ss: FunctionAppRuntimes): number {
+    if (isFlagSet(ss, 'isDefault')) {
+        return 1;
+    } else if (isFlagSet(ss, 'isEarlyAccess')) {
+        return 3;
+    } else if (isFlagSet(ss, 'isPreview')) {
+        return 4;
+    } else if (isFlagSet(ss, 'isHidden')) {
+        return 5;
+    } else {
+        return 2;
+    }
 }
 
 async function getStacks(context: IFunctionAppWizardContext & { _stacks?: FunctionAppStack[] }): Promise<FunctionAppStack[]> {
@@ -55,12 +73,44 @@ async function getStacks(context: IFunctionAppWizardContext & { _stacks?: Functi
             url: 'https://aka.ms/AAa5ia0',
             queryParameters: {
                 'api-version': '2020-10-01',
-                removeHiddenStacks: String(!getWorkspaceSetting<boolean>(hiddenStacksSetting)),
                 removeDeprecatedStacks: 'true'
             }
         });
         context._stacks = <FunctionAppStack[]>result.parsedBody;
+
+        removeHiddenStacks(context._stacks);
     }
 
     return context._stacks;
+}
+
+
+function removeHiddenStacks(stacks: FunctionAppStack[]): void {
+    const showHiddenStacks = getWorkspaceSetting<boolean>(hiddenStacksSetting);
+    for (const stack of stacks) {
+        for (const major of stack.majorVersions) {
+            for (const minor of major.minorVersions) {
+                // Temporary workaround because the platform team doesn't want .NET 5 to show in the portal yet, but they do want it in VS Code
+                // https://github.com/microsoft/vscode-azurefunctions/issues/2552
+                if (major.value === 'dotnet5') {
+                    if (minor.stackSettings.linuxRuntimeSettings) {
+                        minor.stackSettings.linuxRuntimeSettings.isHidden = false;
+                    }
+                    if (minor.stackSettings.windowsRuntimeSettings) {
+                        minor.stackSettings.windowsRuntimeSettings.isHidden = false;
+                    }
+                }
+
+                if (!showHiddenStacks) {
+                    if (minor.stackSettings.linuxRuntimeSettings?.isHidden) {
+                        delete minor.stackSettings.linuxRuntimeSettings;
+                    }
+
+                    if (minor.stackSettings.windowsRuntimeSettings?.isHidden) {
+                        delete minor.stackSettings.windowsRuntimeSettings;
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
and add sorting logic so that the LTS runtime (".NET Core 3.1", which is listed as "default" in the stacks API) still shows up first

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2552