### PR TITLE
Fix debugPort vs. funcPort

### DIFF
--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -7,13 +7,14 @@ import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, Work
 import { callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { isFunctionProject } from '../commands/createNewProject/verifyIsProject';
 import { hostStartTaskName } from '../constants';
-import { ext } from '../extensionVariables';
 import { IPreDebugValidateResult, preDebugValidate } from './validatePreDebug';
 
 export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
     public abstract workerArgKey: string;
     protected abstract defaultPortOrPipeName: number | string;
     protected abstract debugConfig: DebugConfiguration;
+
+    private readonly _debugPorts = new Map<WorkspaceFolder | undefined, number | undefined>();
 
     public abstract getWorkerArgValue(folder: WorkspaceFolder): Promise<string>;
 
@@ -44,7 +45,7 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
             context.errorHandling.suppressDisplay = true;
             context.telemetry.suppressIfSuccessful = true;
 
-            ext.debugPorts.set(folder, <number | undefined>debugConfiguration.port);
+            this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
             if (debugConfiguration.preLaunchTask === hostStartTaskName) {
                 context.telemetry.properties.isActivationEvent = 'false';
                 context.telemetry.suppressIfSuccessful = false;
@@ -62,6 +63,6 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
     }
 
     protected getDebugPortOrPipeName(folder: WorkspaceFolder): number | string {
-        return ext.debugPorts.get(folder) || this.defaultPortOrPipeName;
+        return this._debugPorts.get(folder) || this.defaultPortOrPipeName;
     }
 }

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ExtensionContext, TreeView, WorkspaceFolder } from "vscode";
+import { ExtensionContext, TreeView } from "vscode";
 import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 import { func } from "./constants";
 import { CentralTemplateProvider } from "./templates/CentralTemplateProvider";
@@ -25,7 +25,6 @@ export namespace ext {
     export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'azureFunctions';
     export let experimentationService: IExperimentationServiceAdapter;
-    export const debugPorts = new Map<WorkspaceFolder | undefined, number | undefined>();
 }
 
 export enum TemplateSource {

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -17,7 +17,7 @@ const funcTaskStartedEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder | 
 export const onFuncTaskStarted = funcTaskStartedEmitter.event;
 
 export const runningFuncPortMap = new Map<vscode.WorkspaceFolder | vscode.TaskScope | undefined, string>();
-export const defaultFuncPort: string = '7071';
+const defaultFuncPort: string = '7071';
 
 export function isFuncHostTask(task: vscode.Task): boolean {
     const commandLine: string | undefined = task.execution && (<vscode.ShellExecution>task.execution).commandLine;

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as path from 'path';
-import { Disposable, workspace, WorkspaceFolder } from 'vscode';
+import { Disposable, Task, tasks, workspace, WorkspaceFolder } from 'vscode';
 import { AzExtTreeItem, AzureAccountTreeItemBase, callWithTelemetryAndErrorHandling, GenericTreeItem, IActionContext, ISubscriptionContext } from 'vscode-azureextensionui';
 import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIsProject';
 import { getJavaDebugSubpath } from '../commands/initProjectForVSCode/InitVSCodeStep/JavaInitVSCodeStep';
 import { funcVersionSetting, hostFileName, pomXmlFileName, ProjectLanguage, projectLanguageSetting, projectSubpathSetting } from '../constants';
 import { ext } from '../extensionVariables';
+import { getFuncPortFromTask, isFuncHostTask } from '../funcCoreTools/funcHostTask';
 import { FuncVersion, tryParseFuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { dotnetUtils } from '../utils/dotnetUtils';
@@ -88,7 +89,10 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
                             effectiveProjectPath = projectPath;
                         }
 
-                        const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, { effectiveProjectPath, folder, language, version, preCompiledProjectPath, isIsolated });
+                        const funcTask: Task | undefined = (await tasks.fetchTasks()).find(t => t.scope === folder && isFuncHostTask(t));
+                        const funcPort = getFuncPortFromTask(funcTask);
+
+                        const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, { effectiveProjectPath, folder, language, version, preCompiledProjectPath, isIsolated, funcPort });
                         this._projectDisposables.push(treeItem);
                         children.push(treeItem);
                     }


### PR DESCRIPTION
I got the port used for debugging (i.e. 9229 for node.js) mixed up with the port the func host runs on (usually 7071)

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2723