### PR TITLE
Fix retrying for warmup function

### DIFF
--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -56,7 +56,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
             }
 
             // Retry listing functions if all we see is a "WarmUp" function, an internal function that goes away once the app is ...warmed up
-            if (Date.now() > maxTime || !(funcs.length === 1 && funcs[0].name?.toLowerCase() === 'warmup')) {
+            if (Date.now() > maxTime || !(funcs.length === 1 && isWarmupFunction(funcs[0]))) {
                 context.telemetry.measurements.listFunctionsAttempt = attempt;
                 break;
             } else {
@@ -75,5 +75,13 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
                 return fe.id ? getFunctionNameFromId(fe.id) : undefined;
             }
         );
+    }
+}
+
+function isWarmupFunction(func: WebSiteManagementModels.FunctionEnvelope): boolean {
+    try {
+        return !!func.id && getFunctionNameFromId(func.id).toLowerCase() === 'warmup';
+    } catch {
+        return false;
     }
 }

--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -43,7 +43,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
         }
 
         let funcs: WebSiteManagementModels.FunctionEnvelopeCollection;
-        const maxTime = Date.now() + 60 * 1000;
+        const maxTime = Date.now() + 2 * 60 * 1000;
         let attempt = 1;
         while (true) {
             funcs = this._nextLink ?
@@ -61,7 +61,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
                 break;
             } else {
                 attempt += 1;
-                await delay(5 * 1000);
+                await delay(10 * 1000);
             }
         }
 


### PR DESCRIPTION
Now that most of the parallel test stuff is in, I could more easily see if the retries were working, aaand they weren't. Turns out the name isn't reliable and I should use the existing `getFunctionNameFromId` function. With my new change, I see `listFunctionsAttempt` getting set to >1 on some nightly builds, so I think it's working. It takes almost a minute in most cases for the warmup function to go away, so I also doubled the timeout.