### PR TITLE
Give target framework priority when getting C# templates

### DIFF
--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -179,7 +179,7 @@ export class CentralTemplateProvider implements Disposable {
         let result: ITemplates | undefined;
         let latestErrorMessage: string | undefined;
         try {
-            const latestTemplateVersion: string = await provider.getLatestTemplateVersion();
+            const latestTemplateVersion: string = await provider.getLatestTemplateVersion(context);
             context.telemetry.properties.latestTemplateVersion = latestTemplateVersion;
 
             const cachedTemplateVersion: string | undefined = await provider.getCachedTemplateVersion();

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -69,7 +69,7 @@ export abstract class TemplateProviderBase implements Disposable {
         return ext.context.globalState.get<T>(await this.getCacheKey(key));
     }
 
-    public abstract getLatestTemplateVersion(): Promise<string>;
+    public abstract getLatestTemplateVersion(context: IActionContext): Promise<string>;
     public abstract getLatestTemplates(context: IActionContext, latestTemplateVersion: string): Promise<ITemplates>;
     public abstract getCachedTemplates(context: IActionContext): Promise<ITemplates | undefined>;
     public abstract getBackupTemplates(context: IActionContext): Promise<ITemplates>;

--- a/test/updateBackupTemplates.ts
+++ b/test/updateBackupTemplates.ts
@@ -41,11 +41,12 @@ suite('Backup templates', () => {
 
                 const providers: TemplateProviderBase[] = CentralTemplateProvider.getProviders(testWorkspacePath, worker.language, version, worker.projectTemplateKey);
 
+                const context = createTestActionContext();
                 for (const provider of providers) {
-                    const templateVersion: string = await provider.getLatestTemplateVersion();
+                    const templateVersion: string = await provider.getLatestTemplateVersion(context);
 
                     async function updateBackupTemplatesInternal(): Promise<void> {
-                        await provider.getLatestTemplates(createTestActionContext(), templateVersion);
+                        await provider.getLatestTemplates(context, templateVersion);
                         await provider.updateBackupTemplates();
                     }
 


### PR DESCRIPTION
I'm seeing this error pop up in telemetry:

> Failed to get latest templates: Failed to find templates for .NET worker "netcoreapp3.1".

It's because users have v2 listed as their func version in their VS Code settings, which does not support .net core 3.1 as listed in their csproj. In this case, we will print a warning to the output channel and just use the templates from v3.