### PR TITLE
Remove func task from running map after we terminate it

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -63,6 +63,7 @@ export function stopFuncTaskIfRunning(workspaceFolder: vscode.WorkspaceFolder): 
         // Use `process.kill` because `TaskExecution.terminate` closes the terminal pane and erases all output
         // Also to hopefully fix https://github.com/microsoft/vscode-azurefunctions/issues/1401
         process.kill(runningFuncTask.processId);
+        runningFuncTaskMap.delete(workspaceFolder);
     }
 }
 


### PR DESCRIPTION
The error "kill ESRCH" happens a lot in telemetry for the event "azureFunctions.onDidTerminateDebugSession". Basically, what happens is that VS Code will fire `onDidTerminateDebugSession` twice in a row for some reason and we kill the process the first time and fail to find the process (hence "ESRCH") the second time. This is harmless since we don't display the error to the user, but I thought I would make this change to clean up our telemetry.