### PR TITLE
Use an older mac agent for pipelines

### DIFF
--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -24,7 +24,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-latest
+    vmImage: macOS-10.14
   steps:
   - template: common/build.yml
   - template: common/lint.yml

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -24,7 +24,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.14 # Using 10.14 instead of latest (10.15) because of "ENOTCONN" errors during tests
   steps:
   - template: common/build.yml
   - template: common/lint.yml


### PR DESCRIPTION
Mac builds started failing for several repos. Seems like it's related to the agent being updated recently to 10.15 because 10.14 works for me