### PR TITLE
Fix bug where .NET templates are refreshed too often

### DIFF
--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -163,7 +163,9 @@ export class CentralTemplateProvider implements Disposable {
     }
 
     private async refreshTemplatesForProvider(context: IActionContext, provider: TemplateProviderBase, projectTemplateKey: string | undefined): Promise<ITemplates> {
-        provider.sessionProjKey = projectTemplateKey;
+        if (projectTemplateKey) {
+            provider.sessionProjKey = projectTemplateKey;
+        }
 
         let result: ITemplates | undefined;
         let latestErrorMessage: string | undefined;

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -172,7 +172,7 @@ export abstract class TemplateProviderBase implements Disposable {
             return false; // proj keys not supported, so it's impossible to have changed
         }
 
-        if (this.sessionProjKey !== projKey) {
+        if (projKey && this.sessionProjKey !== projKey) {
             return true;
         }
 

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -28,10 +28,13 @@ export abstract class FunctionTesterBase implements Disposable {
     public abstract getExpectedPaths(functionName: string): string[];
 
     public async initAsync(): Promise<void> {
-        this.baseTestFolder = path.join(testFolderPath, `createFunction${this.language}${this.version}`);
+        this.baseTestFolder = path.join(testFolderPath, getRandomHexString());
         await runForAllTemplateSources(async (source) => {
-            const testFolder = path.join(this.baseTestFolder, source);
-            await this.initializeTestFolder(testFolder);
+            const projectPath = path.join(this.baseTestFolder, source);
+            await this.initializeTestFolder(projectPath);
+
+            // This will initialize and cache the templatesTask for this project. Better to do it here than during the first test
+            await ext.templateProvider.getFunctionTemplates(createTestActionContext(), projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
         });
     }
 


### PR DESCRIPTION
When we get the projectTemplateKey from the VS Code [setting](https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/createFunction/createFunction.ts#L61), the default value is an empty string. Well, we don't want that to affect the sessionProjKey, otherwise it'll refresh the templates all the time. Sure enough, the unit tests were having a lot of timeout problems because of this.

I also had to re-work the function tests a tiny bit. Turns out they were benefiting from the fact that we constantly refreshed the templates. Fix was to make sure .NET 5 and .NET 3.1 tests use a unique project path