### PR TITLE
Fix bug where .NET templates are refreshed too often

### DIFF
--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
@@ -5,11 +5,11 @@
 
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
+import { ext } from '../../../extensionVariables';
 import { FuncVersion } from '../../../FuncVersion';
 import { executeDotnetTemplateCommand, validateDotnetInstalled } from '../../../templates/dotnet/executeDotnetTemplateCommand';
 import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
 import { cpUtils } from '../../../utils/cpUtils';
-import { dotnetUtils } from '../../../utils/dotnetUtils';
 import { nonNullProp } from '../../../utils/nonNull';
 import { FunctionCreateStepBase } from '../FunctionCreateStepBase';
 import { getBindingSetting } from '../IFunctionWizardContext';
@@ -48,7 +48,7 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
         const version: FuncVersion = nonNullProp(context, 'version');
         let projectTemplateKey = context.projectTemplateKey;
         if (!projectTemplateKey) {
-            projectTemplateKey = await dotnetUtils.getTemplateKeyFromProjFile(context.projectPath, context.version, nonNullProp(context, 'language'));
+            projectTemplateKey = await ext.templateProvider.getProjectTemplateKey(context.projectPath, nonNullProp(context, 'language'), context.version, undefined);
         }
         await executeDotnetTemplateCommand(context, version, projectTemplateKey, context.projectPath, 'create', '--identity', template.id, ...args);
 

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -109,6 +109,8 @@ export class CentralTemplateProvider implements Disposable {
 
     public async getProjectTemplateKey(projectPath: string | undefined, language: ProjectLanguage, version: FuncVersion, projectTemplateKey: string | undefined): Promise<string> {
         const cachedProviders = await this.getCachedProviders(projectPath, language, version, projectTemplateKey);
+        // .NET is the only language that supports project template keys and they only have one provider
+        // We probably need to do something better here once multi-provider languages support project template keys
         const provider = nonNullValue(cachedProviders.providers[0], 'firstProvider');
         return await provider.getProjKey();
     }

--- a/src/templates/dotnet/DotnetTemplateProvider.ts
+++ b/src/templates/dotnet/DotnetTemplateProvider.ts
@@ -24,8 +24,8 @@ import { parseDotnetTemplates } from './parseDotnetTemplates';
 export class DotnetTemplateProvider extends TemplateProviderBase {
     public templateType: TemplateType = TemplateType.Dotnet;
 
-    public constructor(version: FuncVersion, projectPath: string | undefined, language: ProjectLanguage) {
-        super(version, projectPath, language);
+    public constructor(version: FuncVersion, projectPath: string | undefined, language: ProjectLanguage, projectTemplateKey: string | undefined) {
+        super(version, projectPath, language, projectTemplateKey);
         if (projectPath) {
             const projGlob = language === ProjectLanguage.FSharp ? '*.fsproj' : '*.csproj';
             const watcher = workspace.createFileSystemWatcher(new RelativePattern(projectPath, projGlob));
@@ -128,6 +128,6 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
 
     public includeTemplate(template: IFunctionTemplate | IBindingTemplate): boolean {
         const isIsolated = (v: string) => v.toLowerCase().includes('isolated');
-        return !('id' in template) || !this.sessionProjKey || isIsolated(template.id) === isIsolated(this.sessionProjKey);
+        return !('id' in template) || !this._sessionProjKey || isIsolated(template.id) === isIsolated(this._sessionProjKey);
     }
 }

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -28,10 +28,13 @@ export abstract class FunctionTesterBase implements Disposable {
     public abstract getExpectedPaths(functionName: string): string[];
 
     public async initAsync(): Promise<void> {
-        this.baseTestFolder = path.join(testFolderPath, `createFunction${this.language}${this.version}`);
+        this.baseTestFolder = path.join(testFolderPath, getRandomHexString());
         await runForAllTemplateSources(async (source) => {
-            const testFolder = path.join(this.baseTestFolder, source);
-            await this.initializeTestFolder(testFolder);
+            const projectPath = path.join(this.baseTestFolder, source);
+            await this.initializeTestFolder(projectPath);
+
+            // This will initialize and cache the templatesTask for this project. Better to do it here than during the first test
+            await ext.templateProvider.getFunctionTemplates(createTestActionContext(), projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
         });
     }
 

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -66,7 +66,10 @@ function addSuite(version: FuncVersion, targetFramework: string, source: Templat
         });
 
         const blobTrigger: string = 'BlobTrigger';
-        test(blobTrigger, async () => {
+        test(blobTrigger, async function (this: Mocha.Context): Promise<void> {
+            // the first function created can take a lot longer - likely related to the dotnet cli's cache
+            this.timeout(150 * 1000);
+
             await csTester.testCreateFunction(
                 blobTrigger,
                 'TestCompany.TestFunction',

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -6,8 +6,8 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../../extension.bundle';
-import { runForAllTemplateSources } from '../global.test';
+import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
+import { allTemplateSources } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
@@ -16,8 +16,8 @@ class CSharpFunctionTester extends FunctionTesterBase {
     private _targetFramework: string;
     private _isIsolated: boolean;
 
-    public constructor(version: FuncVersion, targetFramework: string, isIsolated: boolean) {
-        super(version);
+    public constructor(version: FuncVersion, targetFramework: string, source: TemplateSource, isIsolated: boolean) {
+        super(version, source);
         this._targetFramework = targetFramework;
         this._isIsolated = isIsolated;
     }
@@ -39,12 +39,15 @@ class CSharpFunctionTester extends FunctionTesterBase {
     }
 }
 
-addSuite(FuncVersion.v2, 'netcoreapp2.1');
-addSuite(FuncVersion.v3, 'netcoreapp3.1');
-addSuite(FuncVersion.v3, 'net5.0', true);
+for (const source of allTemplateSources) {
+    addSuite(FuncVersion.v2, 'netcoreapp2.1', source);
+    addSuite(FuncVersion.v3, 'netcoreapp3.1', source);
+    addSuite(FuncVersion.v3, 'net5.0', source, true);
+}
 
-function addSuite(version: FuncVersion, targetFramework: string, isIsolated?: boolean): void {
-    let suiteName: string = `Create Function C# ${version} ${targetFramework}`;
+function addSuite(version: FuncVersion, targetFramework: string, source: TemplateSource, isIsolated?: boolean): void {
+    const csTester: CSharpFunctionTester = new CSharpFunctionTester(version, targetFramework, source, !!isIsolated);
+    let suiteName: string = csTester.suiteName + ` ${targetFramework}`;
     if (isIsolated) {
         suiteName += ' Isolated';
     }
@@ -52,7 +55,6 @@ function addSuite(version: FuncVersion, targetFramework: string, isIsolated?: bo
     suite(suiteName, function (this: Mocha.Suite): void {
         this.timeout(40 * 1000);
 
-        const csTester: CSharpFunctionTester = new CSharpFunctionTester(version, targetFramework, !!isIsolated);
 
         suiteSetup(async function (this: Mocha.Context): Promise<void> {
             this.timeout(120 * 1000);
@@ -179,22 +181,19 @@ function addSuite(version: FuncVersion, targetFramework: string, isIsolated?: bo
         if (version === FuncVersion.v2) {
             // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
             test('createFunction API (deprecated)', async () => {
-                await runForAllTemplateSources(async (source) => {
-                    // Intentionally testing IoTHub trigger since a partner team plans to use that
-                    const templateId: string = 'Azure.Function.CSharp.IotHubTrigger.2.x';
-                    const functionName: string = 'createFunctionApi';
-                    const namespace: string = 'TestCompany.TestFunction';
-                    const iotPath: string = 'messages/events';
-                    const connection: string = 'IoTHub_Setting';
-                    const projectPath: string = path.join(csTester.baseTestFolder, source);
-                    await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.CSharp, async () => {
-                        await runWithFuncSetting(funcVersionSetting, FuncVersion.v2, async () => {
-                            // Intentionally testing weird casing
-                            await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { namEspace: namespace, PaTh: iotPath, ConneCtion: connection });
-                        });
+                // Intentionally testing IoTHub trigger since a partner team plans to use that
+                const templateId: string = 'Azure.Function.CSharp.IotHubTrigger.2.x';
+                const functionName: string = 'createFunctionApi';
+                const namespace: string = 'TestCompany.TestFunction';
+                const iotPath: string = 'messages/events';
+                const connection: string = 'IoTHub_Setting';
+                await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.CSharp, async () => {
+                    await runWithFuncSetting(funcVersionSetting, FuncVersion.v2, async () => {
+                        // Intentionally testing weird casing
+                        await vscode.commands.executeCommand('azureFunctions.createFunction', csTester.projectPath, templateId, functionName, { namEspace: namespace, PaTh: iotPath, ConneCtion: connection });
                     });
-                    await csTester.validateFunction(projectPath, functionName, [namespace, iotPath, connection]);
                 });
+                await csTester.validateFunction(csTester.projectPath, functionName, [namespace, iotPath, connection]);
             });
         }
     });

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -5,8 +5,8 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../../extension.bundle';
-import { runForAllTemplateSources } from '../global.test';
+import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
+import { allTemplateSources } from '../global.test';
 import { getDotnetScriptValidateOptions, validateProject } from '../project/validateProject';
 import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -14,8 +14,8 @@ import { FunctionTesterBase } from './FunctionTesterBase';
 class CSharpScriptFunctionTester extends FunctionTesterBase {
     public language: ProjectLanguage = ProjectLanguage.CSharpScript;
 
-    public constructor() {
-        super(FuncVersion.v1);
+    public constructor(source: TemplateSource) {
+        super(FuncVersion.v1, source);
     }
 
     public getExpectedPaths(functionName: string): string[] {
@@ -26,47 +26,43 @@ class CSharpScriptFunctionTester extends FunctionTesterBase {
     }
 }
 
-// NOTE: Only need to test v1 since v2+ emphasizes C# class libraries instead of C#Script
-suite('Create Function C# Script ~1', () => {
-    const tester: CSharpScriptFunctionTester = new CSharpScriptFunctionTester();
+for (const source of allTemplateSources) {
+    // NOTE: Only need to test v1 since v2+ emphasizes C# class libraries instead of C#Script
+    const tester: CSharpScriptFunctionTester = new CSharpScriptFunctionTester(source);
+    suite(tester.suiteName, function (this: Mocha.Suite): void {
+        suiteSetup(async () => {
+            await tester.initAsync();
+        });
 
-    suiteSetup(async () => {
-        await tester.initAsync();
-    });
+        suiteTeardown(async () => {
+            await tester.dispose();
+        });
 
-    suiteTeardown(async () => {
-        await tester.dispose();
-    });
+        // Intentionally testing IoTHub trigger since a partner team plans to use that
+        const iotTemplateId: string = 'IoTHubTrigger-CSharp';
+        const iotFunctionName: string = 'createFunctionApi';
+        const iotConnection: string = 'test_EVENTHUB';
+        const iotPath: string = 'test-workitems';
+        const iotConsumerGroup: string = 'testconsumergroup';
+        const iotTriggerSettings: {} = { connection: iotConnection, path: iotPath, consumerGroup: iotConsumerGroup };
+        const iotExpectedContents: string[] = [iotConnection, iotPath, iotConsumerGroup];
 
-    // Intentionally testing IoTHub trigger since a partner team plans to use that
-    const iotTemplateId: string = 'IoTHubTrigger-CSharp';
-    const iotFunctionName: string = 'createFunctionApi';
-    const iotConnection: string = 'test_EVENTHUB';
-    const iotPath: string = 'test-workitems';
-    const iotConsumerGroup: string = 'testconsumergroup';
-    const iotTriggerSettings: {} = { connection: iotConnection, path: iotPath, consumerGroup: iotConsumerGroup };
-    const iotExpectedContents: string[] = [iotConnection, iotPath, iotConsumerGroup];
-
-    // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
-    test('createFunction API (deprecated)', async () => {
-        await runForAllTemplateSources(async (source) => {
+        // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
+        test('createFunction API (deprecated)', async () => {
             // Intentionally testing IoTHub trigger since a partner team plans to use that
-            const projectPath: string = path.join(tester.baseTestFolder, source);
             await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.CSharpScript, async () => {
                 await runWithFuncSetting(funcVersionSetting, FuncVersion.v1, async () => {
-                    await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, iotTemplateId, iotFunctionName, iotTriggerSettings);
+                    await vscode.commands.executeCommand('azureFunctions.createFunction', tester.projectPath, iotTemplateId, iotFunctionName, iotTriggerSettings);
                 });
             });
-            await tester.validateFunction(projectPath, iotFunctionName, iotExpectedContents);
+            await tester.validateFunction(tester.projectPath, iotFunctionName, iotExpectedContents);
         });
-    });
 
-    test('createNewProjectAndFunction API (deprecated)', async () => {
-        await runForAllTemplateSources(async (source) => {
-            const projectPath: string = path.join(tester.baseTestFolder, source, 'createNewProjectAndFunction');
+        test('createNewProjectAndFunction API (deprecated)', async () => {
+            const projectPath: string = path.join(tester.projectPath, 'createNewProjectAndFunction');
             await vscode.commands.executeCommand('azureFunctions.createNewProject', projectPath, 'C#Script', '~1', false /* openFolder */, iotTemplateId, iotFunctionName, iotTriggerSettings);
             await tester.validateFunction(projectPath, iotFunctionName, iotExpectedContents);
             await validateProject(projectPath, getDotnetScriptValidateOptions(ProjectLanguage.CSharpScript, FuncVersion.v1));
         });
     });
-});
+}

--- a/test/createFunction/createFunction.JavaScript.v1.test.ts
+++ b/test/createFunction/createFunction.JavaScript.v1.test.ts
@@ -5,16 +5,16 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../../extension.bundle';
-import { runForAllTemplateSources } from '../global.test';
+import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
+import { allTemplateSources } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
 class JSFunctionTesterV1 extends FunctionTesterBase {
     public language: ProjectLanguage = ProjectLanguage.JavaScript;
 
-    public constructor() {
-        super(FuncVersion.v1);
+    public constructor(source: TemplateSource) {
+        super(FuncVersion.v1, source);
     }
 
     public getExpectedPaths(functionName: string): string[] {
@@ -25,88 +25,86 @@ class JSFunctionTesterV1 extends FunctionTesterBase {
     }
 }
 
-suite('Create Function JavaScript ~1', function (this: Mocha.Suite): void {
-    const jsTester: JSFunctionTesterV1 = new JSFunctionTesterV1();
+for (const source of allTemplateSources) {
+    const jsTester: JSFunctionTesterV1 = new JSFunctionTesterV1(source);
+    suite(jsTester.suiteName, function (this: Mocha.Suite): void {
+        suiteSetup(async () => {
+            await jsTester.initAsync();
+        });
 
-    suiteSetup(async () => {
-        await jsTester.initAsync();
-    });
+        suiteTeardown(async () => {
+            await jsTester.dispose();
+        });
 
-    suiteTeardown(async () => {
-        await jsTester.dispose();
-    });
+        const blobTrigger: string = 'Blob trigger';
+        test(blobTrigger, async () => {
+            await jsTester.testCreateFunction(
+                blobTrigger,
+                'AzureWebJobsStorage', // Use existing app setting
+                'test-path/{name}'
+            );
+        });
 
-    const blobTrigger: string = 'Blob trigger';
-    test(blobTrigger, async () => {
-        await jsTester.testCreateFunction(
-            blobTrigger,
-            'AzureWebJobsStorage', // Use existing app setting
-            'test-path/{name}'
-        );
-    });
+        const genericWebhook: string = 'Generic webhook';
+        test(genericWebhook, async () => {
+            await jsTester.testCreateFunction(genericWebhook);
+        });
 
-    const genericWebhook: string = 'Generic webhook';
-    test(genericWebhook, async () => {
-        await jsTester.testCreateFunction(genericWebhook);
-    });
+        const gitHubWebhook: string = 'GitHub webhook';
+        test(gitHubWebhook, async () => {
+            await jsTester.testCreateFunction(gitHubWebhook);
+        });
 
-    const gitHubWebhook: string = 'GitHub webhook';
-    test(gitHubWebhook, async () => {
-        await jsTester.testCreateFunction(gitHubWebhook);
-    });
+        const httpTrigger: string = 'HTTP trigger';
+        test(httpTrigger, async () => {
+            await jsTester.testCreateFunction(
+                httpTrigger,
+                'Admin'
+            );
+        });
 
-    const httpTrigger: string = 'HTTP trigger';
-    test(httpTrigger, async () => {
-        await jsTester.testCreateFunction(
-            httpTrigger,
-            'Admin'
-        );
-    });
+        const httpTriggerWithParameters: string = 'HTTP trigger with parameters';
+        test(httpTriggerWithParameters, async () => {
+            await jsTester.testCreateFunction(
+                httpTriggerWithParameters,
+                'Anonymous'
+            );
+        });
 
-    const httpTriggerWithParameters: string = 'HTTP trigger with parameters';
-    test(httpTriggerWithParameters, async () => {
-        await jsTester.testCreateFunction(
-            httpTriggerWithParameters,
-            'Anonymous'
-        );
-    });
+        const manualTrigger: string = 'Manual trigger';
+        test(manualTrigger, async () => {
+            await jsTester.testCreateFunction(manualTrigger);
+        });
 
-    const manualTrigger: string = 'Manual trigger';
-    test(manualTrigger, async () => {
-        await jsTester.testCreateFunction(manualTrigger);
-    });
+        const queueTrigger: string = 'Queue trigger';
+        test(queueTrigger, async () => {
+            await jsTester.testCreateFunction(
+                queueTrigger,
+                'AzureWebJobsStorage', // Use existing app setting
+                'testqueue'
+            );
+        });
 
-    const queueTrigger: string = 'Queue trigger';
-    test(queueTrigger, async () => {
-        await jsTester.testCreateFunction(
-            queueTrigger,
-            'AzureWebJobsStorage', // Use existing app setting
-            'testqueue'
-        );
-    });
+        const timerTrigger: string = 'Timer trigger';
+        test(timerTrigger, async () => {
+            await jsTester.testCreateFunction(
+                timerTrigger,
+                '0 * 0/5 * * *'
+            );
+        });
 
-    const timerTrigger: string = 'Timer trigger';
-    test(timerTrigger, async () => {
-        await jsTester.testCreateFunction(
-            timerTrigger,
-            '0 * 0/5 * * *'
-        );
-    });
-
-    // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
-    test('createFunction API (deprecated)', async () => {
-        await runForAllTemplateSources(async (source) => {
+        // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
+        test('createFunction API (deprecated)', async () => {
             const templateId: string = 'HttpTrigger-JavaScript';
             const functionName: string = 'createFunctionApi';
             const authLevel: string = 'Anonymous';
-            const projectPath: string = path.join(jsTester.baseTestFolder, source);
             // Intentionally testing weird casing for authLevel
             await runWithFuncSetting(projectLanguageSetting, ProjectLanguage.JavaScript, async () => {
                 await runWithFuncSetting(funcVersionSetting, FuncVersion.v1, async () => {
-                    await vscode.commands.executeCommand('azureFunctions.createFunction', projectPath, templateId, functionName, { aUtHLevel: authLevel });
+                    await vscode.commands.executeCommand('azureFunctions.createFunction', jsTester.projectPath, templateId, functionName, { aUtHLevel: authLevel });
                 });
             });
-            await jsTester.validateFunction(projectPath, functionName, [authLevel]);
+            await jsTester.validateFunction(jsTester.projectPath, functionName, [authLevel]);
         });
     });
-});
+}

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -56,13 +56,13 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
     if (!updateBackupTemplates) {
         await preLoadTemplates(ext.templateProvider);
         templateProviderMap = new Map();
-        for (const source of Object.values(TemplateSource)) {
+        for (const source of allTemplateSources) {
             if (!(source === TemplateSource.Staging && skipStagingTemplateSource)) {
                 templateProviderMap.set(source, new CentralTemplateProvider(source));
             }
-        }
 
-        await runForAllTemplateSources(async (_source, provider) => await preLoadTemplates(provider));
+            await runForTemplateSource(source, preLoadTemplates);
+        }
     }
 
     longRunningTestsEnabled = envUtils.isEnvironmentVariableSet(process.env.ENABLE_LONG_RUNNING_TESTS);
@@ -97,12 +97,7 @@ async function preLoadTemplates(provider: CentralTemplateProvider): Promise<void
     }
 }
 
-export async function runForAllTemplateSources(callback: (source: TemplateSource, templateProvider: CentralTemplateProvider) => Promise<void>): Promise<void> {
-    for (const source of templateProviderMap.keys()) {
-        await runForTemplateSource(source, (templateProvider: CentralTemplateProvider) => callback(source, templateProvider));
-    }
-}
-
+export const allTemplateSources: TemplateSource[] = Object.values(TemplateSource);
 export async function runForTemplateSource(source: TemplateSource | undefined, callback: (templateProvider: CentralTemplateProvider) => Promise<void>): Promise<void> {
     const oldProvider: CentralTemplateProvider = ext.templateProvider;
     try {

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -7,11 +7,15 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { TestInput } from 'vscode-azureextensiondev';
 import { FuncVersion, getRandomHexString, initProjectForVSCode, ProjectLanguage } from '../../extension.bundle';
-import { createTestActionContext, testFolderPath, testUserInput } from '../global.test';
+import { cleanTestWorkspace, createTestActionContext, testFolderPath, testUserInput } from '../global.test';
 import { getCSharpValidateOptions, getCustomValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPowerShellValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
 suite('Init Project For VS Code', function (this: Mocha.Suite): void {
     this.timeout(30 * 1000);
+
+    suiteSetup(async () => {
+        await cleanTestWorkspace();
+    });
 
     test('JavaScript', async () => {
         await initAndValidateProject({ ...getJavaScriptValidateOptions(), mockFiles: [['HttpTriggerJs', 'index.js']] });

--- a/test/updateBackupTemplates.ts
+++ b/test/updateBackupTemplates.ts
@@ -39,10 +39,9 @@ suite('Backup templates', () => {
                     continue;
                 }
 
-                const providers: TemplateProviderBase[] = CentralTemplateProvider.getProviders(testWorkspacePath, worker.language, version);
+                const providers: TemplateProviderBase[] = CentralTemplateProvider.getProviders(testWorkspacePath, worker.language, version, worker.projectTemplateKey);
 
                 for (const provider of providers) {
-                    provider.sessionProjKey = worker.projectTemplateKey;
                     const templateVersion: string = await provider.getLatestTemplateVersion();
 
                     async function updateBackupTemplatesInternal(): Promise<void> {


### PR DESCRIPTION
Tests were timing out on .NET quite a bit - I cleaned some stuff up in both the source code and tests to fix it. Two main fixes in the source code:
1. Don't clear out the sessionProjKey if the value from the VS Code setting is an empty string (that's actually the default)
2. Reduce the number of times we read the csproj to get the projectTemplateKey
