### PR TITLE
Refactor to use `context.ui` instead of `ext.ui`

### DIFF
--- a/src/FuncVersion.ts
+++ b/src/FuncVersion.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAzureQuickPickItem, IAzureQuickPickOptions } from 'vscode-azureextensionui';
-import { ext } from './extensionVariables';
+import { IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions } from 'vscode-azureextensionui';
 import { localize } from './localize';
 import { openUrl } from './utils/openUrl';
 
@@ -16,7 +15,7 @@ export enum FuncVersion {
 
 export const latestGAVersion: FuncVersion = FuncVersion.v3;
 
-export async function promptForFuncVersion(message?: string): Promise<FuncVersion> {
+export async function promptForFuncVersion(context: IActionContext, message?: string): Promise<FuncVersion> {
     const recommended: string = localize('recommended', '(Recommended)');
     let picks: IAzureQuickPickItem<FuncVersion | undefined>[] = [
         { label: 'Azure Functions v3', description: recommended, data: FuncVersion.v3 },
@@ -31,7 +30,7 @@ export async function promptForFuncVersion(message?: string): Promise<FuncVersio
     const options: IAzureQuickPickOptions = { placeHolder: message || localize('selectVersion', 'Select a version'), suppressPersistence: true };
     // eslint-disable-next-line no-constant-condition
     while (true) {
-        const version: FuncVersion | undefined = (await ext.ui.showQuickPick(picks, options)).data;
+        const version: FuncVersion | undefined = (await context.ui.showQuickPick(picks, options)).data;
         if (version === undefined) {
             await openUrl('https://aka.ms/AA1tpij');
         } else {

--- a/src/commands/addBinding/BindingCreateStep.ts
+++ b/src/commands/addBinding/BindingCreateStep.ts
@@ -30,7 +30,7 @@ export class BindingCreateStep extends AzureWizardExecuteStep<IBindingWizardCont
             binding[b.name] = getBindingSetting(context, b);
         }
 
-        await confirmEditJsonFile(context.functionJsonPath, (functionJson: IFunctionJson) => {
+        await confirmEditJsonFile(context, context.functionJsonPath, (functionJson: IFunctionJson) => {
             functionJson.bindings = functionJson.bindings || [];
             functionJson.bindings.push(binding);
             return functionJson;

--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -31,7 +31,7 @@ export async function addBinding(context: IActionContext, data: Uri | LocalFunct
         functionJsonPath = data.fsPath;
         workspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'workspaceFolder');
         workspacePath = workspaceFolder.uri.fsPath;
-        projectPath = await tryGetFunctionProjectRoot(workspacePath) || workspacePath;
+        projectPath = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
         [language, version] = await verifyInitForVSCode(context, projectPath);
     } else {
         if (!data) {

--- a/src/commands/addBinding/settingSteps/AzureConnectionCreateStepBase.ts
+++ b/src/commands/addBinding/settingSteps/AzureConnectionCreateStepBase.ts
@@ -36,6 +36,6 @@ export abstract class AzureConnectionCreateStepBase<T extends IBindingWizardCont
         let appSettingKey: string = `${result.name}_${nonNullProp(this._setting, 'resourceType').toUpperCase()}`;
         appSettingKey = appSettingKey.replace(/[^a-z0-9_\.]/gi, ''); // remove invalid chars
         setBindingSetting(context, this._setting, appSettingKey);
-        await setLocalAppSetting(context.projectPath, appSettingKey, result.connectionString);
+        await setLocalAppSetting(context, context.projectPath, appSettingKey, result.connectionString);
     }
 }

--- a/src/commands/addBinding/settingSteps/LocalAppSettingCreateStep.ts
+++ b/src/commands/addBinding/settingSteps/LocalAppSettingCreateStep.ts
@@ -29,7 +29,7 @@ export class LocalAppSettingCreateStep extends AzureWizardExecuteStep<IBindingWi
         progress.report({ message: localize('updatingLocalSettings', 'Updating {0}...', localSettingsFileName) });
         const appSettingName = String(nonNullValue(getBindingSetting(context, this._setting), this._setting.name));
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await setLocalAppSetting(context.projectPath, appSettingName, nonNullProp(context, <any>this._valueKey));
+        await setLocalAppSetting(context, context.projectPath, appSettingName, nonNullProp(context, <any>this._valueKey));
     }
 
     public shouldExecute(context: IBindingWizardContext): boolean {

--- a/src/commands/addBinding/settingSteps/LocalAppSettingListStep.ts
+++ b/src/commands/addBinding/settingSteps/LocalAppSettingListStep.ts
@@ -30,7 +30,7 @@ import { StorageConnectionCreateStep } from './StorageConnectionCreateStep';
 export class LocalAppSettingListStep extends BindingSettingStepBase {
     public async promptCore(context: IBindingWizardContext): Promise<BindingSettingValue> {
         const localSettingsPath: string = path.join(context.projectPath, localSettingsFileName);
-        const settings: ILocalSettingsJson = await getLocalSettingsJson(localSettingsPath);
+        const settings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath);
         const existingSettings: string[] = settings.Values ? Object.keys(settings.Values) : [];
         let picks: IAzureQuickPickItem<string | undefined>[] = [{ label: localize('newAppSetting', '$(plus) Create new local app setting'), data: undefined }];
         picks = picks.concat(existingSettings.map((s: string) => { return { data: s, label: s }; }));

--- a/src/commands/appSettings/AzureWebJobsStorageExecuteStep.ts
+++ b/src/commands/appSettings/AzureWebJobsStorageExecuteStep.ts
@@ -20,7 +20,7 @@ export class AzureWebJobsStorageExecuteStep<T extends IAzureWebJobsStorageWizard
             value = (await getStorageConnectionString(<IStorageAccountWizardContext>context)).connectionString;
         }
 
-        await setLocalAppSetting(context.projectPath, azureWebJobsStorageKey, value, MismatchBehavior.Overwrite);
+        await setLocalAppSetting(context, context.projectPath, azureWebJobsStorageKey, value, MismatchBehavior.Overwrite);
     }
 
     public shouldExecute(context: IAzureWebJobsStorageWizardContext): boolean {

--- a/src/commands/appSettings/confirmOverwriteSettings.ts
+++ b/src/commands/appSettings/confirmOverwriteSettings.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { DialogResponses } from "vscode-azureextensionui";
+import { DialogResponses, IActionContext } from "vscode-azureextensionui";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
 
-export async function confirmOverwriteSettings(sourceSettings: { [key: string]: string }, destinationSettings: { [key: string]: string }, destinationName: string): Promise<void> {
+export async function confirmOverwriteSettings(context: IActionContext, sourceSettings: { [key: string]: string }, destinationSettings: { [key: string]: string }, destinationName: string): Promise<void> {
     let suppressPrompt: boolean = false;
     let overwriteSetting: boolean = false;
 
@@ -28,7 +28,7 @@ export async function confirmOverwriteSettings(sourceSettings: { [key: string]: 
                 const yesToAll: vscode.MessageItem = { title: localize('yesToAll', 'Yes to all') };
                 const noToAll: vscode.MessageItem = { title: localize('noToAll', 'No to all') };
                 const message: string = localize('overwriteSetting', 'Setting "{0}" already exists in "{1}". Overwrite?', key, destinationName);
-                const result: vscode.MessageItem = await ext.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, yesToAll, DialogResponses.no, noToAll);
+                const result: vscode.MessageItem = await context.ui.showWarningMessage(message, { modal: true }, DialogResponses.yes, yesToAll, DialogResponses.no, noToAll);
                 if (result === DialogResponses.yes) {
                     overwriteSetting = true;
                 } else if (result === yesToAll) {

--- a/src/commands/appSettings/decryptLocalSettings.ts
+++ b/src/commands/appSettings/decryptLocalSettings.ts
@@ -11,9 +11,9 @@ import { localize } from '../../localize';
 import { cpUtils } from "../../utils/cpUtils";
 import { getLocalSettingsFile } from './getLocalSettingsFile';
 
-export async function decryptLocalSettings(_context: IActionContext, uri?: Uri): Promise<void> {
+export async function decryptLocalSettings(context: IActionContext, uri?: Uri): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select the settings file to decrypt.');
-    const localSettingsPath: string = uri ? uri.fsPath : await getLocalSettingsFile(message);
+    const localSettingsPath: string = uri ? uri.fsPath : await getLocalSettingsFile(context, message);
     ext.outputChannel.show(true);
     await cpUtils.executeCommand(ext.outputChannel, path.dirname(localSettingsPath), 'func', 'settings', 'decrypt');
 }

--- a/src/commands/appSettings/downloadAppSettings.ts
+++ b/src/commands/appSettings/downloadAppSettings.ts
@@ -31,10 +31,10 @@ export async function downloadAppSettings(context: IActionContext, node?: AppSet
 
 export async function downloadAppSettingsInternal(context: IActionContext, client: api.IAppSettingsClient): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select the destination file for your downloaded settings.');
-    const localSettingsPath: string = await getLocalSettingsFile(message);
+    const localSettingsPath: string = await getLocalSettingsFile(context, message);
     const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
 
-    let localSettings: ILocalSettingsJson = await getLocalSettingsJson(localSettingsPath, true /* allowOverwrite */);
+    let localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, localSettingsPath, true /* allowOverwrite */);
 
     const isEncrypted: boolean | undefined = localSettings.IsEncrypted;
     if (localSettings.IsEncrypted) {
@@ -51,7 +51,7 @@ export async function downloadAppSettingsInternal(context: IActionContext, clien
 
         ext.outputChannel.appendLog(localize('downloadingSettings', 'Downloading settings...'), { resourceName: client.fullName });
         if (remoteSettings.properties) {
-            await confirmOverwriteSettings(remoteSettings.properties, localSettings.Values, localSettingsFileName);
+            await confirmOverwriteSettings(context, remoteSettings.properties, localSettings.Values, localSettingsFileName);
         }
 
         await fse.ensureFile(localSettingsPath);

--- a/src/commands/appSettings/encryptLocalSettings.ts
+++ b/src/commands/appSettings/encryptLocalSettings.ts
@@ -11,9 +11,9 @@ import { localize } from '../../localize';
 import { cpUtils } from "../../utils/cpUtils";
 import { getLocalSettingsFile } from './getLocalSettingsFile';
 
-export async function encryptLocalSettings(_context: IActionContext, uri?: Uri): Promise<void> {
+export async function encryptLocalSettings(context: IActionContext, uri?: Uri): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select the settings file to encrypt.');
-    const localSettingsPath: string = uri ? uri.fsPath : await getLocalSettingsFile(message);
+    const localSettingsPath: string = uri ? uri.fsPath : await getLocalSettingsFile(context, message);
     ext.outputChannel.show(true);
     await cpUtils.executeCommand(ext.outputChannel, path.dirname(localSettingsPath), 'func', 'settings', 'encrypt');
 }

--- a/src/commands/appSettings/getLocalSettingsFile.ts
+++ b/src/commands/appSettings/getLocalSettingsFile.ts
@@ -6,8 +6,8 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { workspace, WorkspaceFolder } from "vscode";
+import { IActionContext } from 'vscode-azureextensionui';
 import { localSettingsFileName } from "../../constants";
-import { ext } from "../../extensionVariables";
 import { selectWorkspaceFile } from "../../utils/workspace";
 import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
 
@@ -15,11 +15,11 @@ import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
  * If only one project is open and the default local settings file exists, return that.
  * Otherwise, prompt
  */
-export async function getLocalSettingsFile(message: string, workspacePath?: string): Promise<string> {
+export async function getLocalSettingsFile(context: IActionContext, message: string, workspacePath?: string): Promise<string> {
     const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
     if (workspacePath || folders.length === 1) {
         workspacePath = workspacePath || folders[0].uri.fsPath;
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */);
+        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */);
         if (projectPath) {
             const localSettingsFile: string = path.join(projectPath, localSettingsFileName);
             if (await fse.pathExists(localSettingsFile)) {
@@ -28,9 +28,9 @@ export async function getLocalSettingsFile(message: string, workspacePath?: stri
         }
     }
 
-    return await selectWorkspaceFile(ext.ui, message, async (f: WorkspaceFolder): Promise<string> => {
+    return await selectWorkspaceFile(context, message, async (f: WorkspaceFolder): Promise<string> => {
         workspacePath = f.uri.fsPath;
-        const projectPath: string = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */) || workspacePath;
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */) || workspacePath;
         return path.relative(workspacePath, path.join(projectPath, localSettingsFileName));
     });
 }

--- a/src/commands/appSettings/setAzureWebJobsStorage.ts
+++ b/src/commands/appSettings/setAzureWebJobsStorage.ts
@@ -13,7 +13,7 @@ import { IAzureWebJobsStorageWizardContext } from './IAzureWebJobsStorageWizardC
 
 export async function setAzureWebJobsStorage(context: IActionContext): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select your local settings file.');
-    const localSettingsFile: string = await getLocalSettingsFile(message);
+    const localSettingsFile: string = await getLocalSettingsFile(context, message);
     const wizardContext: IAzureWebJobsStorageWizardContext = Object.assign(context, { projectPath: path.dirname(localSettingsFile) });
     const wizard: AzureWizard<IAzureWebJobsStorageWizardContext> = new AzureWizard(wizardContext, {
         promptSteps: [new AzureWebJobsStoragePromptStep()],

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -31,7 +31,7 @@ export async function uploadAppSettings(context: IActionContext, node?: AppSetti
 
 export async function uploadAppSettingsInternal(context: IActionContext, client: api.IAppSettingsClient, workspacePath?: string): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select the local settings file to upload.');
-    const localSettingsPath: string = await getLocalSettingsFile(message, workspacePath);
+    const localSettingsPath: string = await getLocalSettingsFile(context, message, workspacePath);
     const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
 
     let localSettings: ILocalSettingsJson = <ILocalSettingsJson>await fse.readJson(localSettingsPath);
@@ -52,7 +52,7 @@ export async function uploadAppSettingsInternal(context: IActionContext, client:
 
         const uploadSettings: string = localize('uploadingSettings', 'Uploading settings...');
         ext.outputChannel.appendLog(uploadSettings, { resourceName: client.fullName });
-        await confirmOverwriteSettings(localSettings.Values, remoteSettings.properties, client.fullName);
+        await confirmOverwriteSettings(context, localSettings.Values, remoteSettings.properties, client.fullName);
 
         await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: localize('uploadingSettingsTo', 'Uploading settings to "{0}"...', client.fullName) }, async () => {
             await client.updateApplicationSettings(remoteSettings);

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -108,7 +108,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                     break;
             }
 
-            if (!template.isHttpTrigger && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context.projectPath)) {
+            if (!template.isHttpTrigger && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context, context.projectPath)) {
                 promptSteps.push(new AzureWebJobsStoragePromptStep());
                 executeSteps.push(new AzureWebJobsStorageExecuteStep());
             }

--- a/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
+++ b/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
@@ -99,7 +99,7 @@ async function addAutorestSpecificTypescriptDependencies(context: IFunctionWizar
     const coreHttpVersion: string = '^1.1.4';
     const packagePath: string = path.join(context.projectPath, 'package.json');
 
-    await confirmEditJsonFile(packagePath, (data: { devDependencies?: { [key: string]: string } }): {} => {
+    await confirmEditJsonFile(context, packagePath, (data: { devDependencies?: { [key: string]: string } }): {} => {
         data.devDependencies = data.devDependencies || {};
         if (!data.devDependencies[coreHttp]) {
             data.devDependencies[coreHttp] = coreHttpVersion;

--- a/src/commands/createNewProject/FolderListStep.ts
+++ b/src/commands/createNewProject/FolderListStep.ts
@@ -22,7 +22,7 @@ export class FolderListStep extends AzureWizardPromptStep<IProjectWizardContext>
 
     public async prompt(context: IProjectWizardContext): Promise<void> {
         const placeHolder: string = localize('selectNewProjectFolder', 'Select the folder that will contain your function project');
-        FolderListStep.setProjectPath(context, await selectWorkspaceFolder(context.ui, placeHolder));
+        FolderListStep.setProjectPath(context, await selectWorkspaceFolder(context, placeHolder));
     }
 
     public shouldPrompt(context: IProjectWizardContext): boolean {

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -44,7 +44,7 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         const projTemplateKey = nonNullProp(context, 'projectTemplateKey');
         await executeDotnetTemplateCommand(context, version, projTemplateKey, context.projectPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);
 
-        await setLocalAppSetting(context.projectPath, azureWebJobsStorageKey, '', MismatchBehavior.Overwrite);
+        await setLocalAppSetting(context, context.projectPath, azureWebJobsStorageKey, '', MismatchBehavior.Overwrite);
     }
 
     private async confirmOverwriteExisting(context: IProjectWizardContext, projName: string): Promise<void> {

--- a/src/commands/createNewProject/ProjectCreateStep/JavaProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaProjectCreateStep.ts
@@ -47,7 +47,7 @@ export class JavaProjectCreateStep extends ProjectCreateStepBase {
                 mavenUtils.formatMavenArg('DappName', nonNullProp(context, 'javaAppName')),
                 '-B' // in Batch Mode
             );
-            await fsUtil.copyFolder(path.join(tempFolder, artifactId), context.projectPath);
+            await fsUtil.copyFolder(context, path.join(tempFolder, artifactId), context.projectPath);
         } finally {
             await fse.remove(tempFolder);
         }

--- a/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
@@ -27,7 +27,7 @@ export class JavaScriptProjectCreateStep extends ScriptProjectCreateStep {
         await super.executeCore(context, progress);
 
         const packagePath: string = path.join(context.projectPath, 'package.json');
-        if (await confirmOverwriteFile(packagePath)) {
+        if (await confirmOverwriteFile(context, packagePath)) {
             await writeFormattedJson(packagePath, {
                 name: convertToValidPackageName(path.basename(context.projectPath)),
                 version: '1.0.0',

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -74,7 +74,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         await super.executeCore(context, progress);
 
         const profileps1Path: string = path.join(context.projectPath, profileps1FileName);
-        if (await confirmOverwriteFile(profileps1Path)) {
+        if (await confirmOverwriteFile(context, profileps1Path)) {
             await fse.writeFile(profileps1Path, profileps1);
         }
 
@@ -90,7 +90,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         }
 
         const requirementspsd1Path: string = path.join(context.projectPath, requirementspsd1FileName);
-        if (await confirmOverwriteFile(requirementspsd1Path)) {
+        if (await confirmOverwriteFile(context, requirementspsd1Path)) {
             if (majorVersion !== undefined) {
                 await fse.writeFile(requirementspsd1Path, requirementspsd1Online(majorVersion));
             } else {

--- a/src/commands/createNewProject/ProjectCreateStep/PythonProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PythonProjectCreateStep.ts
@@ -37,7 +37,7 @@ export class PythonProjectCreateStep extends ScriptProjectCreateStep {
         await super.executeCore(context, progress);
 
         const requirementsPath: string = path.join(context.projectPath, requirementsFileName);
-        if (await confirmOverwriteFile(requirementsPath)) {
+        if (await confirmOverwriteFile(context, requirementsPath)) {
             let isOldFuncCli: boolean;
             try {
                 const currentVersion: string | null = await getLocalFuncCoreToolsVersion();

--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -31,13 +31,13 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
     public async executeCore(context: IProjectWizardContext, _progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         const version: FuncVersion = nonNullProp(context, 'version');
         const hostJsonPath: string = path.join(context.projectPath, hostFileName);
-        if (await confirmOverwriteFile(hostJsonPath)) {
+        if (await confirmOverwriteFile(context, hostJsonPath)) {
             const hostJson: IHostJsonV2 | IHostJsonV1 = version === FuncVersion.v1 ? {} : await this.getHostContent();
             await writeFormattedJson(hostJsonPath, hostJson);
         }
 
         const localSettingsJsonPath: string = path.join(context.projectPath, localSettingsFileName);
-        if (await confirmOverwriteFile(localSettingsJsonPath)) {
+        if (await confirmOverwriteFile(context, localSettingsJsonPath)) {
             const functionsWorkerRuntime: string | undefined = getFunctionsWorkerRuntime(context.language);
             if (functionsWorkerRuntime) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -48,7 +48,7 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
         }
 
         const proxiesJsonPath: string = path.join(context.projectPath, proxiesFileName);
-        if (await confirmOverwriteFile(proxiesJsonPath)) {
+        if (await confirmOverwriteFile(context, proxiesJsonPath)) {
             await writeFormattedJson(proxiesJsonPath, {
                 $schema: 'http://json.schemastore.org/proxies',
                 proxies: {}
@@ -56,7 +56,7 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
         }
 
         const gitignorePath: string = path.join(context.projectPath, gitignoreFileName);
-        if (await confirmOverwriteFile(gitignorePath)) {
+        if (await confirmOverwriteFile(context, gitignorePath)) {
             await fse.writeFile(gitignorePath, this.gitignore.concat(`
 # Azure Functions artifacts
 bin
@@ -66,7 +66,7 @@ local.settings.json`));
         }
 
         const funcIgnorePath: string = path.join(context.projectPath, '.funcignore');
-        if (await confirmOverwriteFile(funcIgnorePath)) {
+        if (await confirmOverwriteFile(context, funcIgnorePath)) {
             await fse.writeFile(funcIgnorePath, this.funcignore.sort().join(os.EOL));
         }
     }

--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -28,7 +28,7 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
         await super.executeCore(context, progress);
 
         const tsconfigPath: string = path.join(context.projectPath, tsConfigFileName);
-        if (await confirmOverwriteFile(tsconfigPath)) {
+        if (await confirmOverwriteFile(context, tsconfigPath)) {
             await writeFormattedJson(tsconfigPath, {
                 compilerOptions: {
                     module: 'commonjs',

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -111,7 +111,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
 }
 
 async function updateWorkerProcessTo64BitIfRequired(context: IDeployContext, siteConfig: WebSiteManagementModels.SiteConfigResource, node: SlotTreeItemBase, language: ProjectLanguage): Promise<void> {
-    const functionProject: string | undefined = await tryGetFunctionProjectRoot(context.workspaceFolder.uri.fsPath);
+    const functionProject: string | undefined = await tryGetFunctionProjectRoot(context, context.workspaceFolder.uri.fsPath);
     if (functionProject === undefined) {
         return;
     }

--- a/src/commands/deploy/runPreDeployTask.ts
+++ b/src/commands/deploy/runPreDeployTask.ts
@@ -17,7 +17,7 @@ export async function runPreDeployTask(context: IDeployContext, deployFsPath: st
     const preDeployTask: string | undefined = getWorkspaceSetting(preDeployTaskSetting, deployFsPath);
     if (preDeployTask && preDeployTask.startsWith('func:')) {
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to run preDeployTask "{0}".', preDeployTask);
-        if (!await validateFuncCoreToolsInstalled(message, deployFsPath)) {
+        if (!await validateFuncCoreToolsInstalled(context, message, deployFsPath)) {
             throw new UserCancelledError();
         }
     }

--- a/src/commands/deploy/validateRemoteBuild.ts
+++ b/src/commands/deploy/validateRemoteBuild.ts
@@ -21,7 +21,7 @@ export async function validateRemoteBuild(context: IDeployContext, client: SiteC
         await context.ui.showWarningMessage(message, { learnMoreLink, modal: true }, downgrade);
         context.telemetry.properties.cancelStep = undefined;
 
-        const projectPath: string = await tryGetFunctionProjectRoot(workspacePath, true /* suppressPrompt */) || workspacePath;
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */) || workspacePath;
         await updateWorkspaceSetting(remoteBuildSetting, false, workspacePath);
         await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
         const zipFileName: string = path.basename(projectPath) + '.zip';

--- a/src/commands/initProjectForVSCode/detectProjectLanguage.ts
+++ b/src/commands/initProjectForVSCode/detectProjectLanguage.ts
@@ -5,6 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import { IActionContext } from 'vscode-azureextensionui';
 import { localSettingsFileName, pomXmlFileName, ProjectLanguage, workerRuntimeKey } from '../../constants';
 import { getLocalSettingsJson, ILocalSettingsJson } from '../../funcConfig/local.settings';
 import { dotnetUtils } from '../../utils/dotnetUtils';
@@ -13,7 +14,7 @@ import { getScriptFileNameFromLanguage } from '../createFunction/scriptSteps/Scr
 /**
  * Returns the project language if we can uniquely detect it for this folder, otherwise returns undefined
  */
-export async function detectProjectLanguage(projectPath: string): Promise<ProjectLanguage | undefined> {
+export async function detectProjectLanguage(context: IActionContext, projectPath: string): Promise<ProjectLanguage | undefined> {
     let detectedLangs: ProjectLanguage[] = await detectScriptLanguages(projectPath);
 
     if (await isJavaProject(projectPath)) {
@@ -28,7 +29,7 @@ export async function detectProjectLanguage(projectPath: string): Promise<Projec
         detectedLangs.push(ProjectLanguage.FSharp);
     }
 
-    await detectLanguageFromLocalSettings(detectedLangs, projectPath);
+    await detectLanguageFromLocalSettings(context, detectedLangs, projectPath);
 
     // de-dupe
     detectedLangs = detectedLangs.filter((pl, index) => detectedLangs.indexOf(pl) === index);
@@ -50,9 +51,9 @@ async function isFSharpProject(projectPath: string): Promise<boolean> {
 /**
  * If the user has a "local.settings.json" file, we may be able to infer the langauge from the setting "FUNCTIONS_WORKER_RUNTIME"
  */
-async function detectLanguageFromLocalSettings(detectedLangs: ProjectLanguage[], projectPath: string): Promise<void> {
+async function detectLanguageFromLocalSettings(context: IActionContext, detectedLangs: ProjectLanguage[], projectPath: string): Promise<void> {
     try {
-        const settings: ILocalSettingsJson = await getLocalSettingsJson(path.join(projectPath, localSettingsFileName));
+        const settings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
         switch (settings.Values?.[workerRuntimeKey]?.toLowerCase()) {
             case 'java':
                 detectedLangs.push(ProjectLanguage.Java);

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -42,7 +42,7 @@ export async function initProjectForVSCode(context: IActionContext, fsPath?: str
         return;
     }
 
-    language = language || getGlobalSetting(projectLanguageSetting) || await detectProjectLanguage(projectPath);
+    language = language || getGlobalSetting(projectLanguageSetting) || await detectProjectLanguage(context, projectPath);
     const version: FuncVersion = getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion() || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
 

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -83,7 +83,7 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
         await taskUtils.executeIfNotActive(funcTask);
 
         const intervalMs: number = 500;
-        const funcPort: string = await getFuncPortFromTaskOrProject(funcTask, workspaceFolder);
+        const funcPort: string = await getFuncPortFromTaskOrProject(context, funcTask, workspaceFolder);
         const statusRequest: RequestPrepareOptions = { url: `http://localhost:${funcPort}/admin/host/status`, method: 'GET' };
         let statusRequestTimeout: number = intervalMs;
         const maxTime: number = Date.now() + timeoutInSeconds * 1000;

--- a/src/commands/updateDisabledState.ts
+++ b/src/commands/updateDisabledState.ts
@@ -29,7 +29,7 @@ async function updateDisabledState(context: IActionContext, node: FunctionTreeIt
     if (version === FuncVersion.v1) {
         throw new Error(localize('notSupportedV1', 'This operation is not supported for Azure Functions v1.'));
     } else {
-        await node.parent.parent.setApplicationSetting(node.disabledStateKey, String(isDisabled));
+        await node.parent.parent.setApplicationSetting(context, node.disabledStateKey, String(isDisabled));
     }
     await node.parent.parent.refresh(context);
 

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -43,7 +43,7 @@ export class FuncTaskProvider implements TaskProvider {
                 let lastError: unknown;
                 for (const folder of workspace.workspaceFolders) {
                     try {
-                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(folder.uri.fsPath, true /* suppressPrompt */);
+                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath, true /* suppressPrompt */);
                         if (projectRoot) {
                             const language: string | undefined = getWorkspaceSetting(projectLanguageSetting, folder.uri.fsPath);
 

--- a/src/downloadAzureProject/handleUri.ts
+++ b/src/downloadAzureProject/handleUri.ts
@@ -31,7 +31,7 @@ export async function handleUri(uri: vscode.Uri): Promise<void> {
                     await vscode.commands.executeCommand('azure-account.login');
                 }
 
-                const filePathUri: vscode.Uri[] = await ext.ui.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false });
+                const filePathUri: vscode.Uri[] = await context.ui.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false });
                 await setupProjectFolder(uri, filePathUri[0], context);
             } else {
                 throw new RangeError(localize('invalidAction', 'Invalid action "{0}".', action));

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -34,7 +34,7 @@ export function registerFuncHostTaskEvents(): void {
         context.telemetry.suppressIfSuccessful = true;
         if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
             runningFuncTaskMap.set(e.execution.task.scope, { processId: e.processId });
-            runningFuncPortMap.set(e.execution.task.scope, await getFuncPortFromTaskOrProject(e.execution.task, e.execution.task.scope));
+            runningFuncPortMap.set(e.execution.task.scope, await getFuncPortFromTaskOrProject(context, e.execution.task, e.execution.task.scope));
             funcTaskStartedEmitter.fire(e.execution.task.scope);
         }
     });
@@ -67,7 +67,7 @@ export function stopFuncTaskIfRunning(workspaceFolder: vscode.WorkspaceFolder): 
     }
 }
 
-export async function getFuncPortFromTaskOrProject(funcTask: vscode.Task | undefined, projectPathOrTaskScope: string | vscode.WorkspaceFolder | vscode.TaskScope): Promise<string> {
+export async function getFuncPortFromTaskOrProject(context: IActionContext, funcTask: vscode.Task | undefined, projectPathOrTaskScope: string | vscode.WorkspaceFolder | vscode.TaskScope): Promise<string> {
     try {
         // First, check the task itself
         if (funcTask && typeof funcTask.definition.command === 'string') {
@@ -82,11 +82,11 @@ export async function getFuncPortFromTaskOrProject(funcTask: vscode.Task | undef
         if (typeof projectPathOrTaskScope === 'string') {
             projectPath = projectPathOrTaskScope;
         } else if (typeof projectPathOrTaskScope === 'object') {
-            projectPath = await tryGetFunctionProjectRoot(projectPathOrTaskScope.uri.fsPath, true /* suppressPrompt */);
+            projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope.uri.fsPath, true /* suppressPrompt */);
         }
 
         if (projectPath) {
-            const localSettings = await getLocalSettingsJson(path.join(projectPath, localSettingsFileName));
+            const localSettings = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
             if (localSettings.Host) {
                 const key = Object.keys(localSettings.Host).find(k => k.toLowerCase() === 'localhttpport');
                 if (key && localSettings.Host[key]) {

--- a/src/funcCoreTools/installFuncCoreTools.ts
+++ b/src/funcCoreTools/installFuncCoreTools.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from 'vscode-azureextensionui';
 import { funcPackageName, PackageManager } from '../constants';
 import { ext } from '../extensionVariables';
 import { FuncVersion, promptForFuncVersion } from '../FuncVersion';
@@ -11,8 +12,8 @@ import { cpUtils } from '../utils/cpUtils';
 import { getBrewPackageName } from './getBrewPackageName';
 import { getNpmDistTag, INpmDistTag } from './getNpmDistTag';
 
-export async function installFuncCoreTools(packageManagers: PackageManager[], version?: FuncVersion): Promise<void> {
-    version = version || await promptForFuncVersion(localize('selectVersion', 'Select the version of the runtime to install'));
+export async function installFuncCoreTools(context: IActionContext, packageManagers: PackageManager[], version?: FuncVersion): Promise<void> {
+    version = version || await promptForFuncVersion(context, localize('selectVersion', 'Select the version of the runtime to install'));
 
     ext.outputChannel.show();
     // Use the first package manager

--- a/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
+++ b/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
@@ -33,10 +33,10 @@ export async function installOrUpdateFuncCoreTools(context: IActionContext): Pro
 
         let version: FuncVersion | undefined = await tryGetLocalFuncVersion();
         if (version === undefined) {
-            version = await promptForFuncVersion(localize('selectLocalVersion', 'Failed to detect local version automatically. Select your version to update'));
+            version = await promptForFuncVersion(context, localize('selectLocalVersion', 'Failed to detect local version automatically. Select your version to update'));
         }
         await updateFuncCoreTools(packageManager, version);
     } else {
-        await installFuncCoreTools(packageManagers);
+        await installFuncCoreTools(context, packageManagers);
     }
 }

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -67,7 +67,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
 
         const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
         for (const folder of folders) {
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(folder.uri.fsPath, true /* suppressPrompt */);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath, true /* suppressPrompt */);
             if (projectPath) {
                 try {
                     hasLocalProject = true;
@@ -90,7 +90,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
                         }
 
                         const funcTask: Task | undefined = (await tasks.fetchTasks()).find(t => t.scope === folder && isFuncHostTask(t));
-                        const funcPort = await getFuncPortFromTaskOrProject(funcTask, projectPath);
+                        const funcPort = await getFuncPortFromTaskOrProject(context, funcTask, projectPath);
 
                         const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, { effectiveProjectPath, folder, language, version, preCompiledProjectPath, isIsolated, funcPort });
                         this._projectDisposables.push(treeItem);

--- a/src/tree/FunctionTreeItemBase.ts
+++ b/src/tree/FunctionTreeItemBase.ts
@@ -106,7 +106,7 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
             await this.refreshTriggerUrl(context);
         }
 
-        await this.refreshDisabledState();
+        await this.refreshDisabledState(context);
     }
 
     private async refreshTriggerUrl(context: IActionContext): Promise<void> {
@@ -133,7 +133,7 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
     /**
      * https://docs.microsoft.com/azure/azure-functions/disable-function
      */
-    private async refreshDisabledState(): Promise<void> {
+    private async refreshDisabledState(context: IActionContext): Promise<void> {
         if (this._func) {
             this._disabled = !!this._func.isDisabled;
         } else {
@@ -141,7 +141,7 @@ export abstract class FunctionTreeItemBase extends AzExtTreeItem {
             if (version === FuncVersion.v1) {
                 this._disabled = this._config.disabled;
             } else {
-                const appSettings: ApplicationSettings = await this.parent.parent.getApplicationSettings();
+                const appSettings: ApplicationSettings = await this.parent.parent.getApplicationSettings(context);
 
                 /**
                  * The docs only officially mentioned 'true' and 'false', but here is what I found:

--- a/src/tree/IProjectTreeItem.ts
+++ b/src/tree/IProjectTreeItem.ts
@@ -15,6 +15,6 @@ export interface IProjectTreeItem {
     hostUrl: string;
     getHostJson(context: IActionContext): Promise<IParsedHostJson>;
     getVersion(): Promise<FuncVersion>;
-    getApplicationSettings(): Promise<ApplicationSettings>;
-    setApplicationSetting(key: string, value: string): Promise<void>;
+    getApplicationSettings(context: IActionContext): Promise<ApplicationSettings>;
+    setApplicationSetting(context: IActionContext, key: string, value: string): Promise<void>;
 }

--- a/src/tree/SlotTreeItemBase.ts
+++ b/src/tree/SlotTreeItemBase.ts
@@ -135,7 +135,7 @@ export abstract class SlotTreeItemBase extends AzureParentTreeItem<ISiteTreeRoot
         return appSettings.properties || {};
     }
 
-    public async setApplicationSetting(key: string, value: string): Promise<void> {
+    public async setApplicationSetting(_context: IActionContext, key: string, value: string): Promise<void> {
         const settings: WebSiteManagementModels.StringDictionary = await this.root.client.listApplicationSettings();
         if (!settings.properties) {
             settings.properties = {};

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -109,13 +109,13 @@ export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Di
         return this.version;
     }
 
-    public async getApplicationSettings(): Promise<ApplicationSettings> {
-        const localSettings: ILocalSettingsJson = await getLocalSettingsJson(path.join(this.effectiveProjectPath, localSettingsFileName));
+    public async getApplicationSettings(context: IActionContext): Promise<ApplicationSettings> {
+        const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(this.effectiveProjectPath, localSettingsFileName));
         return localSettings.Values || {};
     }
 
-    public async setApplicationSetting(key: string, value: string): Promise<void> {
-        await setLocalAppSetting(this.effectiveProjectPath, key, value, MismatchBehavior.Overwrite);
+    public async setApplicationSetting(context: IActionContext, key: string, value: string): Promise<void> {
+        await setLocalAppSetting(context, this.effectiveProjectPath, key, value, MismatchBehavior.Overwrite);
     }
 
     private async onFuncTaskChanged(scope: WorkspaceFolder | TaskScope | undefined): Promise<void> {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -7,38 +7,37 @@ import * as crypto from "crypto";
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { MessageItem } from "vscode";
-import { DialogResponses } from "vscode-azureextensionui";
-import { ext } from "../extensionVariables";
+import { DialogResponses, IActionContext } from "vscode-azureextensionui";
 import { localize } from "../localize";
 
 export async function writeFormattedJson(fsPath: string, data: object): Promise<void> {
     await fse.writeJson(fsPath, data, { spaces: 2 });
 }
 
-export async function copyFolder(fromPath: string, toPath: string): Promise<void> {
+export async function copyFolder(context: IActionContext, fromPath: string, toPath: string): Promise<void> {
     const files: string[] = await fse.readdir(fromPath);
     for (const file of files) {
         const originPath: string = path.join(fromPath, file);
         const stat: fse.Stats = await fse.stat(originPath);
         const targetPath: string = path.join(toPath, file);
         if (stat.isFile()) {
-            if (await confirmOverwriteFile(targetPath)) {
+            if (await confirmOverwriteFile(context, targetPath)) {
                 await fse.copy(originPath, targetPath, { overwrite: true });
             }
         } else if (stat.isDirectory()) {
-            await copyFolder(originPath, targetPath);
+            await copyFolder(context, originPath, targetPath);
         }
     }
 }
 
-export async function confirmEditJsonFile(fsPath: string, editJson: (existingData: {}) => {}): Promise<void> {
+export async function confirmEditJsonFile(context: IActionContext, fsPath: string, editJson: (existingData: {}) => {}): Promise<void> {
     let newData: {};
     if (await fse.pathExists(fsPath)) {
         try {
             newData = editJson(<{}>await fse.readJson(fsPath));
         } catch (error) {
             // If we failed to parse or edit the existing file, just ask to overwrite the file completely
-            if (await confirmOverwriteFile(fsPath)) {
+            if (await confirmOverwriteFile(context, fsPath)) {
                 newData = editJson({});
             } else {
                 return;
@@ -51,9 +50,9 @@ export async function confirmEditJsonFile(fsPath: string, editJson: (existingDat
     await writeFormattedJson(fsPath, newData);
 }
 
-export async function confirmOverwriteFile(fsPath: string): Promise<boolean> {
+export async function confirmOverwriteFile(context: IActionContext, fsPath: string): Promise<boolean> {
     if (await fse.pathExists(fsPath)) {
-        const result: MessageItem | undefined = await ext.ui.showWarningMessage(localize('fileAlreadyExists', 'File "{0}" already exists. Overwrite?', fsPath), { modal: true }, DialogResponses.yes, DialogResponses.no, DialogResponses.cancel);
+        const result: MessageItem | undefined = await context.ui.showWarningMessage(localize('fileAlreadyExists', 'File "{0}" already exists. Overwrite?', fsPath), { modal: true }, DialogResponses.yes, DialogResponses.no, DialogResponses.cancel);
         if (result === DialogResponses.yes) {
             return true;
         } else {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -5,7 +5,7 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { IAzureQuickPickItem, IAzureUserInput } from 'vscode-azureextensionui';
+import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { localize } from '../localize';
 import * as fsUtils from './fs';
 
@@ -14,9 +14,9 @@ export function isMultiRootWorkspace(): boolean {
         && vscode.workspace.name !== vscode.workspace.workspaceFolders[0].name; // multi-root workspaces always have something like "(Workspace)" appended to their name
 }
 
-export async function selectWorkspaceFolder(ui: IAzureUserInput, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
+export async function selectWorkspaceFolder(context: IActionContext, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
     return await selectWorkspaceItem(
-        ui,
+        context,
         placeHolder,
         {
             canSelectFiles: false,
@@ -28,7 +28,7 @@ export async function selectWorkspaceFolder(ui: IAzureUserInput, placeHolder: st
         getSubPath);
 }
 
-export async function selectWorkspaceFile(ui: IAzureUserInput, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
+export async function selectWorkspaceFile(context: IActionContext, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
     let defaultUri: vscode.Uri | undefined;
     if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0 && getSubPath) {
         const firstFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
@@ -39,7 +39,7 @@ export async function selectWorkspaceFile(ui: IAzureUserInput, placeHolder: stri
     }
 
     return await selectWorkspaceItem(
-        ui,
+        context,
         placeHolder,
         {
             canSelectFiles: true,
@@ -51,7 +51,7 @@ export async function selectWorkspaceFile(ui: IAzureUserInput, placeHolder: stri
         getSubPath);
 }
 
-export async function selectWorkspaceItem(ui: IAzureUserInput, placeHolder: string, options: vscode.OpenDialogOptions, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
+export async function selectWorkspaceItem(context: IActionContext, placeHolder: string, options: vscode.OpenDialogOptions, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {
     let folder: IAzureQuickPickItem<string | undefined> | undefined;
     if (vscode.workspace.workspaceFolders) {
         const folderPicks: IAzureQuickPickItem<string | undefined>[] = await Promise.all(vscode.workspace.workspaceFolders.map(async (f: vscode.WorkspaceFolder) => {
@@ -65,10 +65,10 @@ export async function selectWorkspaceItem(ui: IAzureUserInput, placeHolder: stri
         }));
 
         folderPicks.push({ label: localize('browse', '$(file-directory) Browse...'), description: '', data: undefined });
-        folder = await ui.showQuickPick(folderPicks, { placeHolder });
+        folder = await context.ui.showQuickPick(folderPicks, { placeHolder });
     }
 
-    return folder && folder.data ? folder.data : (await ui.showOpenDialog(options))[0].fsPath;
+    return folder && folder.data ? folder.data : (await context.ui.showOpenDialog(options))[0].fsPath;
 }
 
 export function getContainingWorkspace(fsPath: string): vscode.WorkspaceFolder | undefined {

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -25,7 +25,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
     if (folders) {
         for (const folder of folders) {
             const workspacePath: string = folder.uri.fsPath;
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(workspacePath);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath);
             if (projectPath) {
                 context.telemetry.suppressIfSuccessful = false;
 


### PR DESCRIPTION
I want to run a lot more tests in parallel because the functions builds are pretty dang long. In order to do that we need to use the action-specific user input (`context.ui`) instead of the extension-wide user input (`ext.ui`). I'm doing this refactor by itself because it affects a lot of files but is actually super simple/monotonous