### PR TITLE
Let users debug even if local.settings.json can't be parsed

### DIFF
--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -56,10 +56,13 @@ export async function preDebugValidate(context: IActionContext, debugConfig: vsc
             }
         }
     } catch (error) {
-        if (parseError(error).isUserCancelledError) {
+        const pe = parseError(error);
+        if (pe.isUserCancelledError) {
             shouldContinue = false;
         } else {
-            throw error;
+            // Don't block debugging for "unexpected" errors. The func cli might still work
+            shouldContinue = true;
+            context.telemetry.properties.preDebugValidateError = pe.message;
         }
     }
 


### PR DESCRIPTION
I discovered parse errors in telemetry for a very small number of users and figured we could handle this better. For C# we currently block debugging, but I tried it out and the func cli will still work (for the most part).