### PR TITLE
Add WEBSITE_CONTENT* settings for linux consumption

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -140,10 +140,10 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         }
 
         const isElasticPremium: boolean = context.plan?.sku?.family?.toLowerCase() === 'ep';
-        if (context.newSiteOS === WebsiteOS.windows || isElasticPremium) {
-            // WEBSITE_CONTENT* settings only apply for the following scenarios:
-            // Windows: https://github.com/Microsoft/vscode-azurefunctions/issues/625
-            // Linux Elastic Premium: https://github.com/microsoft/vscode-azurefunctions/issues/1682
+        const isConsumption: boolean = context.plan?.sku?.family?.toLowerCase() === 'y';
+        if (isConsumption || isElasticPremium) {
+            // WEBSITE_CONTENT* settings are added for consumption/premium plans, but not dedicated
+            // https://github.com/microsoft/vscode-azurefunctions/issues/1702
             appSettings.push({
                 name: contentConnectionStringKey,
                 value: storageConnectionString


### PR DESCRIPTION
Per offline email exchange with Functions team:

> we just recently added support to mount and use AzureFiles to store function app content with the last functions release. But it is only enabled for Powershell currently since there is cold start impact for other apps and other apps don't really need it yet since they don't have a feature like ManagedDependencies.
> 
> For other apps even if the appsettings are present, they won't take effect (unless the app is not using RunFromPkg. this is to enable portal editing since apps using portal editing need persistent storage)




Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2830