### PR TITLE
Add AntiMalware Scanner to build

### DIFF
--- a/.azure-pipelines/common/package.yml
+++ b/.azure-pipelines/common/package.yml
@@ -22,4 +22,5 @@ steps:
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)'
     ArtifactName: vsix
-  condition: ne(variables['System.PullRequest.IsFork'], 'True')
+  # Only publish vsix from linux build since we use this to release and want to stay consistent
+  condition: and(eq(variables['Agent.OS'], 'Linux'), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -20,6 +20,7 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
   displayName: 'AntiMalware Scanner'
   inputs:
+    FileDirPath: '$(Build.SourcesDirectory)'
     EnableServices: true
   continueOnError: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -17,6 +17,11 @@ steps:
   continueOnError: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+  displayName: 'AntiMalware Scanner'
+  continueOnError: true
+  condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
   displayName: 'Publish Security Analysis Logs'
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')

--- a/.azure-pipelines/compliance/compliance.yml
+++ b/.azure-pipelines/compliance/compliance.yml
@@ -19,6 +19,8 @@ steps:
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
   displayName: 'AntiMalware Scanner'
+  inputs:
+    EnableServices: true
   continueOnError: true
   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 

--- a/.azure-pipelines/main.yml
+++ b/.azure-pipelines/main.yml
@@ -9,6 +9,7 @@ jobs:
     vmImage: windows-latest
   steps:
   - template: common/build.yml
+  - template: common/package.yml
   - template: common/lint.yml
   - template: compliance/compliance.yml # Only works on Windows
   - template: common/test.yml
@@ -18,7 +19,7 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - template: common/build.yml
-  - template: common/publish-vsix.yml # Only publish vsix from linux build since we use this to release and want to stay consistent
+  - template: common/package.yml
   - template: common/lint.yml
   - template: common/test.yml
 
@@ -27,6 +28,7 @@ jobs:
     vmImage: macOS-10.14 # Using 10.14 instead of latest (10.15) because of "ENOTCONN" errors during tests
   steps:
   - template: common/build.yml
+  - template: common/package.yml
   - template: common/lint.yml
   - template: common/test.yml
 


### PR DESCRIPTION
Also run "package" on all OS's (everything except actually publishing the vsix). I think it's best to make sure the compliance stuff (only run on windows) has access to all the artifacts we create, plus it can't hurt just to be consistent here.