### PR TITLE
Add validation of dotnet vs. dotnet-isolated runtime

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -15,7 +15,7 @@ import { FuncVersion } from '../../../FuncVersion';
 import { bundleFeedUtils } from '../../../utils/bundleFeedUtils';
 import { confirmOverwriteFile, writeFormattedJson } from "../../../utils/fs";
 import { nonNullProp } from '../../../utils/nonNull';
-import { getFunctionsWorkerRuntime } from '../../../vsCodeConfig/settings';
+import { getRootFunctionsWorkerRuntime } from '../../../vsCodeConfig/settings';
 import { IProjectWizardContext } from '../IProjectWizardContext';
 import { ProjectCreateStepBase } from './ProjectCreateStepBase';
 
@@ -39,7 +39,7 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
 
         const localSettingsJsonPath: string = path.join(context.projectPath, localSettingsFileName);
         if (await confirmOverwriteFile(context, localSettingsJsonPath)) {
-            const functionsWorkerRuntime: string | undefined = getFunctionsWorkerRuntime(context.language);
+            const functionsWorkerRuntime: string | undefined = getRootFunctionsWorkerRuntime(context.language);
             if (functionsWorkerRuntime) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 this.localSettingsJson.Values![workerRuntimeKey] = functionsWorkerRuntime;

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -83,7 +83,8 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     }
 
     if (isZipDeploy) {
-        await verifyAppSettings(context, node, version, language, { doRemoteBuild, isConsumption });
+        const projectPath = await tryGetFunctionProjectRoot(context, deployPaths.workspaceFolder.uri.fsPath);
+        await verifyAppSettings(context, node, projectPath, version, language, { doRemoteBuild, isConsumption });
     }
 
     await node.runWithTemporaryDescription(

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -19,7 +19,7 @@ import { validateFuncCoreToolsInstalled } from '../funcCoreTools/validateFuncCor
 import { localize } from '../localize';
 import { getFunctionFolders } from "../tree/localProject/LocalFunctionsTreeItem";
 import { getDebugConfigs, isDebugConfigEqual } from '../vsCodeConfig/launch';
-import { getFunctionsWorkerRuntime, getWorkspaceSetting } from "../vsCodeConfig/settings";
+import { getWorkspaceSetting, tryGetFunctionsWorkerRuntimeForProject } from "../vsCodeConfig/settings";
 
 export interface IPreDebugValidateResult {
     workspace: vscode.WorkspaceFolder;
@@ -103,7 +103,7 @@ function getMatchingWorkspace(debugConfig: vscode.DebugConfiguration): vscode.Wo
  * Automatically add worker runtime setting since it's required to debug, but often gets deleted since it's stored in "local.settings.json" which isn't tracked in source control
  */
 async function validateWorkerRuntime(context: IActionContext, projectLanguage: string | undefined, projectPath: string): Promise<void> {
-    const runtime: string | undefined = getFunctionsWorkerRuntime(projectLanguage);
+    const runtime: string | undefined = await tryGetFunctionsWorkerRuntimeForProject(projectLanguage, projectPath);
     if (runtime) {
         // Not worth handling mismatched runtimes since it's so unlikely
         await setLocalAppSetting(context, projectPath, workerRuntimeKey, runtime, MismatchBehavior.DontChange);

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -16,7 +16,7 @@ import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersio
 import { localize } from "../localize";
 import { createWebSiteClient } from '../utils/azureClients';
 import { nonNullProp } from '../utils/nonNull';
-import { getFunctionsWorkerRuntime, getWorkspaceSettingFromAnyFolder } from '../vsCodeConfig/settings';
+import { getRootFunctionsWorkerRuntime, getWorkspaceSettingFromAnyFolder } from '../vsCodeConfig/settings';
 import { ProductionSlotTreeItem } from './ProductionSlotTreeItem';
 import { isProjectCV, isRemoteProjectCV } from './projectContextValues';
 
@@ -105,7 +105,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         if (!context.advancedCreation) {
             LocationListStep.addStep(wizardContext, promptSteps);
             wizardContext.useConsumptionPlan = true;
-            wizardContext.stackFilter = getFunctionsWorkerRuntime(language);
+            wizardContext.stackFilter = getRootFunctionsWorkerRuntime(language);
             executeSteps.push(new ResourceGroupCreateStep());
             executeSteps.push(new AppServicePlanCreateStep());
             executeSteps.push(new StorageAccountCreateStep(storageAccountCreateOptions));

--- a/test/verifyVersionAndLanguage.test.ts
+++ b/test/verifyVersionAndLanguage.test.ts
@@ -3,28 +3,47 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fse from 'fs-extra';
+import * as path from 'path';
 import { createTestActionContext } from 'vscode-azureextensiondev';
-import { FuncVersion, ProjectLanguage, verifyVersionAndLanguage } from '../extension.bundle';
+import { FuncVersion, getRandomHexString, ProjectLanguage, verifyVersionAndLanguage } from '../extension.bundle';
 import { assertThrowsAsync } from './assertThrowsAsync';
+import { testFolderPath } from './global.test';
 
 suite('verifyVersionAndLanguage', () => {
+
+    let net3Path: string;
+    let net5Path: string;
+    suiteSetup(async () => {
+        net3Path = path.join(testFolderPath, getRandomHexString());
+        const net3ProjPath = path.join(net3Path, 'test.csproj');
+        await fse.ensureFile(net3ProjPath);
+        await fse.writeFile(net3ProjPath, net3Proj);
+
+        net5Path = path.join(testFolderPath, getRandomHexString());
+        const net5ProjPath = path.join(net5Path, 'test.csproj');
+        await fse.ensureFile(net5ProjPath);
+        await fse.writeFile(net5ProjPath, net5Proj);
+    });
+
+
     test('Local: ~1, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~1', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~1'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: 1.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '1.0.0'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~1, Remote: ~2', async () => {
@@ -33,7 +52,7 @@ suite('verifyVersionAndLanguage', () => {
         };
         const context = await createTestActionContext();
         await context.ui.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(context, undefined, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -43,27 +62,27 @@ suite('verifyVersionAndLanguage', () => {
         };
         const context = await createTestActionContext();
         await context.ui.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(context, undefined, 'testSite', FuncVersion.v1, ProjectLanguage.JavaScript, props);
         });
     });
 
     test('Local: ~2, Remote: none', async () => {
         const props: { [name: string]: string } = {};
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~2', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '~2'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: 2.0.0', async () => {
         const props: { [name: string]: string } = {
             FUNCTIONS_EXTENSION_VERSION: '2.0.0'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2, Remote: ~1', async () => {
@@ -72,7 +91,7 @@ suite('verifyVersionAndLanguage', () => {
         };
         const context = await createTestActionContext();
         await context.ui.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(context, undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -82,7 +101,7 @@ suite('verifyVersionAndLanguage', () => {
         };
         const context = await createTestActionContext();
         await context.ui.runWithInputs(['Deploy Anyway'], async () => {
-            await verifyVersionAndLanguage(context, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+            await verifyVersionAndLanguage(context, undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
         });
     });
 
@@ -91,7 +110,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'node'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props);
     });
 
     test('Local: ~2/node, Remote: ~2/dotnet', async () => {
@@ -99,7 +118,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/node, Remote: ~1/dotnet', async () => {
@@ -107,7 +126,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~1',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.JavaScript, props), /dotnet.*match.*node/i);
     });
 
     test('Local: ~2/unknown, Remote: ~2/dotnet', async () => {
@@ -115,7 +134,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'dotnet'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
     });
 
     test('Local: ~2/C#, Remote: ~2/unknown', async () => {
@@ -123,7 +142,7 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'unknown'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, ProjectLanguage.CSharp, props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, ProjectLanguage.CSharp, props);
     });
 
     test('Local: ~2/unknown, Remote: ~2/unknown', async () => {
@@ -131,6 +150,89 @@ suite('verifyVersionAndLanguage', () => {
             FUNCTIONS_EXTENSION_VERSION: '~2',
             FUNCTIONS_WORKER_RUNTIME: 'unknown'
         };
-        await verifyVersionAndLanguage(await createTestActionContext(), 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v2, <ProjectLanguage>"unknown", props);
+    });
+
+    test('Local: ~3/dotnet, Remote: ~3/dotnet', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~3',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet'
+        };
+        await verifyVersionAndLanguage(await createTestActionContext(), net3Path, 'testSite', FuncVersion.v3, ProjectLanguage.CSharp, props);
+    });
+
+    test('Local: ~3/dotnet, Remote: ~3/dotnet-isolated', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~3',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+        };
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), net3Path, 'testSite', FuncVersion.v3, ProjectLanguage.CSharp, props), /dotnet-isolated.*match.*dotnet/i);
+    });
+
+    test('Local: ~3/dotnet-isolated, Remote: ~3/dotnet-isolated', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~3',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+        };
+        await verifyVersionAndLanguage(await createTestActionContext(), net5Path, 'testSite', FuncVersion.v3, ProjectLanguage.CSharp, props);
+    });
+
+    test('Local: ~3/dotnet-isolated, Remote: ~3/dotnet', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~3',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet'
+        };
+        await assertThrowsAsync(async () => await verifyVersionAndLanguage(await createTestActionContext(), net5Path, 'testSite', FuncVersion.v3, ProjectLanguage.CSharp, props), /dotnet.*match.*dotnet-isolated/i);
+    });
+
+    test('Local: ~3/dotnet (unknown projectPath), Remote: ~3/dotnet', async () => {
+        const props: { [name: string]: string } = {
+            FUNCTIONS_EXTENSION_VERSION: '~3',
+            FUNCTIONS_WORKER_RUNTIME: 'dotnet'
+        };
+        await verifyVersionAndLanguage(await createTestActionContext(), undefined, 'testSite', FuncVersion.v3, ProjectLanguage.CSharp, props);
     });
 });
+
+const net3Proj: string = `<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>
+`;
+
+const net5Proj: string = `<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup>
+  <TargetFramework>net5.0</TargetFramework>
+  <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  <OutputType>Exe</OutputType>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
+  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
+  <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.1.0" />
+</ItemGroup>
+<ItemGroup>
+  <None Update="host.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Update="local.settings.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+  </None>
+</ItemGroup>
+</Project>
+`;


### PR DESCRIPTION
I'm talking about this error:
![Screen Shot 2021-07-12 at 5 18 21 PM](https://user-images.githubusercontent.com/11282622/125372280-8c363000-e337-11eb-8ea9-495b1e1202bb.png)

Previously it only checked "node" vs "dotnet", etc.

Also, during preDebugValidate, we will now write the correct worker runtime if it's missing, rather than always "dotnet".

Last piece needed to fix https://github.com/microsoft/vscode-azurefunctions/issues/2551 