### PR TITLE
Fix Add binding test

### DIFF
--- a/extension.bundle.ts
+++ b/extension.bundle.ts
@@ -16,6 +16,7 @@
 // At runtime the tests live in dist/tests and will therefore pick up the main webpack bundle at dist/extension.bundle.js.
 export * from 'vscode-azureappservice';
 export * from 'vscode-azureextensionui';
+export * from './src/commands/addBinding/addBinding';
 export * from './src/commands/copyFunctionUrl';
 export * from './src/commands/createFunction/createFunction';
 export * from './src/commands/createFunction/dotnetSteps/DotnetNamespaceStep';

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -144,6 +144,10 @@ export abstract class TemplateProviderBase implements Disposable {
         return key;
     }
 
+    public supportsProjKey(): boolean {
+        return !!this.refreshProjKey;
+    }
+
     /**
      * Optional method if the provider has project-specific templates
      */

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -144,6 +144,9 @@ export abstract class TemplateProviderBase implements Disposable {
         return key;
     }
 
+    /**
+     * Returns true if this template provider has project-specific templates
+     */
     public supportsProjKey(): boolean {
         return !!this.refreshProjKey;
     }

--- a/test/addBinding.test.ts
+++ b/test/addBinding.test.ts
@@ -6,10 +6,10 @@
 import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { commands, Uri } from 'vscode';
+import { Uri } from 'vscode';
 import { AzExtTreeItem } from 'vscode-azureextensionui';
-import { ext, getRandomHexString, IFunctionBinding, IFunctionJson, ProjectLanguage } from '../extension.bundle';
-import { cleanTestWorkspace, createTestActionContext, getTestWorkspaceFolder, testUserInput } from './global.test';
+import { addBinding, createNewProjectInternal, ext, getRandomHexString, IFunctionBinding, IFunctionJson, ProjectLanguage } from '../extension.bundle';
+import { cleanTestWorkspace, createTestActionContext, getTestWorkspaceFolder, runWithTestActionContext } from './global.test';
 
 suite('Add Binding', () => {
     let functionJsonPath: string;
@@ -19,9 +19,11 @@ suite('Add Binding', () => {
     suiteSetup(async () => {
         await cleanTestWorkspace();
         const testWorkspacePath = getTestWorkspaceFolder();
-        await testUserInput.runWithInputs([testWorkspacePath, ProjectLanguage.JavaScript, /http\s*trigger/i, functionName, 'Anonymous'], async () => {
-            await commands.executeCommand('azureFunctions.createNewProject');
-        });
+        await runWithTestActionContext('createNewProject', async (context) => {
+            await context.ui.runWithInputs([testWorkspacePath, ProjectLanguage.JavaScript, /http\s*trigger/i, functionName, 'Anonymous'], async () => {
+                await createNewProjectInternal(context, {});
+            });
+        })
         functionJsonPath = path.join(testWorkspacePath, functionName, 'function.json');
         assert.ok(await fse.pathExists(functionJsonPath), 'Failed to create project');
         initialBindingsCount = await getBindingsCount();
@@ -38,17 +40,17 @@ suite('Add Binding', () => {
         if (!await ext.azureAccountTreeItem.getIsLoggedIn()) {
             userInputs.unshift('Local Project');
         }
-        await validateAddBinding([], userInputs);
+        await validateAddBinding(undefined, userInputs);
     });
 
     test('Uri', async () => {
-        await validateAddBinding([Uri.parse(functionJsonPath)], []);
+        await validateAddBinding(Uri.parse(functionJsonPath), []);
     });
 
     test('Tree', async () => {
         const treeItem: AzExtTreeItem | undefined = await ext.tree.findTreeItem(`/localProject0/functions/${functionName}`, createTestActionContext());
         assert.ok(treeItem, 'Failed to find tree item');
-        await validateAddBinding([treeItem], []);
+        await validateAddBinding(treeItem, []);
     });
 
     async function getBindingsCount(): Promise<number> {
@@ -56,12 +58,14 @@ suite('Add Binding', () => {
         return (data.bindings || []).length;
     }
 
-    async function validateAddBinding(commandInputs: any[], userInputs: string[]): Promise<void> {
+    async function validateAddBinding(commandInput: any, userInputs: string[]): Promise<void> {
         const bindingType: string = 'HTTP';
         const bindingDirection: string = 'out';
         const bindingName: string = 'binding' + getRandomHexString();
-        await testUserInput.runWithInputs([...userInputs, bindingDirection, bindingType, bindingName], async () => {
-            await commands.executeCommand('azureFunctions.addBinding', ...commandInputs);
+        await runWithTestActionContext('addBinding', async (context) => {
+            await context.ui.runWithInputs([...userInputs, bindingDirection, bindingType, bindingName], async () => {
+                await addBinding(context, commandInput);
+            });
         });
 
         const data: IFunctionJson = <IFunctionJson>await fse.readJSON(functionJsonPath);

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -35,9 +35,12 @@ export function createTestActionContext(): TestActionContext {
  */
 export async function runWithTestActionContext(callbackId: string, callback: (context: TestActionContext) => Promise<void>): Promise<void> {
     const context = createTestActionContext();
+    const start: number = Date.now();
     try {
         await callback(context);
     } finally {
+        const end: number = Date.now();
+        context.telemetry.measurements.duration = (end - start) / 1000;
         console.log(`** TELEMETRY(${callbackId}) properties=${JSON.stringify(context.telemetry.properties)}, measurements=${JSON.stringify(context.telemetry.measurements)}`);
     }
 }
@@ -117,7 +120,7 @@ async function preLoadTemplates(): Promise<void> {
             ext.templateProvider.registerActionVariable(provider, context);
             for (const version of Object.values(FuncVersion)) {
                 for (const language of [ProjectLanguage.JavaScript, ProjectLanguage.CSharp]) {
-                    tasks.push(provider.getFunctionTemplates(context, undefined, language, version, TemplateFilter.Verified, undefined));
+                    tasks.push(provider.getFunctionTemplates(context, testWorkspaceFolders[0], language, version, TemplateFilter.Verified, undefined));
                 }
             }
         });


### PR DESCRIPTION
After https://github.com/microsoft/vscode-azurefunctions/pull/2856, the Adding Binding test started timing out. Basically it's the first test and "preLoadTemplates" wasn't quite pre-loading correctly. Fix was to pass `testWorkspaceFolders[0]` (the folder used for all non-parallel tests) as the projectPath

When I was investigating the issue, I also worked on improving the perf by re-using `templatesTask` more often. We used to have a separate templatesTask per projectPath, but .NET is the only one where the projectPath actually matters