### PR TITLE
Move resource group list step before location step in advanced create

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -110,9 +110,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             executeSteps.push(new StorageAccountCreateStep(storageAccountCreateOptions));
             executeSteps.push(new AppInsightsCreateStep());
         } else {
+            promptSteps.push(new ResourceGroupListStep());
             CustomLocationListStep.addStep(wizardContext, promptSteps);
             promptSteps.push(new FunctionAppHostingPlanStep());
-            promptSteps.push(new ResourceGroupListStep());
             promptSteps.push(new StorageAccountListStep(
                 storageAccountCreateOptions,
                 {

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -21,6 +21,7 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
     let rgName: string;
     let saName: string;
     let aiName: string;
+    let location: string;
 
     suiteSetup(async function (this: Mocha.Context): Promise<void> {
         if (!longRunningTestsEnabled) {
@@ -36,10 +37,11 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
         resourceGroupsToDelete.push(rgName);
         saName = getRandomHexString().toLowerCase(); // storage account must have lower case name
         aiName = getRandomHexString();
+        location = getRotatingLocation();
     });
 
     test('Create - Advanced', async () => {
-        const testInputs: (string | RegExp)[] = [appName, /\.net/i, 'Windows', 'Consumption', '$(plus) Create new resource group', rgName, '$(plus) Create new storage account', saName, '$(plus) Create new Application Insights resource', aiName, getRotatingLocation()];
+        const testInputs: (string | RegExp)[] = [appName, /\.net/i, 'Windows', '$(plus) Create new resource group', rgName, location, 'Consumption', '$(plus) Create new storage account', saName, '$(plus) Create new Application Insights resource', aiName];
         await testUserInput.runWithInputs(testInputs, async () => {
             await vscode.commands.executeCommand('azureFunctions.createFunctionAppAdvanced');
         });
@@ -48,7 +50,7 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
     });
 
     test('Create - Advanced - Existing RG/SA/AI', async () => {
-        const testInputs: (string | RegExp)[] = [app2Name, /\.net/i, 'Windows', 'Consumption', rgName, saName, aiName];
+        const testInputs: (string | RegExp)[] = [app2Name, /\.net/i, 'Windows', rgName, location, 'Consumption', saName, aiName];
         await testUserInput.runWithInputs(testInputs, async () => {
             await vscode.commands.executeCommand('azureFunctions.createFunctionAppAdvanced');
         });


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-azuretools/pull/908, I want the location step and storage account step as close to each other as possible since the selected location directly influences the storage accounts we list. By moving rg before location, it's easier for users to go back and change the location after they see their storage accounts.

Also fixes nightly tests