### PR TITLE
Search at all levels when looking for a project

### DIFF
--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -31,7 +31,7 @@ export async function addBinding(context: IActionContext, data: Uri | LocalFunct
         functionJsonPath = data.fsPath;
         workspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'workspaceFolder');
         workspacePath = workspaceFolder.uri.fsPath;
-        projectPath = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
+        projectPath = await tryGetFunctionProjectRoot(context, workspacePath, 'modalPrompt') || workspacePath;
         [language, version] = await verifyInitForVSCode(context, projectPath);
     } else {
         if (!data) {

--- a/src/commands/appSettings/getLocalSettingsFile.ts
+++ b/src/commands/appSettings/getLocalSettingsFile.ts
@@ -19,7 +19,7 @@ export async function getLocalSettingsFile(context: IActionContext, message: str
     const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
     if (workspacePath || folders.length === 1) {
         workspacePath = workspacePath || folders[0].uri.fsPath;
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */);
+        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath);
         if (projectPath) {
             const localSettingsFile: string = path.join(projectPath, localSettingsFileName);
             if (await fse.pathExists(localSettingsFile)) {
@@ -30,7 +30,7 @@ export async function getLocalSettingsFile(context: IActionContext, message: str
 
     return await selectWorkspaceFile(context, message, async (f: WorkspaceFolder): Promise<string> => {
         workspacePath = f.uri.fsPath;
-        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */) || workspacePath;
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
         return path.relative(workspacePath, path.join(projectPath, localSettingsFileName));
     });
 }

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -24,7 +24,7 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 export type MultiProjectPromptBehavior = 'silent' | 'prompt' | 'modalPrompt';
 
 /**
- * Checks root folder and subFolders one level down
+ * Checks root folder and one level down first, then all levels of tree
  * If a single function project is found, returns that path.
  * If multiple projects are found, prompt to pick the project.
  */

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -5,7 +5,7 @@
 
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { MessageItem } from 'vscode';
+import { MessageItem, RelativePattern, workspace } from 'vscode';
 import { DialogResponses, IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { hostFileName, projectSubpathSetting } from '../../constants';
 import { localize } from '../../localize';
@@ -19,49 +19,55 @@ export async function isFunctionProject(folderPath: string): Promise<boolean> {
 }
 
 /**
+ * Describes what to do if multiple projects are found
+ */
+export type MultiProjectPromptBehavior = 'silent' | 'prompt' | 'modalPrompt';
+
+/**
  * Checks root folder and subFolders one level down
  * If a single function project is found, returns that path.
  * If multiple projects are found, prompt to pick the project.
  */
-export async function tryGetFunctionProjectRoot(context: IActionContext, folderPath: string, suppressPrompt: boolean = false): Promise<string | undefined> {
-    let subpath: string | undefined = getWorkspaceSetting(projectSubpathSetting, folderPath);
-    if (!subpath) {
-        if (getWorkspaceSetting<boolean>('suppressProject', folderPath)) {
-            return undefined;
-        } else if (!(await fse.pathExists(folderPath))) {
-            return undefined;
-        } else if (await isFunctionProject(folderPath)) {
-            return folderPath;
-        } else {
-            const subpaths: string[] = await fse.readdir(folderPath);
-            const matchingSubpaths: string[] = [];
-            await Promise.all(subpaths.map(async s => {
-                if (await isFunctionProject(path.join(folderPath, s))) {
-                    matchingSubpaths.push(s);
-                }
-            }));
-
-            if (matchingSubpaths.length === 1) {
-                subpath = matchingSubpaths[0];
-            } else if (matchingSubpaths.length !== 0 && !suppressPrompt) {
-                subpath = await promptForProjectSubpath(context, folderPath, matchingSubpaths);
+export async function tryGetFunctionProjectRoot(context: IActionContext, folderPath: string, promptBehavior: MultiProjectPromptBehavior = 'silent'): Promise<string | undefined> {
+    if (!getWorkspaceSetting<boolean>('suppressProject', folderPath)) {
+        const subpath: string | undefined = getWorkspaceSetting(projectSubpathSetting, folderPath);
+        if (subpath) {
+            return path.join(folderPath, subpath);
+        } else if (await fse.pathExists(folderPath)) {
+            if (await isFunctionProject(folderPath)) {
+                return folderPath;
             } else {
-                return undefined;
+                const hostJsonUris = await workspace.findFiles(new RelativePattern(folderPath, `*/${hostFileName}`));
+                if (hostJsonUris.length !== 1) {
+                    // NOTE: If we found a single project at the root or one level down, we will use that without searching any further.
+                    // This will reduce false positives in the case of compiled languages like C# where a 'host.json' file is often copied to a build/publish directory a few levels down
+                    // It also maintains consistent historical behavior by giving that project priority because we used to _only_ look at the root and one level down
+                    hostJsonUris.push(...await workspace.findFiles(new RelativePattern(folderPath, `*/*/**/${hostFileName}`)));
+                }
+
+                const projectPaths = hostJsonUris.map(uri => path.dirname(uri.fsPath));
+                if (projectPaths.length === 1) {
+                    return projectPaths[0];
+                } else if (projectPaths.length > 1 && promptBehavior !== 'silent') {
+                    const subpaths = projectPaths.map(p => path.relative(folderPath, p));
+                    const pickedSubpath = await promptForProjectSubpath(context, folderPath, subpaths, promptBehavior);
+                    return path.join(folderPath, pickedSubpath);
+                }
             }
         }
     }
 
-    return path.join(folderPath, subpath);
+    return undefined;
 }
 
-async function promptForProjectSubpath(context: IActionContext, workspacePath: string, matchingSubpaths: string[]): Promise<string> {
+async function promptForProjectSubpath(context: IActionContext, workspacePath: string, matchingSubpaths: string[], promptLevel: MultiProjectPromptBehavior): Promise<string> {
     const message: string = localize('detectedMultipleProject', 'Detected multiple function projects in the same workspace folder. You must either set the default or use a multi-root workspace.');
     const learnMoreLink: string = 'https://aka.ms/AA4nmfy';
     const setDefault: MessageItem = { title: localize('setDefault', 'Set default') };
     // No need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(message, { learnMoreLink }, setDefault);
+    await context.ui.showWarningMessage(message, { learnMoreLink, modal: promptLevel === 'modalPrompt' }, setDefault);
 
-    const picks: IAzureQuickPickItem<string>[] = matchingSubpaths.map(p => { return { label: p, description: workspacePath, data: p }; });
+    const picks: IAzureQuickPickItem<string>[] = matchingSubpaths.map(p => { return { label: p, data: p }; });
     const placeHolder: string = localize('selectProject', 'Select the default project subpath');
     const subpath: string = (await context.ui.showQuickPick(picks, { placeHolder })).data;
     await updateWorkspaceSetting(projectSubpathSetting, subpath, workspacePath);
@@ -75,7 +81,7 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
 export async function verifyAndPromptToCreateProject(context: IActionContext, fsPath: string, options?: api.ICreateFunctionOptions): Promise<string | undefined> {
     options = options || {};
 
-    const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, fsPath);
+    const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, fsPath, 'modalPrompt');
     if (!projectPath) {
         if (!options.suppressCreateProjectPrompt) {
             const message: string = localize('notFunctionApp', 'The selected folder is not a function project. Create new project?');

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -26,7 +26,7 @@ export type MultiProjectPromptBehavior = 'silent' | 'prompt' | 'modalPrompt';
 /**
  * Checks root folder and one level down first, then all levels of tree
  * If a single function project is found, returns that path.
- * If multiple projects are found, prompt to pick the project.
+ * If multiple projects are found, will prompt based on the value of `promptBehavior`
  */
 export async function tryGetFunctionProjectRoot(context: IActionContext, folderPath: string, promptBehavior: MultiProjectPromptBehavior = 'silent'): Promise<string | undefined> {
     if (!getWorkspaceSetting<boolean>('suppressProject', folderPath)) {
@@ -60,12 +60,12 @@ export async function tryGetFunctionProjectRoot(context: IActionContext, folderP
     return undefined;
 }
 
-async function promptForProjectSubpath(context: IActionContext, workspacePath: string, matchingSubpaths: string[], promptLevel: MultiProjectPromptBehavior): Promise<string> {
+async function promptForProjectSubpath(context: IActionContext, workspacePath: string, matchingSubpaths: string[], promptBehavior: MultiProjectPromptBehavior): Promise<string> {
     const message: string = localize('detectedMultipleProject', 'Detected multiple function projects in the same workspace folder. You must either set the default or use a multi-root workspace.');
     const learnMoreLink: string = 'https://aka.ms/AA4nmfy';
     const setDefault: MessageItem = { title: localize('setDefault', 'Set default') };
     // No need to check result - cancel will throw a UserCancelledError
-    await context.ui.showWarningMessage(message, { learnMoreLink, modal: promptLevel === 'modalPrompt' }, setDefault);
+    await context.ui.showWarningMessage(message, { learnMoreLink, modal: promptBehavior === 'modalPrompt' }, setDefault);
 
     const picks: IAzureQuickPickItem<string>[] = matchingSubpaths.map(p => { return { label: p, data: p }; });
     const placeHolder: string = localize('selectProject', 'Select the default project subpath');

--- a/src/commands/deploy/validateRemoteBuild.ts
+++ b/src/commands/deploy/validateRemoteBuild.ts
@@ -21,7 +21,7 @@ export async function validateRemoteBuild(context: IDeployContext, client: SiteC
         await context.ui.showWarningMessage(message, { learnMoreLink, modal: true }, downgrade);
         context.telemetry.properties.cancelStep = undefined;
 
-        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath, true /* suppressPrompt */) || workspacePath;
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
         await updateWorkspaceSetting(remoteBuildSetting, false, workspacePath);
         await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
         const zipFileName: string = path.basename(projectPath) + '.zip';

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -43,7 +43,7 @@ export class FuncTaskProvider implements TaskProvider {
                 let lastError: unknown;
                 for (const folder of workspace.workspaceFolders) {
                     try {
-                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath, true /* suppressPrompt */);
+                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath);
                         if (projectRoot) {
                             const language: string | undefined = getWorkspaceSetting(projectLanguageSetting, folder.uri.fsPath);
 

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -38,7 +38,7 @@ export async function preDebugValidate(context: IActionContext, debugConfig: vsc
 
         if (shouldContinue) {
             context.telemetry.properties.lastValidateStep = 'getProjectRoot';
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspace.uri.fsPath, true /* suppressPrompt */);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspace.uri.fsPath);
 
             if (projectPath) {
                 const projectLanguage: string | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -82,7 +82,7 @@ export async function getFuncPortFromTaskOrProject(context: IActionContext, func
         if (typeof projectPathOrTaskScope === 'string') {
             projectPath = projectPathOrTaskScope;
         } else if (typeof projectPathOrTaskScope === 'object') {
-            projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope.uri.fsPath, true /* suppressPrompt */);
+            projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope.uri.fsPath);
         }
 
         if (projectPath) {

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -67,7 +67,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
 
         const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
         for (const folder of folders) {
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath, true /* suppressPrompt */);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath);
             if (projectPath) {
                 try {
                     hasLocalProject = true;

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -25,7 +25,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
     if (folders) {
         for (const folder of folders) {
             const workspacePath: string = folder.uri.fsPath;
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath, 'prompt');
             if (projectPath) {
                 context.telemetry.suppressIfSuccessful = false;
 


### PR DESCRIPTION
We've had various issues reported in the past about projects not being found, and we've generally resisted for perf reasons, but I feel like it's finally time to just do it. A few notes:
1. I still give priority to the root and one level down
2. I switched to use VS Code's `findFiles` api, which is simpler and hopefully better perf than searching ourselves with `readdir`
3. As of https://github.com/microsoft/vscode-azurefunctions/pull/2657, we're activating based on the whole workspace anyways, so I feel like we might as well support any project that caused us to activate

I also changed how `suppressPrompt` works because I was annoyed how often I had to change from the default. Now 'silent' (the most common case) is the default. I also split the other case into a modal or non-modal option to better fit each scenario.

Related to https://github.com/microsoft/vscode-azurefunctions/issues/2578 and https://github.com/microsoft/vscode-azurefunctions/issues/2659