### PR TITLE
Explicitly create consumption plans

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -7,6 +7,7 @@ import { AppServicePlanListStep, IAppServiceWizardContext, setLocationsTask } fr
 import { AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
 import { getRandomHexString } from '../../utils/fs';
+import { nonNullProp } from '../../utils/nonNull';
 
 export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
     public async prompt(context: IAppServiceWizardContext): Promise<void> {
@@ -34,6 +35,6 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IAppServic
 }
 
 export function setConsumptionPlanProperties(context: IAppServiceWizardContext): void {
-    context.newPlanName = `ASP-${context.newSiteName}-${getRandomHexString(4)}`;
+    context.newPlanName = `ASP-${nonNullProp(context, 'newSiteName')}-${getRandomHexString(4)}`;
     context.newPlanSku = { name: 'Y1', tier: 'Dynamic', size: 'Y1', family: 'Y', capacity: 0 };
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { WebSiteManagementClient, WebSiteManagementModels } from '@azure/arm-appservice';
-import { AppInsightsCreateStep, AppInsightsListStep, AppKind, CustomLocationListStep, IAppServiceWizardContext, SiteClient, SiteNameStep, WebsiteOS } from 'vscode-azureappservice';
+import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, CustomLocationListStep, IAppServiceWizardContext, SiteClient, SiteNameStep, WebsiteOS } from 'vscode-azureappservice';
 import { AzExtTreeItem, AzureTreeItem, AzureWizard, AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, ICreateChildImplContext, INewStorageAccountDefaults, LocationListStep, parseError, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, VerifyProvidersStep } from 'vscode-azureextensionui';
 import { FunctionAppCreateStep } from '../commands/createFunctionApp/FunctionAppCreateStep';
-import { FunctionAppHostingPlanStep } from '../commands/createFunctionApp/FunctionAppHostingPlanStep';
+import { FunctionAppHostingPlanStep, setConsumptionPlanProperties } from '../commands/createFunctionApp/FunctionAppHostingPlanStep';
 import { IFunctionAppWizardContext } from '../commands/createFunctionApp/IFunctionAppWizardContext';
 import { FunctionAppStackStep } from '../commands/createFunctionApp/stacks/FunctionAppStackStep';
 import { funcVersionSetting, projectLanguageSetting, webProvider } from '../constants';
@@ -107,6 +107,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             wizardContext.useConsumptionPlan = true;
             wizardContext.stackFilter = getFunctionsWorkerRuntime(language);
             executeSteps.push(new ResourceGroupCreateStep());
+            executeSteps.push(new AppServicePlanCreateStep());
             executeSteps.push(new StorageAccountCreateStep(storageAccountCreateOptions));
             executeSteps.push(new AppInsightsCreateStep());
         } else {
@@ -147,6 +148,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
                 throw new Error(localize('noUniqueName', 'Failed to generate unique name for resources. Use advanced creation to manually enter resource names.'));
             }
             wizardContext.newResourceGroupName = context.newResourceGroupName || newName;
+            setConsumptionPlanProperties(wizardContext);
             wizardContext.newStorageAccountName = newName;
             wizardContext.newAppInsightsName = newName;
         }

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -104,14 +104,14 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
     });
 
     test('Delete', async () => {
-        await testUserInput.runWithInputs([appName, DialogResponses.deleteResponse.title], async () => {
+        await testUserInput.runWithInputs([appName, DialogResponses.deleteResponse.title, DialogResponses.yes.title], async () => {
             await vscode.commands.executeCommand('azureFunctions.deleteFunctionApp');
         });
         const site: Models.Site | undefined = await tryGetWebApp(testClient, rgName, appName);
         assert.equal(site, undefined);
     });
 
-    test('Delete - Last App on Plan', async () => {
+    test('Delete - Existing RG/SA/AI', async () => {
         await testUserInput.runWithInputs([app2Name, DialogResponses.deleteResponse.title, DialogResponses.yes.title], async () => {
             await vscode.commands.executeCommand('azureFunctions.deleteFunctionApp');
         });


### PR DESCRIPTION
rather than letting Azure create one for us under the covers. I modeled the behavior and naming after the portal, which is already doing this. The portal always creates a new plan for each app, which I think is fine for the consumption billing model.

Two main benefits:
1. We don't have to deal with `undefined` plans after the function app is created (aka this PR replaces https://github.com/microsoft/vscode-azurefunctions/pull/2799)
2. Users can create a windows and linux app in the same resource group. Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2234

