### PR TITLE
Take app setting validation from shared package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "portfinder": "^1.0.23",
                 "ps-tree": "^1.1.1",
                 "semver": "^5.7.1",
-                "vscode-azureappservice": "^0.76.1",
+                "vscode-azureappservice": "^0.77.0",
                 "vscode-azureextensionui": "^0.41.3",
                 "vscode-azurekudu": "^0.2.0",
                 "vscode-nls": "^4.1.1",
@@ -12144,9 +12144,10 @@
             }
         },
         "node_modules/vscode-azureappservice": {
-            "version": "0.76.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.76.1.tgz",
-            "integrity": "sha512-zQEo49juQet8hJZkV3ZwxzQY/cdsjzde3kTNmIVHt/NLD2rGXTLp4gbGvgqQzAhp054Wc4rQ5+RvlmdIUCyvag==",
+            "version": "0.77.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.77.0.tgz",
+            "integrity": "sha512-UzhG7KICasaLVpt2p2d63r0y0zQz9tD1N1yWlMG4xAh8Uc8dPc8nnmo8ru38NQprum54QQjGpzaymTFXBEn7DA==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^3.0.0",
@@ -22895,9 +22896,9 @@
             }
         },
         "vscode-azureappservice": {
-            "version": "0.76.1",
-            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.76.1.tgz",
-            "integrity": "sha512-zQEo49juQet8hJZkV3ZwxzQY/cdsjzde3kTNmIVHt/NLD2rGXTLp4gbGvgqQzAhp054Wc4rQ5+RvlmdIUCyvag==",
+            "version": "0.77.0",
+            "resolved": "https://registry.npmjs.org/vscode-azureappservice/-/vscode-azureappservice-0.77.0.tgz",
+            "integrity": "sha512-UzhG7KICasaLVpt2p2d63r0y0zQz9tD1N1yWlMG4xAh8Uc8dPc8nnmo8ru38NQprum54QQjGpzaymTFXBEn7DA==",
             "requires": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1109,7 +1109,7 @@
         "portfinder": "^1.0.23",
         "ps-tree": "^1.1.1",
         "semver": "^5.7.1",
-        "vscode-azureappservice": "^0.76.1",
+        "vscode-azureappservice": "^0.77.0",
         "vscode-azureextensionui": "^0.41.3",
         "vscode-azurekudu": "^0.2.0",
         "vscode-nls": "^4.1.1",

--- a/src/commands/deploy/runPreDeployTask.ts
+++ b/src/commands/deploy/runPreDeployTask.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { handleFailedPreDeployTask, IPreDeployTaskResult, tryRunPreDeployTask } from 'vscode-azureappservice';
-import { DialogResponses, IActionContext, UserCancelledError } from 'vscode-azureextensionui';
+import { handleFailedPreDeployTask, IDeployContext, IPreDeployTaskResult, tryRunPreDeployTask } from 'vscode-azureappservice';
+import { DialogResponses, UserCancelledError } from 'vscode-azureextensionui';
 import { buildNativeDeps, packTaskName, preDeployTaskSetting, tasksFileName } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
@@ -13,7 +13,7 @@ import { localize } from '../../localize';
 import { openUrl } from '../../utils/openUrl';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 
-export async function runPreDeployTask(context: IActionContext, deployFsPath: string, scmType: string | undefined): Promise<void> {
+export async function runPreDeployTask(context: IDeployContext, deployFsPath: string, scmType: string | undefined): Promise<void> {
     const preDeployTask: string | undefined = getWorkspaceSetting(preDeployTaskSetting, deployFsPath);
     if (preDeployTask && preDeployTask.startsWith('func:')) {
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to run preDeployTask "{0}".', preDeployTask);
@@ -36,7 +36,7 @@ export async function runPreDeployTask(context: IActionContext, deployFsPath: st
     }
 }
 
-async function promptToBuildNativeDeps(context: IActionContext, deployFsPath: string, scmType: string | undefined): Promise<IPreDeployTaskResult> {
+async function promptToBuildNativeDeps(context: IDeployContext, deployFsPath: string, scmType: string | undefined): Promise<IPreDeployTaskResult> {
     const message: string = localize('funcPackFailed', 'Failed to package your project. Use a Docker container to build incompatible dependencies?');
     const result: vscode.MessageItem | undefined = await vscode.window.showErrorMessage(message, { modal: true }, DialogResponses.yes, DialogResponses.learnMore);
     if (result === DialogResponses.yes) {

--- a/src/commands/deploy/validateRemoteBuild.ts
+++ b/src/commands/deploy/validateRemoteBuild.ts
@@ -5,34 +5,28 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { SiteClient } from 'vscode-azureappservice';
-import { IActionContext } from 'vscode-azureextensionui';
-import { deploySubpathSetting, packTaskName, preDeployTaskSetting, ProjectLanguage } from '../../constants';
+import { IDeployContext, SiteClient } from 'vscode-azureappservice';
+import { deploySubpathSetting, packTaskName, preDeployTaskSetting, ProjectLanguage, remoteBuildSetting } from '../../constants';
 import { localize } from '../../localize';
-import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
+import { updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
 import { ensureGitIgnoreContents } from '../initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep';
 
-export async function validateRemoteBuild(context: IActionContext, client: SiteClient, workspacePath: string, language: ProjectLanguage): Promise<void> {
+export async function validateRemoteBuild(context: IDeployContext, client: SiteClient, workspacePath: string, language: ProjectLanguage): Promise<void> {
     if (language === ProjectLanguage.Python && !client.kuduUrl) {
-        const remoteBuildKey: string = 'scmDoBuildDuringDeployment';
+        const message: string = localize('remoteBuildNotSupported', 'The selected Function App doesn\'t support your project\'s configuration. Deploy to a newer Function App or downgrade your config.');
+        const learnMoreLink: string = 'https://aka.ms/AA5vsfd';
+        const downgrade: vscode.MessageItem = { title: localize('downgrade', 'Downgrade config') };
+        context.telemetry.properties.cancelStep = 'validateRemoteBuild';
+        await context.ui.showWarningMessage(message, { learnMoreLink, modal: true }, downgrade);
+        context.telemetry.properties.cancelStep = undefined;
 
-        const remoteBuild: boolean | undefined = getWorkspaceSetting(remoteBuildKey, workspacePath);
-        if (remoteBuild) {
-            const message: string = localize('remoteBuildNotSupported', 'The selected Function App doesn\'t support your project\'s configuration. Deploy to a newer Function App or downgrade your config.');
-            const learnMoreLink: string = 'https://aka.ms/AA5vsfd';
-            const downgrade: vscode.MessageItem = { title: localize('downgrade', 'Downgrade config') };
-            context.telemetry.properties.cancelStep = 'validateRemoteBuild';
-            await context.ui.showWarningMessage(message, { learnMoreLink, modal: true }, downgrade);
-            context.telemetry.properties.cancelStep = undefined;
-
-            const projectPath: string = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */) || workspacePath;
-            await updateWorkspaceSetting(remoteBuildKey, false, workspacePath);
-            await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
-            const zipFileName: string = path.basename(projectPath) + '.zip';
-            // Always use posix separators for config checked in to source control
-            await updateWorkspaceSetting(deploySubpathSetting, path.posix.join(path.relative(workspacePath, projectPath), zipFileName), workspacePath);
-            await ensureGitIgnoreContents(projectPath, [zipFileName]);
-        }
+        const projectPath: string = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */) || workspacePath;
+        await updateWorkspaceSetting(remoteBuildSetting, false, workspacePath);
+        await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
+        const zipFileName: string = path.basename(projectPath) + '.zip';
+        // Always use posix separators for config checked in to source control
+        await updateWorkspaceSetting(deploySubpathSetting, path.posix.join(path.relative(workspacePath, projectPath), zipFileName), workspacePath);
+        await ensureGitIgnoreContents(projectPath, [zipFileName]);
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const pythonVenvSetting: string = 'pythonVenv';
 export const projectOpenBehaviorSetting: string = 'projectOpenBehavior';
 export const hiddenStacksSetting: string = 'showHiddenStacks';
 export const projectTemplateKeySetting: string = 'projectTemplateKey';
+export const remoteBuildSetting: string = 'scmDoBuildDuringDeployment';
 
 export enum ProjectLanguage {
     CSharp = 'C#',


### PR DESCRIPTION
This logic is unique to Functions and I wanted to consolidate all app settings verification into this repo.

Depends on https://github.com/microsoft/vscode-azuretools/pull/893