### PR TITLE
Support listing functions and "copy function url" for .NET 5

### DIFF
--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -39,6 +39,9 @@ export async function addBinding(context: IActionContext, data: Uri | LocalFunct
             data = await ext.tree.showTreeItemPicker<LocalFunctionTreeItem>(/Local;ReadWrite;Function;/i, { ...context, noItemFoundErrorMessage });
         }
 
+        if (!data.functionJsonPath) {
+            throw new Error(localize('addBindingNotSupported', 'Add binding is not supported for this project type.'));
+        }
         functionJsonPath = data.functionJsonPath;
 
         const projectTi: LocalProjectTreeItem = data.parent.parent;

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementModels } from '@azure/arm-appservice';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { deploy as innerDeploy, getDeployFsPath, getDeployNode, IDeployContext, IDeployPaths, showDeployConfirmation } from 'vscode-azureappservice';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
@@ -100,12 +99,11 @@ async function updateWorkerProcessTo64BitIfRequired(context: IDeployContext, sit
     if (functionProject === undefined) {
         return;
     }
-    const projectFiles: string[] = await dotnetUtils.getProjFiles(language, functionProject);
+    const projectFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(language, functionProject);
     if (projectFiles.length !== 1) {
         return;
     }
-    const mainProject: string = path.join(functionProject, projectFiles[0]);
-    const platformTarget: string | undefined = await dotnetUtils.tryGetPlatformTarget(mainProject);
+    const platformTarget: string | undefined = await dotnetUtils.tryGetPlatformTarget(projectFiles[0]);
     if (platformTarget === 'x64' && siteConfig.use32BitWorkerProcess === true) {
         const message: string = localize('overwriteSetting', 'The remote app targets "{0}", but your local project targets "{1}". Update remote app to "{1}"?', '32 bit', '64 bit');
         const deployAnyway: vscode.MessageItem = { title: localize('deployAnyway', 'Deploy Anyway') };

--- a/src/commands/deploy/notifyDeployComplete.ts
+++ b/src/commands/deploy/notifyDeployComplete.ts
@@ -7,7 +7,6 @@ import * as retry from 'p-retry';
 import { MessageItem, window } from 'vscode';
 import { AzExtTreeItem, AzureTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
-import { HttpAuthLevel } from '../../funcConfig/function';
 import { localize } from '../../localize';
 import { RemoteFunctionsTreeItem } from '../../tree/remoteProject/RemoteFunctionsTreeItem';
 import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionTreeItem';
@@ -64,7 +63,7 @@ async function listHttpTriggerUrls(context: IActionContext, node: SlotTreeItemBa
     const logOptions: {} = { resourceName: node.client.fullName };
     let hasHttpTriggers: boolean = false;
     const functions: AzExtTreeItem[] = await functionsNode.getCachedChildren(context);
-    const anonFunctions: RemoteFunctionTreeItem[] = <RemoteFunctionTreeItem[]>functions.filter((f: AzureTreeItem) => f instanceof RemoteFunctionTreeItem && f.config.isHttpTrigger && f.config.authLevel === HttpAuthLevel.anonymous);
+    const anonFunctions: RemoteFunctionTreeItem[] = <RemoteFunctionTreeItem[]>functions.filter((f: AzureTreeItem) => f instanceof RemoteFunctionTreeItem && f.isHttpTrigger && f.isAnonymous);
     if (anonFunctions.length > 0) {
         hasHttpTriggers = true;
         ext.outputChannel.appendLog(localize('anonymousFunctionUrls', 'HTTP Trigger Urls:'), logOptions);
@@ -73,7 +72,7 @@ async function listHttpTriggerUrls(context: IActionContext, node: SlotTreeItemBa
         }
     }
 
-    if (functions.find((f: AzureTreeItem) => f instanceof RemoteFunctionTreeItem && f.config.isHttpTrigger && f.config.authLevel !== HttpAuthLevel.anonymous)) {
+    if (functions.find((f: AzureTreeItem) => f instanceof RemoteFunctionTreeItem && f.isHttpTrigger && !f.isAnonymous)) {
         hasHttpTriggers = true;
         ext.outputChannel.appendLog(localize('nonAnonymousWarning', 'WARNING: Some http trigger urls cannot be displayed in the output window because they require an authentication token. Instead, you may copy them from the Azure Functions explorer.'), logOptions);
     }

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -21,11 +21,11 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
     }
 
     const client: SiteClient | undefined = node instanceof RemoteFunctionTreeItem ? node.parent.parent.root.client : undefined;
-    const triggerBindingType: string | undefined = node.config.triggerBinding?.type;
+    const triggerBindingType: string | undefined = node.triggerBindingType;
     context.telemetry.properties.triggerBindingType = triggerBindingType;
 
     let functionInput: string | {} = '';
-    if (!node.config.isTimerTrigger) {
+    if (!node.isTimerTrigger) {
         const prompt: string = localize('enterRequestBody', 'Enter request body');
         let value: string | undefined;
         if (triggerBindingType) {
@@ -48,7 +48,7 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
 
     let url: string;
     let body: {};
-    if (node.config.isHttpTrigger) {
+    if (node.isHttpTrigger) {
         url = nonNullProp(node, 'triggerUrl');
         body = functionInput;
     } else {

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
@@ -47,11 +47,11 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
         const projectPath: string = context.projectPath;
         const language: ProjectLanguage = nonNullProp(context, 'language');
 
-        let projFileName: string;
-        const projFiles: string[] = await dotnetUtils.getProjFiles(language, projectPath);
+        let projFile: dotnetUtils.ProjectFile;
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(language, projectPath);
         const fileExt: string = language === ProjectLanguage.FSharp ? 'fsproj' : 'csproj';
         if (projFiles.length === 1) {
-            projFileName = projFiles[0];
+            projFile = projFiles[0];
         } else if (projFiles.length === 0) {
             context.errorHandling.suppressReportIssue = true;
             throw new Error(localize('projNotFound', 'Failed to find {0} file in folder "{1}".', fileExt, path.basename(projectPath)));
@@ -60,9 +60,7 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
             throw new Error(localize('projNotFound', 'Expected to find a single {0} file in folder "{1}", but found multiple instead: {2}.', fileExt, path.basename(projectPath), projFiles.join(', ')));
         }
 
-        const projFilePath: string = path.join(projectPath, projFileName);
-
-        const versionInProjFile: string | undefined = await dotnetUtils.tryGetFuncVersion(projFilePath);
+        const versionInProjFile: string | undefined = await dotnetUtils.tryGetFuncVersion(projFile);
         context.telemetry.properties.versionInProjFile = versionInProjFile;
         // The version from the proj file takes precedence over whatever was set in `context` before this
         context.version = tryParseFuncVersion(versionInProjFile) || context.version;
@@ -87,7 +85,7 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
             }
         }
 
-        const targetFramework: string = await dotnetUtils.getTargetFramework(projFilePath);
+        const targetFramework: string = await dotnetUtils.getTargetFramework(projFile);
         this.setDeploySubpath(context, `bin/Release/${targetFramework}/publish`);
         this._debugSubpath = dotnetUtils.getDotnetDebugSubpath(targetFramework);
     }

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -18,6 +18,9 @@ export async function viewProperties(context: IActionContext, node?: SlotTreeIte
     }
 
     if (node instanceof LocalFunctionTreeItem) {
+        if (!node.functionJsonPath) {
+            throw new Error(localize('viewPropsNotSupported', 'View function properties is not supported for this project type.'));
+        }
         await window.showTextDocument(Uri.file(node.functionJsonPath));
     } else {
         let data: {};
@@ -29,7 +32,7 @@ export async function viewProperties(context: IActionContext, node?: SlotTreeIte
             });
             data = node.site;
         } else {
-            data = node.config.data;
+            data = node.rawConfig;
         }
 
         await openReadOnlyJson(node, data);

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -7,14 +7,13 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Work
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { isFunctionProject } from '../commands/createNewProject/verifyIsProject';
 import { hostStartTaskName } from '../constants';
+import { ext } from '../extensionVariables';
 import { IPreDebugValidateResult, preDebugValidate } from './validatePreDebug';
 
 export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
     public abstract workerArgKey: string;
     protected abstract defaultPortOrPipeName: number | string;
     protected abstract debugConfig: DebugConfiguration;
-
-    private readonly _debugPorts: Map<WorkspaceFolder | undefined, number | undefined> = new Map<WorkspaceFolder | undefined, number | undefined>();
 
     public abstract getWorkerArgValue(folder: WorkspaceFolder): Promise<string>;
 
@@ -45,7 +44,7 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
             context.errorHandling.suppressDisplay = true;
             context.telemetry.suppressIfSuccessful = true;
 
-            this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
+            ext.debugPorts.set(folder, <number | undefined>debugConfiguration.port);
             if (debugConfiguration.preLaunchTask === hostStartTaskName) {
                 context.telemetry.properties.isActivationEvent = 'false';
                 context.telemetry.suppressIfSuccessful = false;
@@ -63,6 +62,6 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
     }
 
     protected getDebugPortOrPipeName(folder: WorkspaceFolder): number | string {
-        return this._debugPorts.get(folder) || this.defaultPortOrPipeName;
+        return ext.debugPorts.get(folder) || this.defaultPortOrPipeName;
     }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext, TreeView } from "vscode";
+import { ExtensionContext, TreeView, WorkspaceFolder } from "vscode";
 import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 import { func } from "./constants";
 import { CentralTemplateProvider } from "./templates/CentralTemplateProvider";
@@ -25,6 +25,7 @@ export namespace ext {
     export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'azureFunctions';
     export let experimentationService: IExperimentationServiceAdapter;
+    export const debugPorts = new Map<WorkspaceFolder | undefined, number | undefined>();
 }
 
 export enum TemplateSource {

--- a/src/funcConfig/function.ts
+++ b/src/funcConfig/function.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from "../localize";
-
 export interface IFunctionJson {
     disabled?: boolean;
     scriptFile?: string;
@@ -67,16 +65,11 @@ export class ParsedFunctionJson {
         return !!this.triggerBinding && !!this.triggerBinding.type && /^timer/i.test(this.triggerBinding.type);
     }
 
-    public get authLevel(): HttpAuthLevel {
+    public get authLevel(): HttpAuthLevel | undefined {
         if (this.triggerBinding && this.triggerBinding.authLevel) {
-            const authLevel: HttpAuthLevel | undefined = <HttpAuthLevel>HttpAuthLevel[this.triggerBinding.authLevel.toLowerCase()];
-            if (authLevel === undefined) {
-                throw new Error(localize('unrecognizedAuthLevel', 'Unrecognized auth level "{0}".', this.triggerBinding.authLevel));
-            } else {
-                return authLevel;
-            }
+            return <HttpAuthLevel | undefined>HttpAuthLevel[this.triggerBinding.authLevel.toLowerCase()];
         } else {
-            return HttpAuthLevel.function;
+            return undefined;
         }
     }
 }

--- a/src/tree/FunctionTreeItemBase.ts
+++ b/src/tree/FunctionTreeItemBase.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { WebSiteManagementModels } from '@azure/arm-appservice';
 import * as url from 'url';
-import { AzExtTreeItem, TreeItemIconPath } from 'vscode-azureextensionui';
-import { ParsedFunctionJson } from '../funcConfig/function';
+import { AzExtTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { HttpAuthLevel, ParsedFunctionJson } from '../funcConfig/function';
 import { IParsedHostJson } from '../funcConfig/host';
 import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
@@ -16,17 +17,19 @@ import { getProjectContextValue, ProjectResource } from './projectContextValues'
 
 export abstract class FunctionTreeItemBase extends AzExtTreeItem {
     public readonly parent: FunctionsTreeItemBase;
-    public readonly config: ParsedFunctionJson;
     public readonly name: string;
     public readonly commandId: string = 'azureFunctions.viewProperties';
     public triggerUrl: string | undefined;
 
+    protected readonly _config: ParsedFunctionJson;
     private _disabled: boolean;
+    private _func: WebSiteManagementModels.FunctionEnvelope | undefined;
 
-    protected constructor(parent: FunctionsTreeItemBase, config: ParsedFunctionJson, name: string) {
+    protected constructor(parent: FunctionsTreeItemBase, config: ParsedFunctionJson, name: string, func: WebSiteManagementModels.FunctionEnvelope | undefined) {
         super(parent);
-        this.config = config;
+        this._config = config;
         this.name = name;
+        this._func = func;
     }
 
     public get id(): string {
@@ -37,11 +40,32 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
         return this.name;
     }
 
+    public get isHttpTrigger(): boolean {
+        // invokeUrlTemplate take precedence. Config can't always be retrieved
+        return !!this._func?.invokeUrlTemplate || this._config.isHttpTrigger;
+    }
+
+    public get isTimerTrigger(): boolean {
+        return this._config.isTimerTrigger;
+    }
+
+    public get isAnonymous(): boolean {
+        return this._config.authLevel === HttpAuthLevel.anonymous;
+    }
+
+    public get rawConfig(): {} {
+        return this._config.data;
+    }
+
+    public get triggerBindingType(): string | undefined {
+        return this._config.triggerBinding?.type;
+    }
+
     public get contextValue(): string {
         let triggerType: string;
-        if (this.config.isHttpTrigger) {
+        if (this.isHttpTrigger) {
             triggerType = 'Http';
-        } else if (this.config.isTimerTrigger) {
+        } else if (this.isTimerTrigger) {
             triggerType = 'Timer';
         } else {
             triggerType = 'Unknown';
@@ -54,9 +78,9 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
 
     public get description(): string | undefined {
         const descriptions: string[] = [];
-        if (this.config.isHttpTrigger) {
+        if (this.isHttpTrigger) {
             descriptions.push(localize('http', 'HTTP'));
-        } else if (this.config.isTimerTrigger) {
+        } else if (this.isTimerTrigger) {
             descriptions.push(localize('timer', 'Timer'));
         }
 
@@ -77,20 +101,32 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
 
     public abstract getKey(): Promise<string | undefined>;
 
-    public async refreshImpl(): Promise<void> {
-        if (this.config.isHttpTrigger) {
+    public async refreshImpl(_context: IActionContext, isInitializing?: boolean): Promise<void> {
+        if (!isInitializing) { // no need to refresh "_func" if we're initializing the class since it's set in the constructor
+            this._func = await this.refreshFuncEnvelope();
+        }
+
+        if (this.isHttpTrigger) {
             await this.refreshTriggerUrl();
         }
 
         await this.refreshDisabledState();
     }
 
-    private async refreshTriggerUrl(): Promise<void> {
-        const triggerUrl: url.URL = new url.URL(this.parent.parent.hostUrl);
+    public abstract refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined>;
 
-        const route: string = (this.config.triggerBinding && this.config.triggerBinding.route) || this.name;
-        const hostJson: IParsedHostJson = await this.parent.parent.getHostJson();
-        triggerUrl.pathname = `${hostJson.routePrefix}/${route}`;
+    private async refreshTriggerUrl(): Promise<void> {
+        const hostUrl = new url.URL(this.parent.parent.hostUrl);
+        let triggerUrl: url.URL;
+        if (this._func?.invokeUrlTemplate) {
+            triggerUrl = new url.URL(this._func?.invokeUrlTemplate);
+            triggerUrl.protocol = hostUrl.protocol; // invokeUrlTemplate seems to use the wrong protocol sometimes. Make sure it matches the hostUrl
+        } else {
+            triggerUrl = hostUrl;
+            const route: string = (this._config.triggerBinding && this._config.triggerBinding.route) || this.name;
+            const hostJson: IParsedHostJson = await this.parent.parent.getHostJson();
+            triggerUrl.pathname = `${hostJson.routePrefix}/${route}`;
+        }
 
         const key: string | undefined = await this.getKey();
         if (key) {
@@ -104,20 +140,24 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
      * https://docs.microsoft.com/azure/azure-functions/disable-function
      */
     private async refreshDisabledState(): Promise<void> {
-        const version: FuncVersion = await this.parent.parent.getVersion();
-        if (version === FuncVersion.v1) {
-            this._disabled = this.config.disabled;
+        if (this._func) {
+            this._disabled = !!this._func.isDisabled;
         } else {
-            const appSettings: ApplicationSettings = await this.parent.parent.getApplicationSettings();
+            const version: FuncVersion = await this.parent.parent.getVersion();
+            if (version === FuncVersion.v1) {
+                this._disabled = this._config.disabled;
+            } else {
+                const appSettings: ApplicationSettings = await this.parent.parent.getApplicationSettings();
 
-            /**
-             * The docs only officially mentioned 'true' and 'false', but here is what I found:
-             * The following resulted in a disabled function:
-             * true, tRue, 1
-             * The following resulted in an enabled function:
-             * false, fAlse, 0, fdsaf, 2, undefined
-             */
-            this._disabled = /^(1|true)$/i.test(appSettings[this.disabledStateKey] || '');
+                /**
+                 * The docs only officially mentioned 'true' and 'false', but here is what I found:
+                 * The following resulted in a disabled function:
+                 * true, tRue, 1
+                 * The following resulted in an enabled function:
+                 * false, fAlse, 0, fdsaf, 2, undefined
+                 */
+                this._disabled = /^(1|true)$/i.test(appSettings[this.disabledStateKey] || '');
+            }
         }
     }
 }

--- a/src/tree/FunctionTreeItemBase.ts
+++ b/src/tree/FunctionTreeItemBase.ts
@@ -5,7 +5,7 @@
 
 import { WebSiteManagementModels } from '@azure/arm-appservice';
 import * as url from 'url';
-import { AzExtTreeItem, IActionContext, TreeItemIconPath } from 'vscode-azureextensionui';
+import { AzExtTreeItem, TreeItemIconPath } from 'vscode-azureextensionui';
 import { HttpAuthLevel, ParsedFunctionJson } from '../funcConfig/function';
 import { IParsedHostJson } from '../funcConfig/host';
 import { FuncVersion } from '../FuncVersion';
@@ -101,19 +101,13 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
 
     public abstract getKey(): Promise<string | undefined>;
 
-    public async refreshImpl(_context: IActionContext, isInitializing?: boolean): Promise<void> {
-        if (!isInitializing) { // no need to refresh "_func" if we're initializing the class since it's set in the constructor
-            this._func = await this.refreshFuncEnvelope();
-        }
-
+    public async initAsync(): Promise<void> {
         if (this.isHttpTrigger) {
             await this.refreshTriggerUrl();
         }
 
         await this.refreshDisabledState();
     }
-
-    public abstract refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined>;
 
     private async refreshTriggerUrl(): Promise<void> {
         const hostUrl = new url.URL(this.parent.parent.hostUrl);

--- a/src/tree/localProject/LocalFunctionTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionTreeItem.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementModels } from '@azure/arm-appservice';
-import { IActionContext } from 'vscode-azureextensionui';
 import { ParsedFunctionJson } from '../../funcConfig/function';
-import { requestUtils } from '../../utils/requestUtils';
 import { FunctionTreeItemBase } from '../FunctionTreeItemBase';
 import { LocalFunctionsTreeItem } from './LocalFunctionsTreeItem';
 
@@ -19,24 +17,10 @@ export class LocalFunctionTreeItem extends FunctionTreeItemBase {
         this.functionJsonPath = functionJsonPath;
     }
 
-    public static async create(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string | undefined, func: WebSiteManagementModels.FunctionEnvelope | undefined, context: IActionContext): Promise<LocalFunctionTreeItem> {
+    public static async create(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string | undefined, func: WebSiteManagementModels.FunctionEnvelope | undefined): Promise<LocalFunctionTreeItem> {
         const ti: LocalFunctionTreeItem = new LocalFunctionTreeItem(parent, name, config, functionJsonPath, func);
-        // initialize
-        await ti.refreshImpl(context, true);
+        await ti.initAsync();
         return ti;
-    }
-
-    public async refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined> {
-        try {
-            const response = await requestUtils.sendRequestWithExtTimeout({
-                url: `${this.parent.parent.hostUrl}/admin/functions/${this.name}`,
-                method: 'GET'
-            });
-            return requestUtils.convertToAzureSdkObject(response.parsedBody);
-        } catch {
-            // project isn't running
-            return undefined;
-        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await

--- a/src/tree/localProject/LocalFunctionTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionTreeItem.ts
@@ -3,24 +3,40 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { WebSiteManagementModels } from '@azure/arm-appservice';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ParsedFunctionJson } from '../../funcConfig/function';
+import { requestUtils } from '../../utils/requestUtils';
 import { FunctionTreeItemBase } from '../FunctionTreeItemBase';
 import { LocalFunctionsTreeItem } from './LocalFunctionsTreeItem';
 
 export class LocalFunctionTreeItem extends FunctionTreeItemBase {
     public readonly parent: LocalFunctionsTreeItem;
-    public readonly functionJsonPath: string;
+    public readonly functionJsonPath: string | undefined;
 
-    private constructor(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string) {
-        super(parent, config, name);
+    private constructor(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string | undefined, func: WebSiteManagementModels.FunctionEnvelope | undefined) {
+        super(parent, config, name, func);
         this.functionJsonPath = functionJsonPath;
     }
 
-    public static async create(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string): Promise<LocalFunctionTreeItem> {
-        const ti: LocalFunctionTreeItem = new LocalFunctionTreeItem(parent, name, config, functionJsonPath);
+    public static async create(parent: LocalFunctionsTreeItem, name: string, config: ParsedFunctionJson, functionJsonPath: string | undefined, func: WebSiteManagementModels.FunctionEnvelope | undefined, context: IActionContext): Promise<LocalFunctionTreeItem> {
+        const ti: LocalFunctionTreeItem = new LocalFunctionTreeItem(parent, name, config, functionJsonPath, func);
         // initialize
-        await ti.refreshImpl();
+        await ti.refreshImpl(context, true);
         return ti;
+    }
+
+    public async refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined> {
+        try {
+            const response = await requestUtils.sendRequestWithExtTimeout({
+                url: `${this.parent.parent.hostUrl}/admin/functions/${this.name}`,
+                method: 'GET'
+            });
+            return requestUtils.convertToAzureSdkObject(response.parsedBody);
+        } catch {
+            // project isn't running
+            return undefined;
+        }
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await

--- a/src/tree/localProject/LocalFunctionsTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionsTreeItem.ts
@@ -3,12 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { WebSiteManagementModels } from '@azure/arm-appservice';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { AzExtTreeItem, GenericTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { functionJsonFileName } from '../../constants';
 import { ParsedFunctionJson } from '../../funcConfig/function';
+import { runningFuncTaskMap } from '../../funcCoreTools/funcHostTask';
 import { localize } from '../../localize';
+import { nonNullProp } from '../../utils/nonNull';
+import { requestUtils } from '../../utils/requestUtils';
 import { treeUtils } from '../../utils/treeUtils';
 import { FunctionsTreeItemBase } from '../FunctionsTreeItemBase';
 import { LocalFunctionTreeItem } from './LocalFunctionTreeItem';
@@ -27,32 +31,36 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
-        const functions: string[] = await getFunctionFolders(this.parent.effectiveProjectPath);
-        const children: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
-            functions,
-            'azFuncInvalidLocalFunction',
-            async func => {
-                const functionJsonPath: string = path.join(this.parent.effectiveProjectPath, func, functionJsonFileName);
-                const config: ParsedFunctionJson = new ParsedFunctionJson(await fse.readJSON(functionJsonPath));
-                return LocalFunctionTreeItem.create(this, func, config, functionJsonPath);
-            },
-            (func: string) => func
-        );
+    public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
+        if (this.parent.isIsolated) {
+            return await this.getChildrenForIsolatedProject(context);
+        } else {
+            const functions: string[] = await getFunctionFolders(this.parent.effectiveProjectPath);
+            const children: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
+                functions,
+                'azFuncInvalidLocalFunction',
+                async func => {
+                    const functionJsonPath: string = path.join(this.parent.effectiveProjectPath, func, functionJsonFileName);
+                    const config: ParsedFunctionJson = new ParsedFunctionJson(await fse.readJSON(functionJsonPath));
+                    return LocalFunctionTreeItem.create(this, func, config, functionJsonPath, undefined, context);
+                },
+                (func: string) => func
+            );
 
-        if (this.parent.preCompiledProjectPath) {
-            const ti: GenericTreeItem = new GenericTreeItem(this, {
-                label: localize('runBuildTask', 'Run build task to update this list...'),
-                iconPath: treeUtils.getThemedIconPath('info'),
-                commandId: 'workbench.action.tasks.build',
-                contextValue: 'runBuildTask'
-            });
-            // By default `GenericTreeItem` will pass itself as the args, but VS Code doesn't seem to like that so pass empty array
-            ti.commandArgs = [];
-            children.push(ti);
+            if (this.parent.preCompiledProjectPath) {
+                const ti: GenericTreeItem = new GenericTreeItem(this, {
+                    label: localize('runBuildTask', 'Run build task to update this list...'),
+                    iconPath: treeUtils.getThemedIconPath('info'),
+                    commandId: 'workbench.action.tasks.build',
+                    contextValue: 'runBuildTask'
+                });
+                // By default `GenericTreeItem` will pass itself as the args, but VS Code doesn't seem to like that so pass empty array
+                ti.commandArgs = [];
+                children.push(ti);
+            }
+
+            return children;
         }
-
-        return children;
     }
 
     public compareChildrenImpl(item1: AzExtTreeItem, item2: AzExtTreeItem): number {
@@ -62,6 +70,37 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
             return 1;
         } else {
             return super.compareChildrenImpl(item1, item2);
+        }
+    }
+
+    /**
+     * .NET Isolated projects don't have typical "function.json" files, so we'll have to ping localhost to get functions (only available if the project is running)
+     */
+    private async getChildrenForIsolatedProject(context: IActionContext): Promise<AzExtTreeItem[]> {
+        if (runningFuncTaskMap.has(this.parent.workspaceFolder)) {
+            const functions = await requestUtils.sendRequestWithExtTimeout({
+                url: `${this.parent.hostUrl}/admin/functions`,
+                method: 'GET'
+            });
+            return await this.createTreeItemsWithErrorHandling(
+                <WebSiteManagementModels.FunctionEnvelope[]>functions.parsedBody,
+                'azFuncInvalidLocalFunction',
+                async func => {
+                    func = requestUtils.convertToAzureSdkObject(func);
+                    return LocalFunctionTreeItem.create(this, nonNullProp(func, 'name'), func.config, undefined, func, context);
+                },
+                func => func.name
+            );
+        } else {
+            const ti: GenericTreeItem = new GenericTreeItem(this, {
+                label: localize('startDebugging', 'Start debugging to update this list...'),
+                iconPath: treeUtils.getThemedIconPath('info'),
+                commandId: 'workbench.action.debug.start',
+                contextValue: 'startDebugging'
+            });
+            // By default `GenericTreeItem` will pass itself as the args, but VS Code doesn't seem to like that so pass empty array
+            ti.commandArgs = [];
+            return [ti];
         }
     }
 }

--- a/src/tree/localProject/LocalFunctionsTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionsTreeItem.ts
@@ -31,9 +31,9 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
         return false;
     }
 
-    public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(_clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         if (this.parent.isIsolated) {
-            return await this.getChildrenForIsolatedProject(context);
+            return await this.getChildrenForIsolatedProject();
         } else {
             const functions: string[] = await getFunctionFolders(this.parent.effectiveProjectPath);
             const children: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
@@ -42,7 +42,7 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
                 async func => {
                     const functionJsonPath: string = path.join(this.parent.effectiveProjectPath, func, functionJsonFileName);
                     const config: ParsedFunctionJson = new ParsedFunctionJson(await fse.readJSON(functionJsonPath));
-                    return LocalFunctionTreeItem.create(this, func, config, functionJsonPath, undefined, context);
+                    return LocalFunctionTreeItem.create(this, func, config, functionJsonPath, undefined);
                 },
                 (func: string) => func
             );
@@ -76,7 +76,7 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
     /**
      * .NET Isolated projects don't have typical "function.json" files, so we'll have to ping localhost to get functions (only available if the project is running)
      */
-    private async getChildrenForIsolatedProject(context: IActionContext): Promise<AzExtTreeItem[]> {
+    private async getChildrenForIsolatedProject(): Promise<AzExtTreeItem[]> {
         if (runningFuncTaskMap.has(this.parent.workspaceFolder)) {
             const functions = await requestUtils.sendRequestWithExtTimeout({
                 url: `${this.parent.hostUrl}/admin/functions`,
@@ -87,7 +87,7 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
                 'azFuncInvalidLocalFunction',
                 async func => {
                     func = requestUtils.convertToAzureSdkObject(func);
-                    return LocalFunctionTreeItem.create(this, nonNullProp(func, 'name'), func.config, undefined, func, context);
+                    return LocalFunctionTreeItem.create(this, nonNullProp(func, 'name'), func.config, undefined, func);
                 },
                 func => func.name
             );

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -6,8 +6,10 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Disposable, WorkspaceFolder } from 'vscode';
-import { AzExtParentTreeItem, AzExtTreeItem } from 'vscode-azureextensionui';
+import { AzExtParentTreeItem, AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
+import { onDotnetFuncTaskStarted } from '../../commands/pickFuncProcess';
 import { functionJsonFileName, hostFileName, localSettingsFileName, ProjectLanguage } from '../../constants';
+import { ext } from '../../extensionVariables';
 import { IParsedHostJson, parseHostJson } from '../../funcConfig/host';
 import { getLocalSettingsJson, ILocalSettingsJson, MismatchBehavior, setLocalAppSetting } from '../../funcConfig/local.settings';
 import { FuncVersion } from '../../FuncVersion';
@@ -16,6 +18,15 @@ import { isLocalProjectCV, matchesAnyPart, ProjectResource, ProjectSource } from
 import { createRefreshFileWatcher } from './createRefreshFileWatcher';
 import { LocalFunctionsTreeItem } from './LocalFunctionsTreeItem';
 import { LocalProjectTreeItemBase } from './LocalProjectTreeItemBase';
+
+export type LocalProjectOptions = {
+    effectiveProjectPath: string;
+    folder: WorkspaceFolder;
+    version: FuncVersion;
+    language: ProjectLanguage;
+    preCompiledProjectPath?: string
+    isIsolated?: boolean;
+}
 
 export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Disposable, IProjectTreeItem {
     public static contextValue: string = 'azFuncLocalProject';
@@ -27,11 +38,12 @@ export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Di
     public readonly workspaceFolder: WorkspaceFolder;
     public readonly version: FuncVersion;
     public readonly langauge: ProjectLanguage;
+    public readonly isIsolated: boolean;
 
     private readonly _disposables: Disposable[] = [];
     private readonly _localFunctionsTreeItem: LocalFunctionsTreeItem;
 
-    public constructor(parent: AzExtParentTreeItem, options: { effectiveProjectPath: string; folder: WorkspaceFolder; version: FuncVersion; language: ProjectLanguage; preCompiledProjectPath?: string }) {
+    public constructor(parent: AzExtParentTreeItem, options: LocalProjectOptions) {
         super(parent, options.preCompiledProjectPath || options.effectiveProjectPath);
         this.effectiveProjectPath = options.effectiveProjectPath;
         this.workspacePath = options.folder.uri.fsPath;
@@ -39,15 +51,27 @@ export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Di
         this.preCompiledProjectPath = options.preCompiledProjectPath;
         this.version = options.version;
         this.langauge = options.language;
+        this.isIsolated = !!options.isIsolated;
 
         this._disposables.push(createRefreshFileWatcher(this, path.join(this.effectiveProjectPath, '*', functionJsonFileName)));
         this._disposables.push(createRefreshFileWatcher(this, path.join(this.effectiveProjectPath, localSettingsFileName)));
+
+        this._disposables.push(onDotnetFuncTaskStarted(async scope => {
+            if (this.workspaceFolder === scope) {
+                await callWithTelemetryAndErrorHandling('onDotnetFuncTaskStarted', async (context: IActionContext) => {
+                    context.errorHandling.suppressDisplay = true;
+                    context.telemetry.suppressIfSuccessful = true;
+                    await this.refresh(context);
+                });
+            }
+        }));
 
         this._localFunctionsTreeItem = new LocalFunctionsTreeItem(this);
     }
 
     public get hostUrl(): string {
-        return 'http://localhost:7071';
+        const port = ext.debugPorts.get(this.workspaceFolder) || 7071;
+        return `http://localhost:${port}`;
     }
 
     public dispose(): void {

--- a/src/tree/remoteProject/RemoteFunctionTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionTreeItem.ts
@@ -21,12 +21,11 @@ export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
         super(parent, config, name, func);
     }
 
-    public static async create(parent: RemoteFunctionsTreeItem, func: WebSiteManagementModels.FunctionEnvelope, context: IActionContext): Promise<RemoteFunctionTreeItem> {
+    public static async create(parent: RemoteFunctionsTreeItem, func: WebSiteManagementModels.FunctionEnvelope): Promise<RemoteFunctionTreeItem> {
         const config: ParsedFunctionJson = new ParsedFunctionJson(func.config);
         const name: string = getFunctionNameFromId(nonNullProp(func, 'id'));
         const ti: RemoteFunctionTreeItem = new RemoteFunctionTreeItem(parent, config, name, func);
-        // initialize
-        await ti.refreshImpl(context, true);
+        await ti.initAsync();
         return ti;
     }
 
@@ -59,12 +58,8 @@ export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
         });
     }
 
-    public async refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined> {
-        return await this.parent.parent.client.getFunction(this.name);
-    }
-
     public async getKey(): Promise<string | undefined> {
-        if (this._config.authLevel === HttpAuthLevel.anonymous) {
+        if (this.isAnonymous) {
             return undefined;
         } else if (this._config.authLevel === HttpAuthLevel.function) {
             try {

--- a/src/tree/remoteProject/RemoteFunctionTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionTreeItem.ts
@@ -6,7 +6,7 @@
 import { WebSiteManagementModels } from '@azure/arm-appservice';
 import { ProgressLocation, window } from 'vscode';
 import { IFunctionKeys, ISiteTreeRoot, SiteClient } from 'vscode-azureappservice';
-import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
+import { DialogResponses, IActionContext, parseError } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { HttpAuthLevel, ParsedFunctionJson } from '../../funcConfig/function';
 import { localize } from '../../localize';
@@ -17,16 +17,16 @@ import { RemoteFunctionsTreeItem } from './RemoteFunctionsTreeItem';
 export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
     public readonly parent: RemoteFunctionsTreeItem;
 
-    private constructor(parent: RemoteFunctionsTreeItem, config: ParsedFunctionJson, name: string) {
-        super(parent, config, name);
+    private constructor(parent: RemoteFunctionsTreeItem, config: ParsedFunctionJson, name: string, func: WebSiteManagementModels.FunctionEnvelope) {
+        super(parent, config, name, func);
     }
 
-    public static async create(parent: RemoteFunctionsTreeItem, func: WebSiteManagementModels.FunctionEnvelope): Promise<RemoteFunctionTreeItem> {
+    public static async create(parent: RemoteFunctionsTreeItem, func: WebSiteManagementModels.FunctionEnvelope, context: IActionContext): Promise<RemoteFunctionTreeItem> {
         const config: ParsedFunctionJson = new ParsedFunctionJson(func.config);
         const name: string = getFunctionNameFromId(nonNullProp(func, 'id'));
-        const ti: RemoteFunctionTreeItem = new RemoteFunctionTreeItem(parent, config, name);
+        const ti: RemoteFunctionTreeItem = new RemoteFunctionTreeItem(parent, config, name, func);
         // initialize
-        await ti.refreshImpl();
+        await ti.refreshImpl(context, true);
         return ti;
     }
 
@@ -59,18 +59,28 @@ export class RemoteFunctionTreeItem extends FunctionTreeItemBase {
         });
     }
 
+    public async refreshFuncEnvelope(): Promise<WebSiteManagementModels.FunctionEnvelope | undefined> {
+        return await this.parent.parent.client.getFunction(this.name);
+    }
+
     public async getKey(): Promise<string | undefined> {
-        switch (this.config.authLevel) {
-            case HttpAuthLevel.admin:
-                const hostKeys: WebSiteManagementModels.HostKeys = await this.client.listHostKeys();
-                return nonNullProp(hostKeys, 'masterKey');
-            case HttpAuthLevel.function:
+        if (this._config.authLevel === HttpAuthLevel.anonymous) {
+            return undefined;
+        } else if (this._config.authLevel === HttpAuthLevel.function) {
+            try {
                 const functionKeys: IFunctionKeys = await this.client.listFunctionKeys(this.name);
                 return nonNullProp(functionKeys, 'default');
-            case HttpAuthLevel.anonymous:
-            default:
-                return undefined;
+            } catch (error) {
+                if (parseError(error).errorType === 'NotFound') {
+                    // There are no function-specific keys, fall through to admin key
+                } else {
+                    throw error;
+                }
+            }
         }
+
+        const hostKeys: WebSiteManagementModels.HostKeys = await this.client.listHostKeys();
+        return nonNullProp(hostKeys, 'masterKey');
     }
 }
 

--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -36,7 +36,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
         return !!this._nextLink;
     }
 
-    public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(clearCache: boolean, _context: IActionContext): Promise<AzExtTreeItem[]> {
         if (clearCache) {
             this._nextLink = undefined;
         }
@@ -55,7 +55,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
         return await this.createTreeItemsWithErrorHandling(
             funcs,
             'azFuncInvalidFunction',
-            async (fe: WebSiteManagementModels.FunctionEnvelope) => await RemoteFunctionTreeItem.create(this, fe, context),
+            async (fe: WebSiteManagementModels.FunctionEnvelope) => await RemoteFunctionTreeItem.create(this, fe),
             (fe: WebSiteManagementModels.FunctionEnvelope) => {
                 return fe.id ? getFunctionNameFromId(fe.id) : undefined;
             }

--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { WebSiteManagementModels } from '@azure/arm-appservice';
 import { isArray } from 'util';
-import { AzExtTreeItem } from 'vscode-azureextensionui';
+import { AzExtTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { FunctionsTreeItemBase } from '../FunctionsTreeItemBase';
 import { SlotTreeItemBase } from '../SlotTreeItemBase';
@@ -36,7 +36,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
         return !!this._nextLink;
     }
 
-    public async loadMoreChildrenImpl(clearCache: boolean): Promise<AzExtTreeItem[]> {
+    public async loadMoreChildrenImpl(clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
         if (clearCache) {
             this._nextLink = undefined;
         }
@@ -55,7 +55,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
         return await this.createTreeItemsWithErrorHandling(
             funcs,
             'azFuncInvalidFunction',
-            async (fe: WebSiteManagementModels.FunctionEnvelope) => await RemoteFunctionTreeItem.create(this, fe),
+            async (fe: WebSiteManagementModels.FunctionEnvelope) => await RemoteFunctionTreeItem.create(this, fe, context),
             (fe: WebSiteManagementModels.FunctionEnvelope) => {
                 return fe.id ? getFunctionNameFromId(fe.id) : undefined;
             }

--- a/src/utils/requestUtils.ts
+++ b/src/utils/requestUtils.ts
@@ -49,4 +49,37 @@ export namespace requestUtils {
             stream.pipe(fse.createWriteStream(filePath).on('finish', resolve).on('error', reject));
         });
     }
+
+    /**
+     * Mimics what the azure sdk does under the covers to create standardized property names
+     */
+    export function convertToAzureSdkObject(data: {}): {} {
+        const result = {};
+        for (const key of Object.keys(data)) {
+            result[convertPropertyName(key)] = convertPropertyValue(data[key]);
+        }
+        return result;
+    }
+
+    /**
+     * Converts property name like "function_app_id" to "functionAppId"
+     */
+    function convertPropertyName(name: string): string {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const match: RegExpMatchArray | null = /_([a-z])/g.exec(name);
+            if (match) {
+                name = name.replace(match[0], match[1].toUpperCase());
+            } else {
+                return name;
+            }
+        }
+    }
+
+    /**
+     * The azure sdk types all use undefined instead of null, so ensure we align with that
+     */
+    function convertPropertyValue(value: string | null | undefined): string | undefined {
+        return value === null ? undefined : value;
+    }
 }

--- a/src/vsCodeConfig/verifyTargetFramework.ts
+++ b/src/vsCodeConfig/verifyTargetFramework.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import { DialogResponses, IActionContext } from 'vscode-azureextensionui';
 import { deploySubpathSetting, ProjectLanguage } from '../constants';
@@ -16,12 +15,12 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, fo
     const settingKey: string = 'showTargetFrameworkWarning';
     if (getWorkspaceSetting<boolean>(settingKey)) {
 
-        const projFiles: string[] = await dotnetUtils.getProjFiles(projectLanguage, projectPath);
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(projectLanguage, projectPath);
         if (projFiles.length === 1) {
 
             let targetFramework: string;
             try {
-                targetFramework = await dotnetUtils.getTargetFramework(path.join(projectPath, projFiles[0]));
+                targetFramework = await dotnetUtils.getTargetFramework(projFiles[0]);
             } catch {
                 // ignore
                 return;

--- a/test/ParsedFunctionJson.test.ts
+++ b/test/ParsedFunctionJson.test.ts
@@ -9,7 +9,7 @@ import { HttpAuthLevel, ParsedFunctionJson } from '../extension.bundle';
 suite('ParsedFunctionJson', () => {
     test('null', () => {
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson(null);
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 0);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, undefined);
@@ -19,7 +19,7 @@ suite('ParsedFunctionJson', () => {
 
     test('undefined', () => {
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson(undefined);
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 0);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, undefined);
@@ -29,7 +29,7 @@ suite('ParsedFunctionJson', () => {
 
     test('empty object', () => {
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({});
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 0);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, undefined);
@@ -39,7 +39,7 @@ suite('ParsedFunctionJson', () => {
 
     test('bindings is not array', () => {
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: 'test' });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 0);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, undefined);
@@ -51,7 +51,7 @@ suite('ParsedFunctionJson', () => {
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({
             disabled: true
         });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 0);
         assert.equal(funcJson.disabled, true);
         assert.equal(funcJson.triggerBinding, undefined);
@@ -65,7 +65,7 @@ suite('ParsedFunctionJson', () => {
             type: 'testTrigger'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);
@@ -79,7 +79,7 @@ suite('ParsedFunctionJson', () => {
             type: 'httpTrigger'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);
@@ -93,7 +93,7 @@ suite('ParsedFunctionJson', () => {
             type: 'hTtpTrigGer'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);
@@ -107,7 +107,7 @@ suite('ParsedFunctionJson', () => {
             type: 'timerTrigger'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);
@@ -121,7 +121,7 @@ suite('ParsedFunctionJson', () => {
             type: 'TiMerTriggER'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.equal(funcJson.authLevel, HttpAuthLevel.function);
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);
@@ -181,10 +181,7 @@ suite('ParsedFunctionJson', () => {
             authLevel: 'testAuthLevel'
         };
         const funcJson: ParsedFunctionJson = new ParsedFunctionJson({ bindings: [triggerBinding] });
-        assert.throws(
-            () => funcJson.authLevel,
-            (error: Error) => error.message.includes('Unrecognized') && error.message.includes('testAuthLevel')
-        );
+        assert.equal(funcJson.authLevel, undefined);
         assert.equal(funcJson.bindings.length, 1);
         assert.equal(funcJson.disabled, false);
         assert.equal(funcJson.triggerBinding, triggerBinding);


### PR DESCRIPTION
.NET 5 doesn't use the typical "function.json" files, which breaks two scenarios:


 ### List functions locally

There's a url I can ping (`http://localhost:7071/admin/functions`) to get them. It's not the best because the project has to be running, but that's when you probably want to "Copy Function Url" or "Execute Functions" anyways. I also have a placeholder tree item like this:
<img width="335" alt="Screen Shot 2021-03-02 at 6 37 11 PM" src="https://user-images.githubusercontent.com/11282622/109745840-4dbe8680-7b89-11eb-9087-57452c519306.png">

### Copy function url for remote functions

In this case, the `config` property on `FunctionEnvelope` usually corresponds to the contents of the "functions.json" file, but it's an empty object for .NET 5. We'll use `invokeUrlTemplate` instead - it doesn't have _all_ the information we might want, but it gets http triggers working which is the most important part.