### PR TITLE
Add action-specific templateProvider for parallel tests

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -16,10 +16,13 @@
 // At runtime the tests live in dist/tests and will therefore pick up the main webpack bundle at dist/extension.bundle.js.
 export * from 'vscode-azureappservice';
 export * from 'vscode-azureextensionui';
+export * from './src/commands/copyFunctionUrl';
 export * from './src/commands/createFunction/createFunction';
 export * from './src/commands/createFunction/dotnetSteps/DotnetNamespaceStep';
+export * from './src/commands/createFunctionApp/createFunctionApp';
 export * from './src/commands/createNewProject/createNewProject';
 export * from './src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep';
+export * from './src/commands/deploy/deploy';
 export * from './src/commands/deploy/verifyAppSettings';
 export * from './src/commands/initProjectForVSCode/initProjectForVSCode';
 export * from './src/constants';

--- a/src/commands/addBinding/BindingListStep.ts
+++ b/src/commands/addBinding/BindingListStep.ts
@@ -41,7 +41,8 @@ export class BindingListStep extends AzureWizardPromptStep<IBindingWizardContext
     private async getPicks(context: IBindingWizardContext, direction: string): Promise<IAzureQuickPickItem<IBindingTemplate>[]> {
         const language: ProjectLanguage = nonNullProp(context, 'language');
         const version: FuncVersion = nonNullProp(context, 'version');
-        const templates: IBindingTemplate[] = await ext.templateProvider.getBindingTemplates(context, context.projectPath, language, version);
+        const templateProvider = ext.templateProvider.get(context);
+        const templates: IBindingTemplate[] = await templateProvider.getBindingTemplates(context, context.projectPath, language, version);
         return templates
             .filter(b => b.direction.toLowerCase() === direction.toLowerCase())
             .sort((a, b) => a.displayName.localeCompare(b.displayName))

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -46,7 +46,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
         if (options.templateId) {
             const language: ProjectLanguage = nonNullProp(context, 'language');
             const version: FuncVersion = nonNullProp(context, 'version');
-            const templates: IFunctionTemplate[] = await ext.templateProvider.getFunctionTemplates(context, context.projectPath, language, version, TemplateFilter.All, context.projectTemplateKey);
+            const templateProvider = ext.templateProvider.get(context);
+            const templates: IFunctionTemplate[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, version, TemplateFilter.All, context.projectTemplateKey);
             const foundTemplate: IFunctionTemplate | undefined = templates.find((t: IFunctionTemplate) => {
                 if (options.templateId) {
                     const actualId: string = t.id.toLowerCase();
@@ -143,13 +144,14 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     public async prompt(context: IFunctionWizardContext): Promise<void> {
         let templateFilter: TemplateFilter = getWorkspaceSetting<TemplateFilter>(templateFilterSetting, context.projectPath) || TemplateFilter.Verified;
 
+        const templateProvider = ext.templateProvider.get(context);
         while (!context.functionTemplate) {
             let placeHolder: string = this._isProjectWizard ?
                 localize('selectFirstFuncTemplate', "Select a template for your project's first function") :
                 localize('selectFuncTemplate', 'Select a template for your function');
 
-            if (ext.templateProvider.templateSource) {
-                placeHolder += localize('templateSource', ' (Template source: "{0}")', ext.templateProvider.templateSource)
+            if (templateProvider.templateSource) {
+                placeHolder += localize('templateSource', ' (Template source: "{0}")', templateProvider.templateSource)
             }
 
             const result: IFunctionTemplate | TemplatePromptResult = (await context.ui.showQuickPick(this.getPicks(context, templateFilter), { placeHolder })).data;
@@ -167,7 +169,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                 context.generateFromOpenAPI = true;
                 break;
             } else if (result === 'reloadTemplates') {
-                await ext.templateProvider.clearTemplateCache(context.projectPath, nonNullProp(context, 'language'), nonNullProp(context, 'version'));
+                await templateProvider.clearTemplateCache(context, context.projectPath, nonNullProp(context, 'language'), nonNullProp(context, 'version'));
                 context.telemetry.properties.reloaded = 'true';
             } else {
                 context.functionTemplate = result;
@@ -184,7 +186,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     private async getPicks(context: IFunctionWizardContext, templateFilter: TemplateFilter): Promise<IAzureQuickPickItem<IFunctionTemplate | TemplatePromptResult>[]> {
         const language: ProjectLanguage = nonNullProp(context, 'language');
         const version: FuncVersion = nonNullProp(context, 'version');
-        const templates: IFunctionTemplate[] = await ext.templateProvider.getFunctionTemplates(context, context.projectPath, language, version, templateFilter, context.projectTemplateKey);
+        const templateProvider = ext.templateProvider.get(context);
+        const templates: IFunctionTemplate[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, version, templateFilter, context.projectTemplateKey);
         context.telemetry.measurements.templateCount = templates.length;
         const picks: IAzureQuickPickItem<IFunctionTemplate | TemplatePromptResult>[] = templates
             .sort((a, b) => sortTemplates(a, b, templateFilter))

--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
@@ -48,7 +48,8 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
         const version: FuncVersion = nonNullProp(context, 'version');
         let projectTemplateKey = context.projectTemplateKey;
         if (!projectTemplateKey) {
-            projectTemplateKey = await ext.templateProvider.getProjectTemplateKey(context.projectPath, nonNullProp(context, 'language'), context.version, undefined);
+            const templateProvider = ext.templateProvider.get(context);
+            projectTemplateKey = await templateProvider.getProjectTemplateKey(context.projectPath, nonNullProp(context, 'language'), context.version, undefined);
         }
         await executeDotnetTemplateCommand(context, version, projectTemplateKey, context.projectPath, 'create', '--identity', template.id, ...args);
 

--- a/src/commands/createNewProject/ProjectCreateStep/CustomProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/CustomProjectCreateStep.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from 'vscode-azureextensionui';
 import { IHostJsonV2 } from '../../../funcConfig/host';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
 export class CustomProjectCreateStep extends ScriptProjectCreateStep {
-    protected async getHostContent(): Promise<IHostJsonV2> {
-        const hostJson: IHostJsonV2 = await super.getHostContent();
+    protected async getHostContent(context: IActionContext): Promise<IHostJsonV2> {
+        const hostJson: IHostJsonV2 = await super.getHostContent(context);
         hostJson.customHandler = {
             description: {
                 defaultExecutablePath: '',

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -7,6 +7,7 @@ import { HttpOperationResponse } from '@azure/ms-rest-js';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { workerRuntimeVersionKey } from '../../../constants';
 import { IHostJsonV2 } from '../../../funcConfig/host';
 import { hasMinFuncCliVersion } from '../../../funcCoreTools/hasMinFuncCliVersion';
@@ -99,8 +100,8 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
         }
     }
 
-    protected async getHostContent(): Promise<IHostJsonV2> {
-        const hostJson: IHostJsonV2 = await super.getHostContent();
+    protected async getHostContent(context: IActionContext): Promise<IHostJsonV2> {
+        const hostJson: IHostJsonV2 = await super.getHostContent(context);
         hostJson.managedDependency = { enabled: true };
         return hostJson;
     }

--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -7,6 +7,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { Progress } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { gitignoreFileName, hostFileName, localSettingsFileName, proxiesFileName, workerRuntimeKey } from '../../../constants';
 import { IHostJsonV1, IHostJsonV2 } from '../../../funcConfig/host';
 import { ILocalSettingsJson } from '../../../funcConfig/local.settings';
@@ -32,7 +33,7 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
         const version: FuncVersion = nonNullProp(context, 'version');
         const hostJsonPath: string = path.join(context.projectPath, hostFileName);
         if (await confirmOverwriteFile(context, hostJsonPath)) {
-            const hostJson: IHostJsonV2 | IHostJsonV1 = version === FuncVersion.v1 ? {} : await this.getHostContent();
+            const hostJson: IHostJsonV2 | IHostJsonV1 = version === FuncVersion.v1 ? {} : await this.getHostContent(context);
             await writeFormattedJson(hostJsonPath, hostJson);
         }
 
@@ -71,7 +72,7 @@ local.settings.json`));
         }
     }
 
-    protected async getHostContent(): Promise<IHostJsonV2> {
+    protected async getHostContent(context: IActionContext): Promise<IHostJsonV2> {
         const hostJson: IHostJsonV2 = {
             version: '2.0',
             logging: {
@@ -84,7 +85,7 @@ local.settings.json`));
             }
         };
 
-        await bundleFeedUtils.addDefaultBundle(hostJson);
+        await bundleFeedUtils.addDefaultBundle(context, hostJson);
 
         return hostJson;
     }

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -20,7 +20,7 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
     }
 
     public static async createStep(context: IProjectWizardContext): Promise<DotnetRuntimeStep> {
-        const funcRelease = await cliFeedUtils.getRelease(await cliFeedUtils.getLatestVersion(context.version));
+        const funcRelease = await cliFeedUtils.getRelease(await cliFeedUtils.getLatestVersion(context, context.version));
         const showHiddenStacks = getWorkspaceSetting<boolean>(hiddenStacksSetting);
         const runtimes = Object.values(funcRelease.workerRuntimes.dotnet).filter(r => !r.displayInfo.hidden || showHiddenStacks);
         if (runtimes.length === 0) {

--- a/src/commands/executeFunction.ts
+++ b/src/commands/executeFunction.ts
@@ -30,7 +30,8 @@ export async function executeFunction(context: IActionContext, node?: FunctionTr
         let value: string | undefined;
         if (triggerBindingType) {
             const version: FuncVersion = await node.parent.parent.getVersion();
-            value = await ext.templateProvider.tryGetSampleData(context, version, triggerBindingType);
+            const templateProvider = ext.templateProvider.get(context);
+            value = await templateProvider.tryGetSampleData(context, version, triggerBindingType);
             if (value) {
                 // Clean up the whitespace to make it more friendly for a one-line input box
                 value = value.replace(/[\r\n\t]/g, ' ');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,8 +63,9 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             await verifyVSCodeConfigOnActivate(actionContext, event.added);
         });
 
-        ext.templateProvider = new CentralTemplateProvider();
-        context.subscriptions.push(ext.templateProvider);
+        const templateProvider = new CentralTemplateProvider();
+        ext.templateProvider.registerExtensionVariable(templateProvider);
+        context.subscriptions.push(templateProvider);
 
         // Suppress "Report an Issue" button for all errors in favor of the command
         registerErrorHandler(c => c.errorHandling.suppressReportIssue = true);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -4,10 +4,40 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ExtensionContext, TreeView } from "vscode";
-import { AzExtTreeDataProvider, AzExtTreeItem, IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter } from "vscode-azureextensionui";
+import { AzExtTreeDataProvider, AzExtTreeItem, IActionContext, IAzExtOutputChannel, IAzureUserInput, IExperimentationServiceAdapter } from "vscode-azureextensionui";
 import { func } from "./constants";
 import { CentralTemplateProvider } from "./templates/CentralTemplateProvider";
 import { AzureAccountTreeItemWithProjects } from "./tree/AzureAccountTreeItemWithProjects";
+
+/**
+ * Used for extensionVariables that can also be set per-action
+ */
+class ActionVariable<T> {
+    private _extensionVariable: T | undefined;
+    private _key: string;
+
+    public constructor(key: string) {
+        this._key = key;
+    }
+
+    public registerActionVariable(value: T, context: IActionContext): void {
+        context[this._key] = value;
+    }
+
+    public registerExtensionVariable(value: T): void {
+        this._extensionVariable = value;
+    }
+
+    public get(context: IActionContext): T {
+        if (context[this._key] !== undefined) {
+            return <T>context[this._key];
+        } else if (this._extensionVariable !== undefined) {
+            return <T>this._extensionVariable;
+        } else {
+            throw new Error(`Internal Error: "${this._key}" must be registered before use.`);
+        }
+    }
+}
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -19,12 +49,12 @@ export namespace ext {
     export let azureAccountTreeItem: AzureAccountTreeItemWithProjects;
     export let outputChannel: IAzExtOutputChannel;
     export let ui: IAzureUserInput;
-    export let templateProvider: CentralTemplateProvider;
     // eslint-disable-next-line prefer-const
     export let funcCliPath: string = func;
     export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'azureFunctions';
     export let experimentationService: IExperimentationServiceAdapter;
+    export const templateProvider = new ActionVariable<CentralTemplateProvider>('_centralTemplateProvider');
 }
 
 export enum TemplateSource {

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -79,11 +79,11 @@ export class CentralTemplateProvider implements Disposable {
         }
     }
 
-    public async clearTemplateCache(projectPath: string | undefined, language: ProjectLanguage, version: FuncVersion): Promise<void> {
+    public async clearTemplateCache(context: IActionContext, projectPath: string | undefined, language: ProjectLanguage, version: FuncVersion): Promise<void> {
         const providers: TemplateProviderBase[] = CentralTemplateProvider.getProviders(projectPath, language, version, undefined);
         for (const provider of providers) {
             await provider.clearCachedTemplateMetadata();
-            await provider.clearCachedTemplates();
+            await provider.clearCachedTemplates(context);
             provider.projKeyMayHaveChanged();
         }
         const key: string = this.getProvidersKey(projectPath, language, version);
@@ -234,7 +234,7 @@ export class CentralTemplateProvider implements Disposable {
             context.telemetry.properties.templateSource = 'latest';
             const result: ITemplates = await provider.getLatestTemplates(context, latestTemplateVersion);
             await provider.cacheTemplateMetadata(latestTemplateVersion);
-            await provider.cacheTemplates();
+            await provider.cacheTemplates(context);
             return result;
         }
 
@@ -268,7 +268,7 @@ export class CentralTemplateProvider implements Disposable {
                 context.telemetry.properties.backupTemplateVersion = backupTemplateVersion;
                 const result: ITemplates = await provider.getBackupTemplates(context);
                 await provider.cacheTemplateMetadata(backupTemplateVersion);
-                await provider.cacheTemplates();
+                await provider.cacheTemplates(context);
                 return result;
             } catch (error) {
                 const errorMessage: string = parseError(error).message;

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -73,9 +73,9 @@ export abstract class TemplateProviderBase implements Disposable {
     public abstract getLatestTemplates(context: IActionContext, latestTemplateVersion: string): Promise<ITemplates>;
     public abstract getCachedTemplates(context: IActionContext): Promise<ITemplates | undefined>;
     public abstract getBackupTemplates(context: IActionContext): Promise<ITemplates>;
-    public abstract cacheTemplates(): Promise<void>;
-    public abstract clearCachedTemplates(): Promise<void>;
-    public abstract updateBackupTemplates(): Promise<void>;
+    public abstract cacheTemplates(context: IActionContext): Promise<void>;
+    public abstract clearCachedTemplates(context: IActionContext): Promise<void>;
+    public abstract updateBackupTemplates(context: IActionContext): Promise<void>;
 
     /**
      * Unless this is overidden, all templates will be included

--- a/src/templates/dotnet/executeDotnetTemplateCommand.ts
+++ b/src/templates/dotnet/executeDotnetTemplateCommand.ts
@@ -19,22 +19,23 @@ export async function executeDotnetTemplateCommand(context: IActionContext, vers
         'dotnet',
         cpUtils.wrapArgInQuotes(jsonDllPath),
         '--templateDir',
-        cpUtils.wrapArgInQuotes(getDotnetTemplateDir(version, projTemplateKey)),
+        cpUtils.wrapArgInQuotes(getDotnetTemplateDir(context, version, projTemplateKey)),
         '--operation',
         operation,
         ...args);
 }
 
-export function getDotnetItemTemplatePath(version: FuncVersion, projTemplateKey: string): string {
-    return path.join(getDotnetTemplateDir(version, projTemplateKey), 'item.nupkg');
+export function getDotnetItemTemplatePath(context: IActionContext, version: FuncVersion, projTemplateKey: string): string {
+    return path.join(getDotnetTemplateDir(context, version, projTemplateKey), 'item.nupkg');
 }
 
-export function getDotnetProjectTemplatePath(version: FuncVersion, projTemplateKey: string): string {
-    return path.join(getDotnetTemplateDir(version, projTemplateKey), 'project.nupkg');
+export function getDotnetProjectTemplatePath(context: IActionContext, version: FuncVersion, projTemplateKey: string): string {
+    return path.join(getDotnetTemplateDir(context, version, projTemplateKey), 'project.nupkg');
 }
 
-export function getDotnetTemplateDir(version: FuncVersion, projTemplateKey: string): string {
-    return path.join(ext.context.globalStoragePath, ext.templateProvider.templateSource || '', version, projTemplateKey);
+export function getDotnetTemplateDir(context: IActionContext, version: FuncVersion, projTemplateKey: string): string {
+    const templateProvider = ext.templateProvider.get(context);
+    return path.join(ext.context.globalStoragePath, templateProvider.templateSource || '', version, projTemplateKey);
 }
 
 export async function validateDotnetInstalled(context: IActionContext): Promise<void> {

--- a/src/templates/dotnet/parseDotnetTemplates.ts
+++ b/src/templates/dotnet/parseDotnetTemplates.ts
@@ -133,7 +133,8 @@ async function copyCSharpSettingsFromJS(csharpTemplates: IFunctionTemplate[], ve
         jsContext.errorHandling.suppressDisplay = true;
         jsContext.telemetry.properties.isActivationEvent = 'true';
 
-        const jsTemplates: IFunctionTemplate[] = await ext.templateProvider.getFunctionTemplates(jsContext, undefined, ProjectLanguage.JavaScript, version, TemplateFilter.All, undefined);
+        const templateProvider = ext.templateProvider.get(jsContext);
+        const jsTemplates: IFunctionTemplate[] = await templateProvider.getFunctionTemplates(jsContext, undefined, ProjectLanguage.JavaScript, version, TemplateFilter.All, undefined);
         for (const csharpTemplate of csharpTemplates) {
             const normalizedDotnetId = normalizeDotnetId(csharpTemplate.id);
             const jsTemplate: IFunctionTemplate | undefined = jsTemplates.find((t: IFunctionTemplate) => normalizeScriptId(t.id) === normalizedDotnetId);

--- a/src/templates/script/ScriptBundleTemplateProvider.ts
+++ b/src/templates/script/ScriptBundleTemplateProvider.ts
@@ -25,14 +25,14 @@ export class ScriptBundleTemplateProvider extends ScriptTemplateProvider {
         return bundleFeedUtils.defaultBundleId;
     }
 
-    public async getLatestTemplateVersion(): Promise<string> {
+    public async getLatestTemplateVersion(context: IActionContext): Promise<string> {
         const bundleMetadata: IBundleMetadata | undefined = await this.getBundleInfo();
-        return await bundleFeedUtils.getLatestTemplateVersion(bundleMetadata);
+        return await bundleFeedUtils.getLatestTemplateVersion(context, bundleMetadata);
     }
 
-    public async getLatestTemplates(_context: IActionContext, latestTemplateVersion: string): Promise<ITemplates> {
+    public async getLatestTemplates(context: IActionContext, latestTemplateVersion: string): Promise<ITemplates> {
         const bundleMetadata: IBundleMetadata | undefined = await this.getBundleInfo();
-        const release: bundleFeedUtils.ITemplatesRelease = await bundleFeedUtils.getRelease(bundleMetadata, latestTemplateVersion);
+        const release: bundleFeedUtils.ITemplatesRelease = await bundleFeedUtils.getRelease(context, bundleMetadata, latestTemplateVersion);
 
         const language: string = this.getResourcesLanguage();
         const resourcesUrl: string = release.resources.replace('{locale}', language);

--- a/src/templates/script/ScriptTemplateProvider.ts
+++ b/src/templates/script/ScriptTemplateProvider.ts
@@ -46,16 +46,16 @@ export class ScriptTemplateProvider extends TemplateProviderBase {
         }
     }
 
-    public async getLatestTemplateVersion(): Promise<string> {
-        return await cliFeedUtils.getLatestVersion(this.version);
+    public async getLatestTemplateVersion(context: IActionContext): Promise<string> {
+        return await cliFeedUtils.getLatestVersion(context, this.version);
     }
 
     public async getLatestTemplates(_context: IActionContext, latestTemplateVersion: string): Promise<ITemplates> {
         const templateRelease: cliFeedUtils.IRelease = await cliFeedUtils.getRelease(latestTemplateVersion);
 
-        const templatesPath: string = path.join(ext.context.globalStoragePath, 'scriptTemplates');
+        const templatesPath: string = path.join(ext.context.globalStoragePath, 'script', getRandomHexString());
         try {
-            const filePath: string = path.join(templatesPath, `${getRandomHexString()}.zip`);
+            const filePath: string = path.join(templatesPath, 'templates.zip');
             await requestUtils.downloadFile(templateRelease.templates, filePath);
 
             await new Promise((resolve: (value?: unknown) => void, reject: (e: Error) => void): void => {

--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext, TemplateSource } from '../extensionVariables';
 import { FuncVersion, getMajorVersion, isPreviewVersion } from '../FuncVersion';
 import { feedUtils } from './feedUtils';
@@ -49,14 +50,15 @@ export namespace cliFeedUtils {
         }
     }
 
-    export async function getLatestVersion(version: FuncVersion): Promise<string> {
+    export async function getLatestVersion(context: IActionContext, version: FuncVersion): Promise<string> {
         const cliFeed: ICliFeed = await getCliFeed();
 
         const majorVersion: string = getMajorVersion(version);
         let tag: string = 'v' + majorVersion;
+        const templateProvider = ext.templateProvider.get(context);
         if (isPreviewVersion(version)) {
             tag = tag + '-preview';
-        } else if (ext.templateProvider.templateSource === TemplateSource.Staging) {
+        } else if (templateProvider.templateSource === TemplateSource.Staging) {
             tag = tag + '-prerelease';
         }
 

--- a/src/utils/verifyExtensionBundle.ts
+++ b/src/utils/verifyExtensionBundle.ts
@@ -48,7 +48,7 @@ export async function verifyExtensionBundle(context: IFunctionWizardContext | IB
 
             if (!hostJson.extensionBundle) {
                 context.telemetry.properties.bundleResult = 'addedBundle';
-                await bundleFeedUtils.addDefaultBundle(hostJson);
+                await bundleFeedUtils.addDefaultBundle(context, hostJson);
                 await writeFormattedJson(hostFilePath, hostJson);
             } else {
                 context.telemetry.properties.bundleResult = 'alreadyHasBundle';

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -36,7 +36,8 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
                     void callWithTelemetryAndErrorHandling('initializeTemplates', async (templatesContext: IActionContext) => {
                         templatesContext.telemetry.properties.isActivationEvent = 'true';
                         templatesContext.errorHandling.suppressDisplay = true;
-                        await ext.templateProvider.getFunctionTemplates(templatesContext, projectPath, language, version, TemplateFilter.Verified, undefined);
+                        const templateProvider = ext.templateProvider.get(templatesContext);
+                        await templateProvider.getFunctionTemplates(templatesContext, projectPath, language, version, TemplateFilter.Verified, undefined);
                     });
 
                     let isDotnet: boolean = false;

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -8,7 +8,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Disposable } from 'vscode';
 import { createFunctionInternal, FuncVersion, funcVersionSetting, getRandomHexString, IFunctionTemplate, ProjectLanguage, projectLanguageSetting, TemplateFilter, templateFilterSetting, TemplateSource } from '../../extension.bundle';
-import { cleanTestWorkspace, createTestActionContext, runForTemplateSource, testFolderPath, testUserInput } from '../global.test';
+import { cleanTestWorkspace, runForTemplateSource, runWithTestActionContext, TestActionContext, testFolderPath } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 
 export abstract class FunctionTesterBase implements Disposable {
@@ -35,27 +35,32 @@ export abstract class FunctionTesterBase implements Disposable {
     public abstract getExpectedPaths(functionName: string): string[];
 
     public async initAsync(): Promise<void> {
-        await cleanTestWorkspace();
-        await runForTemplateSource(this._source, async (templateProvider) => {
-            await this.initializeTestFolder(this.projectPath);
+        await runWithTestActionContext('testCreateFunctionInit', async context => {
+            await runForTemplateSource(context, this._source, async (templateProvider) => {
+                await this.initializeTestFolder(this.projectPath);
 
-            // This will initialize and cache the templatesTask for this project. Better to do it here than during the first test
-            await templateProvider.getFunctionTemplates(createTestActionContext(), this.projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
+                // This will initialize and cache the templatesTask for this project. Better to do it here than during the first test
+                await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
+            });
         });
     }
 
     public async dispose(): Promise<void> {
         await cleanTestWorkspace();
-        await runForTemplateSource(this._source, async (templateProvider) => {
-            const templates: IFunctionTemplate[] = await templateProvider.getFunctionTemplates(createTestActionContext(), this.projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
-            assert.deepEqual(this.testedFunctions.sort(), templates.map(t => t.name).sort(), 'Not all "Verified" templates were tested');
+        await runWithTestActionContext('testCreateFunctionDispose', async context => {
+            await runForTemplateSource(context, this._source, async (templateProvider) => {
+                const templates: IFunctionTemplate[] = await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, this.version, TemplateFilter.Verified, undefined);
+                assert.deepEqual(this.testedFunctions.sort(), templates.map(t => t.name).sort(), 'Not all "Verified" templates were tested');
+            });
         });
     }
 
     public async testCreateFunction(templateName: string, ...inputs: string[]): Promise<void> {
         this.testedFunctions.push(templateName);
-        await runForTemplateSource(this._source, async () => {
-            await this.testCreateFunctionInternal(this.projectPath, templateName, inputs.slice());
+        await runWithTestActionContext('testCreateFunction', async context => {
+            await runForTemplateSource(context, this._source, async () => {
+                await this.testCreateFunctionInternal(context, this.projectPath, templateName, inputs.slice());
+            });
         });
     }
 
@@ -84,7 +89,7 @@ export abstract class FunctionTesterBase implements Disposable {
         ]);
     }
 
-    private async testCreateFunctionInternal(testFolder: string, templateName: string, inputs: string[]): Promise<void> {
+    private async testCreateFunctionInternal(context: TestActionContext, testFolder: string, templateName: string, inputs: string[]): Promise<void> {
         // clone inputs array
         const expectedContents: string[] = inputs.slice(0);
 
@@ -93,11 +98,11 @@ export abstract class FunctionTesterBase implements Disposable {
         inputs.unshift(funcName); // Specify the function name
         inputs.unshift(templateName); // Select the function template
 
-        await testUserInput.runWithInputs(inputs, async () => {
+        await context.ui.runWithInputs(inputs, async () => {
             await runWithFuncSetting(templateFilterSetting, TemplateFilter.Verified, async () => {
                 await runWithFuncSetting(projectLanguageSetting, this.language, async () => {
                     await runWithFuncSetting(funcVersionSetting, this.version, async () => {
-                        await createFunctionInternal(createTestActionContext(), {
+                        await createFunctionInternal(context, {
                             folderPath: testFolder
                         });
                     });

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -7,8 +7,8 @@ import { WebSiteManagementModels as Models } from '@azure/arm-appservice';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { tryGetWebApp } from 'vscode-azureappservice';
-import { DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
-import { cleanTestWorkspace, longRunningTestsEnabled, testUserInput } from '../global.test';
+import { createFunctionAppAdvanced, DialogResponses, getRandomHexString, ProjectLanguage } from '../../extension.bundle';
+import { cleanTestWorkspace, longRunningTestsEnabled, runWithTestActionContext, testUserInput } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
 import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
@@ -42,8 +42,10 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
 
     test('Create - Advanced', async () => {
         const testInputs: (string | RegExp)[] = [appName, /\.net/i, 'Windows', '$(plus) Create new resource group', rgName, location, 'Consumption', '$(plus) Create new storage account', saName, '$(plus) Create new Application Insights resource', aiName];
-        await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('azureFunctions.createFunctionAppAdvanced');
+        await runWithTestActionContext('createFunctionAppAdvanced', async context => {
+            await context.ui.runWithInputs(testInputs, async () => {
+                await createFunctionAppAdvanced(context);
+            });
         });
         const createdApp: Models.Site | undefined = await tryGetWebApp(testClient, rgName, appName);
         assert.ok(createdApp);
@@ -51,8 +53,10 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
 
     test('Create - Advanced - Existing RG/SA/AI', async () => {
         const testInputs: (string | RegExp)[] = [app2Name, /\.net/i, 'Windows', rgName, location, 'Consumption', saName, aiName];
-        await testUserInput.runWithInputs(testInputs, async () => {
-            await vscode.commands.executeCommand('azureFunctions.createFunctionAppAdvanced');
+        await runWithTestActionContext('createFunctionAppAdvanced', async context => {
+            await context.ui.runWithInputs(testInputs, async () => {
+                await createFunctionAppAdvanced(context);
+            });
         });
         const createdApp: Models.Site | undefined = await tryGetWebApp(testClient, rgName, app2Name);
         assert.ok(createdApp);

--- a/test/project/createAndValidateProject.ts
+++ b/test/project/createAndValidateProject.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { TestInput } from 'vscode-azureextensiondev';
 import { createNewProjectInternal, funcVersionSetting, getRandomHexString, hiddenStacksSetting, ProjectLanguage } from '../../extension.bundle';
 import * as api from '../../src/vscode-azurefunctions.api';
-import { createTestActionContext, testFolderPath, testUserInput } from '../global.test';
+import { TestActionContext, testFolderPath } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { IValidateProjectOptions, validateProject } from './validateProject';
 
@@ -17,7 +17,7 @@ export interface ICreateProjectTestOptions extends IValidateProjectOptions {
     projectPath?: string;
 }
 
-export async function createAndValidateProject(options: ICreateProjectTestOptions): Promise<void> {
+export async function createAndValidateProject(context: TestActionContext, options: ICreateProjectTestOptions): Promise<void> {
     // Clone inputs here so we have a different array each time
     const inputs: (string | TestInput | RegExp)[] = options.inputs ? [...options.inputs] : [];
     const language: ProjectLanguage = options.language;
@@ -39,8 +39,8 @@ export async function createAndValidateProject(options: ICreateProjectTestOption
 
     await runWithFuncSetting(funcVersionSetting, options.version, async () => {
         await runWithFuncSetting(hiddenStacksSetting, true, async () => {
-            await testUserInput.runWithInputs(inputs, async () => {
-                await createNewProjectInternal(createTestActionContext(), {
+            await context.ui.runWithInputs(inputs, async () => {
+                await createNewProjectInternal(context, {
                     language: options.isHiddenLanguage ? <api.ProjectLanguage>language : undefined,
                     suppressOpenFolder: true
                 });

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -5,7 +5,7 @@
 
 import { TestInput } from 'vscode-azureextensiondev';
 import { FuncVersion, ProjectLanguage } from '../../extension.bundle';
-import { allTemplateSources, cleanTestWorkspace, longRunningTestsEnabled, runForTemplateSource } from '../global.test';
+import { allTemplateSources, cleanTestWorkspace, longRunningTestsEnabled, runForTemplateSource, runWithTestActionContext } from '../global.test';
 import { createAndValidateProject, ICreateProjectTestOptions } from './createAndValidateProject';
 import { getCSharpValidateOptions, getCustomValidateOptions, getDotnetScriptValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPowerShellValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions } from './validateProject';
 
@@ -78,8 +78,10 @@ function addTest(testCase: ICreateProjectTestCase): void {
                 }
             }
 
-            await runForTemplateSource(source, async () => {
-                await createAndValidateProject(testCase);
+            await runWithTestActionContext('createProject', async context => {
+                await runForTemplateSource(context, source, async () => {
+                    await createAndValidateProject(context, testCase);
+                });
             });
         });
     }

--- a/test/project/createNewPythonProject.test.ts
+++ b/test/project/createNewPythonProject.test.ts
@@ -6,14 +6,16 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { FuncVersion, getRandomHexString } from '../../extension.bundle';
-import { longRunningTestsEnabled, testFolderPath } from '../global.test';
+import { longRunningTestsEnabled, runWithTestActionContext, testFolderPath } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { createAndValidateProject } from './createAndValidateProject';
 import { getPythonValidateOptions } from './validateProject';
 
 suite('Create New Python Project', () => {
     test('skip venv', async () => {
-        await createAndValidateProject({ ...getPythonValidateOptions(undefined, FuncVersion.v2), inputs: [/skip/i] });
+        await runWithTestActionContext('createProject', async context => {
+            await createAndValidateProject(context, { ...getPythonValidateOptions(undefined, FuncVersion.v2), inputs: [/skip/i] });
+        });
     });
 
     test('enter venv', async function (this: Mocha.Context): Promise<void> {
@@ -23,12 +25,16 @@ suite('Create New Python Project', () => {
         this.timeout(2 * 60 * 1000);
 
         const alias: string = process.platform === 'win32' ? 'py -3.6' : 'python3.6';
-        await createAndValidateProject({ ...getPythonValidateOptions('.venv', FuncVersion.v2), inputs: [/enter/i, alias] });
+        await runWithTestActionContext('createProject', async context => {
+            await createAndValidateProject(context, { ...getPythonValidateOptions('.venv', FuncVersion.v2), inputs: [/enter/i, alias] });
+        });
     });
 
     test('no venv', async () => {
         await runWithFuncSetting('createPythonVenv', false, async () => {
-            await createAndValidateProject({ ...getPythonValidateOptions(undefined, FuncVersion.v2) });
+            await runWithTestActionContext('createProject', async context => {
+                await createAndValidateProject(context, { ...getPythonValidateOptions(undefined, FuncVersion.v2) });
+            });
         });
     });
 
@@ -36,7 +42,9 @@ suite('Create New Python Project', () => {
         const projectPath: string = path.join(testFolderPath, getRandomHexString());
         const venvName: string = 'testVenv';
         await createTestVenv(projectPath, venvName);
-        await createAndValidateProject({ ...getPythonValidateOptions(venvName, FuncVersion.v2), projectPath });
+        await runWithTestActionContext('createProject', async context => {
+            await createAndValidateProject(context, { ...getPythonValidateOptions(venvName, FuncVersion.v2), projectPath });
+        });
     });
 
     test('multiple existing venvs', async () => {
@@ -44,7 +52,9 @@ suite('Create New Python Project', () => {
         const venvName: string = 'testVenv2';
         await createTestVenv(projectPath, 'testVenv1');
         await createTestVenv(projectPath, venvName);
-        await createAndValidateProject({ ...getPythonValidateOptions(venvName, FuncVersion.v2), projectPath, inputs: [venvName] });
+        await runWithTestActionContext('createProject', async context => {
+            await createAndValidateProject(context, { ...getPythonValidateOptions(venvName, FuncVersion.v2), projectPath, inputs: [venvName] });
+        });
     });
 });
 

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { TestInput } from 'vscode-azureextensiondev';
 import { FuncVersion, getRandomHexString, initProjectForVSCode, ProjectLanguage } from '../../extension.bundle';
-import { cleanTestWorkspace, createTestActionContext, testFolderPath, testUserInput } from '../global.test';
+import { cleanTestWorkspace, runWithTestActionContext, testFolderPath } from '../global.test';
 import { getCSharpValidateOptions, getCustomValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPowerShellValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
 suite('Init Project For VS Code', function (this: Mocha.Suite): void {
@@ -331,8 +331,10 @@ async function initAndValidateProject(options: IInitProjectTestOptions): Promise
         }
     }));
 
-    await testUserInput.runWithInputs(options.inputs || [], async () => {
-        await initProjectForVSCode(createTestActionContext(), projectPath);
+    await runWithTestActionContext('initProject', async context => {
+        await context.ui.runWithInputs(options.inputs || [], async () => {
+            await initProjectForVSCode(context, projectPath);
+        });
     });
 
     await validateProject(projectPath, options);

--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { CentralTemplateProvider, FuncVersion, IFunctionTemplate, ProjectLanguage, TemplateFilter, TemplateSource } from '../extension.bundle';
-import { createTestActionContext, longRunningTestsEnabled, runForTemplateSource, skipStagingTemplateSource, testWorkspacePath } from './global.test';
+import { longRunningTestsEnabled, runForTemplateSource, runWithTestActionContext, skipStagingTemplateSource, testWorkspacePath } from './global.test';
 import { javaUtils } from './utils/javaUtils';
 
 addSuite(undefined);
@@ -55,9 +55,11 @@ function addSuite(source: TemplateSource | undefined): void {
                     await javaPreTest(this);
                 }
 
-                await runForTemplateSource(source, async (provider: CentralTemplateProvider) => {
-                    const templates: IFunctionTemplate[] = await provider.getFunctionTemplates(createTestActionContext(), testWorkspacePath, language, version, TemplateFilter.Verified, projectTemplateKey);
-                    assert.equal(templates.length, expectedCount);
+                await runWithTestActionContext('getFunctionTemplates', async context => {
+                    await runForTemplateSource(context, source, async (provider: CentralTemplateProvider) => {
+                        const templates: IFunctionTemplate[] = await provider.getFunctionTemplates(context, testWorkspacePath, language, version, TemplateFilter.Verified, projectTemplateKey);
+                        assert.equal(templates.length, expectedCount);
+                    });
                 });
             });
         }

--- a/test/updateBackupTemplates.ts
+++ b/test/updateBackupTemplates.ts
@@ -47,7 +47,7 @@ suite('Backup templates', () => {
 
                     async function updateBackupTemplatesInternal(): Promise<void> {
                         await provider.getLatestTemplates(context, templateVersion);
-                        await provider.updateBackupTemplates();
+                        await provider.updateBackupTemplates(context);
                     }
 
                     if (worker.language === ProjectLanguage.JavaScript) {

--- a/test/verifyVersionAndLanguage.test.ts
+++ b/test/verifyVersionAndLanguage.test.ts
@@ -5,7 +5,7 @@
 
 import { FuncVersion, ProjectLanguage, verifyVersionAndLanguage } from '../extension.bundle';
 import { assertThrowsAsync } from './assertThrowsAsync';
-import { createTestActionContext, testUserInput } from './global.test';
+import { createTestActionContext } from './global.test';
 
 suite('verifyVersionAndLanguage', () => {
     test('Local: ~1, Remote: none', async () => {
@@ -31,8 +31,9 @@ suite('verifyVersionAndLanguage', () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
-        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        const context = createTestActionContext();
+        await context.ui.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -40,8 +41,9 @@ suite('verifyVersionAndLanguage', () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
-        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        const context = createTestActionContext();
+        await context.ui.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -68,8 +70,9 @@ suite('verifyVersionAndLanguage', () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
-        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        const context = createTestActionContext();
+        await context.ui.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -77,8 +80,9 @@ suite('verifyVersionAndLanguage', () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
-        await testUserInput.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        const context = createTestActionContext();
+        await context.ui.runWithInputs(['Deploy Anyway'], async () => {
+            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 


### PR DESCRIPTION
I'm splitting up my 'parallel tests' work into smaller PRs. The focus of this PR is to add a new `ActionVariable` class in `extensionVariables.ts` because I need a way to have a unique `templateProvider` for each action when running in parallel. _Most_ of this PR is monotonous changes as a consequence of that. The interesting files are `extensionVariables.ts` as mentioned, and `global.test.ts` which handles `templateProvider` on the test side of things.

One consequence of this work is that I can't use `executeCommand` from the tests as often, but I think this is fine because it actually more accurately reports errors as test failures when you call the function directly. The only downside is we lose a bit of telemetry logging, but I added that back in `runWithTestActionContext`.