### PR TITLE
Add targetFramework as a parameter for createFunction

### DIFF
--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -23,6 +23,8 @@ export interface IProjectWizardContext extends IActionContext {
 
     generateFromOpenAPI?: boolean;
     openApiSpecificationFile?: Uri[];
+
+    targetNetwork?: string;
 }
 
 export type OpenBehavior = 'AddToWorkspace' | 'OpenInNewWindow' | 'OpenInCurrentWindow' | 'AlreadyOpen' | 'DontOpen';

--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -24,7 +24,7 @@ export interface IProjectWizardContext extends IActionContext {
     generateFromOpenAPI?: boolean;
     openApiSpecificationFile?: Uri[];
 
-    targetNetwork?: string;
+    targetFramework?: string;
 }
 
 export type OpenBehavior = 'AddToWorkspace' | 'OpenInNewWindow' | 'OpenInCurrentWindow' | 'AlreadyOpen' | 'DontOpen';

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -49,7 +49,6 @@ export async function createNewProjectInternal(context: IActionContext, options:
     const version: string = options.version || getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion() || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
     const wizardContext: Partial<IFunctionWizardContext> & IActionContext = Object.assign(context, options, { language, version: tryParseFuncVersion(version), projectTemplateKey });
-    wizardContext.targetNetwork = options.targetNetwork;
 
     if (options.folderPath) {
         FolderListStep.setProjectPath(wizardContext, options.folderPath);

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -49,6 +49,7 @@ export async function createNewProjectInternal(context: IActionContext, options:
     const version: string = options.version || getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion() || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
     const wizardContext: Partial<IFunctionWizardContext> & IActionContext = Object.assign(context, options, { language, version: tryParseFuncVersion(version), projectTemplateKey });
+    wizardContext.targetNetwork = options.targetNetwork;
 
     if (options.folderPath) {
         FolderListStep.setProjectPath(wizardContext, options.folderPath);

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -25,18 +25,19 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
         const runtimes = Object.values(funcRelease.workerRuntimes.dotnet).filter(r => !r.displayInfo.hidden || showHiddenStacks);
         if (runtimes.length === 0) {
             throw new Error('Internal error: No .NET worker runtimes found.')
-        } else if (runtimes.length === 1) {
-            // No need to prompt if it only supports one
-            setWorkerRuntime(context, runtimes[0]);
         } else if (context.targetFramework) {
             // if a targetFramework was provided from createNewProject
             const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetFramework);
             if (!workerRuntime) {
-                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: "{1}".', context.targetFramework, runtimes.join(', ')));
+                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: "{1}".', context.targetFramework,
+                    runtimes.map(rt => rt.targetFramework).join(', ')));
             }
-
             setWorkerRuntime(context, workerRuntime);
+        } else if (runtimes.length === 1) {
+            // No need to prompt if it only supports one
+            setWorkerRuntime(context, runtimes[0]);
         }
+
         return new DotnetRuntimeStep(runtimes);
     }
 

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -28,12 +28,14 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
         } else if (runtimes.length === 1) {
             // No need to prompt if it only supports one
             setWorkerRuntime(context, runtimes[0]);
-        } else if (context.targetNetwork) {
-            // if a targetNetwork was provided from createNewProject
-            const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetNetwork);
-            if (workerRuntime) {
-                setWorkerRuntime(context, workerRuntime);
+        } else if (context.targetFramework) {
+            // if a targetFramework was provided from createNewProject
+            const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetFramework);
+            if (!workerRuntime) {
+                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: "{1}".', context.targetFramework, runtimes.join(', ')));
             }
+
+            setWorkerRuntime(context, workerRuntime);
         }
         return new DotnetRuntimeStep(runtimes);
     }

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -28,6 +28,12 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
         } else if (runtimes.length === 1) {
             // No need to prompt if it only supports one
             setWorkerRuntime(context, runtimes[0]);
+        } else if (context.targetNetwork) {
+            // if a targetNetwork was provided from createNewProject
+            const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetNetwork);
+            if (workerRuntime) {
+                setWorkerRuntime(context, workerRuntime);
+            }
         }
         return new DotnetRuntimeStep(runtimes);
     }

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -29,8 +29,8 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
             // if a targetFramework was provided from createNewProject
             const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetFramework);
             if (!workerRuntime) {
-                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: "{1}".', context.targetFramework,
-                    runtimes.map(rt => rt.targetFramework).join(', ')));
+                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: {1}.', context.targetFramework,
+                    runtimes.map(rt => `"${rt.targetFramework}"`).join(', ')));
             }
             setWorkerRuntime(context, workerRuntime);
         } else if (runtimes.length === 1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         createFunction: createFunctionFromApi,
         downloadAppSettings: downloadAppSettingsFromApi,
         uploadAppSettings: uploadAppSettingsFromApi,
-        apiVersion: '1.3.0'
+        apiVersion: '1.4.0'
     }]);
 }
 

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -15,7 +15,6 @@ export interface AzureFunctionsExtensionApi {
 
 export type ProjectLanguage = 'JavaScript' | 'TypeScript' | 'C#' | 'Python' | 'PowerShell' | 'Java';
 export type ProjectVersion = '~1' | '~2' | '~3';
-export type TargetFramework = 'netcoreapp3.1' | 'net5.0';
 
 export interface IAppSettingsClient {
     fullName: string;
@@ -81,7 +80,7 @@ export interface ICreateFunctionOptions {
     suppressOpenFolder?: boolean;
 
     /**
-     * If set, it will automatically select the worker runtime for .NET with the matching targetNetwork
+     * If set, it will automatically select the worker runtime for .NET with the matching targetFramework
      */
-    targetNetwork?: TargetFramework;
+    targetFramework?: string;
 }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -15,6 +15,7 @@ export interface AzureFunctionsExtensionApi {
 
 export type ProjectLanguage = 'JavaScript' | 'TypeScript' | 'C#' | 'Python' | 'PowerShell' | 'Java';
 export type ProjectVersion = '~1' | '~2' | '~3';
+export type TargetFramework = 'netcoreapp3.1' | 'net5.0';
 
 export interface IAppSettingsClient {
     fullName: string;
@@ -78,4 +79,9 @@ export interface ICreateFunctionOptions {
      * If set to true, it will not try to open the folder after create finishes. Defaults to false
      */
     suppressOpenFolder?: boolean;
+
+    /**
+     * If set, it will automatically select the worker runtime for .NET with the matching targetNetwork
+     */
+    targetNetwork?: TargetFramework;
 }


### PR DESCRIPTION
I couldn't find an `id` property that I could use on the runtimeWorkers.  My main concern with using targetFramework is that would `netcoreapp3.1` be replaced by `netcoreapp3.2` when they start supporting .NET 3.2?  Any suggestion on what I should pass in for a more stable id?

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2760