### PR TITLE
Fix "InitLocalProjectTreeItem" incorrectly showing up in tree picker

### DIFF
--- a/src/tree/localProject/InitLocalProjectTreeItem.ts
+++ b/src/tree/localProject/InitLocalProjectTreeItem.ts
@@ -6,6 +6,7 @@
 import { ThemeIcon } from 'vscode';
 import { AzExtParentTreeItem, AzExtTreeItem, GenericTreeItem } from 'vscode-azureextensionui';
 import { localize } from '../../localize';
+import { isLocalProjectCV } from '../projectContextValues';
 import { LocalProjectTreeItemBase } from './LocalProjectTreeItemBase';
 
 export class InitLocalProjectTreeItem extends LocalProjectTreeItemBase {
@@ -32,5 +33,9 @@ export class InitLocalProjectTreeItem extends LocalProjectTreeItemBase {
         });
         ti.commandArgs = [this._projectPath];
         return [ti];
+    }
+
+    public isAncestorOfImpl(contextValue: string | RegExp): boolean {
+        return isLocalProjectCV(contextValue);
     }
 }


### PR DESCRIPTION
Found this bug while working on nightly tests

Repro steps:
1. Create a project with the func cli
2. Open in VS Code, but don't initialize when prompted. You'll see this in the tree view:
    <img width="446" alt="Screen Shot 2021-06-15 at 3 34 54 PM" src="https://user-images.githubusercontent.com/11282622/122132254-5a40b500-cdef-11eb-86e5-8d953be426cf.png">
3. Deploy

### Expected:
It auto-selects my subscription because I only have one

### Actual:
It prompts for subscription or local project
<img width="271" alt="Screen Shot 2021-06-15 at 3 35 01 PM" src="https://user-images.githubusercontent.com/11282622/122132309-6fb5df00-cdef-11eb-976f-a04a9f81bb3e.png">

