### PR TITLE
Fix venvUtil tests

### DIFF
--- a/test/runWithSetting.ts
+++ b/test/runWithSetting.ts
@@ -5,16 +5,18 @@
 
 import { ext, getGlobalSetting, updateGlobalSetting } from "../extension.bundle";
 
-export async function runWithFuncSetting(key: string, value: string | boolean | undefined, callback: () => Promise<void>): Promise<void> {
+type SettingValue = {} | string | boolean | undefined;
+
+export async function runWithFuncSetting(key: string, value: SettingValue, callback: () => Promise<void>): Promise<void> {
     await runWithSettingInternal(key, value, ext.prefix, callback);
 }
 
-export async function runWithSetting(key: string, value: string | boolean | undefined, callback: () => Promise<void>): Promise<void> {
+export async function runWithSetting(key: string, value: SettingValue, callback: () => Promise<void>): Promise<void> {
     await runWithSettingInternal(key, value, '', callback);
 }
 
-async function runWithSettingInternal(key: string, value: string | boolean | undefined, prefix: string, callback: () => Promise<void>): Promise<void> {
-    const oldValue: string | boolean | undefined = getGlobalSetting(key, prefix);
+async function runWithSettingInternal(key: string, value: SettingValue, prefix: string, callback: () => Promise<void>): Promise<void> {
+    const oldValue: SettingValue = getGlobalSetting(key, prefix);
     try {
         await updateGlobalSetting(key, value, prefix);
         await callback();


### PR DESCRIPTION
The old terminal profile settings were deprecated and don't work the same, so I have to update the tests
https://code.visualstudio.com/updates/v1_56#_profile-improvements

The production code doesn't reference the settings at all since it uses `vscode.env.shell`, so that code can stay the same.