### PR TITLE
Ignore errors when verifying extension bundle

### DIFF
--- a/src/utils/verifyExtensionBundle.ts
+++ b/src/utils/verifyExtensionBundle.ts
@@ -48,7 +48,7 @@ export async function verifyExtensionBundle(context: IFunctionWizardContext | IB
 
             if (!hostJson.extensionBundle) {
                 context.telemetry.properties.bundleResult = 'addedBundle';
-                await bundleFeedUtils.addDefaultBundle(context, hostJson);
+                await bundleFeedUtils.addDefaultBundle(hostJson);
                 await writeFormattedJson(hostFilePath, hostJson);
             } else {
                 context.telemetry.properties.bundleResult = 'alreadyHasBundle';


### PR DESCRIPTION
This specific `fse.readJSON` call was causing problems when running tests in parallel - there's a Node.js issue on Windows where it'll return an empty string if you're doing too many read calls at once. It only repros on the build machine for me and it's pretty obscure (I saw it mentioned in a comment [here](https://stackoverflow.com/questions/38859609/fs-readfilesync-always-returns-empty-string)).

Then I got to thinking if we even need to show these errors to the user - at this point we've already successfully created the function itself and they may or may not already have the bundle in their host.json (even if it's currently not possible to parse it) - so I decided it was fine to just swallow these errors (and track in telemetry).