### PR TITLE
Show "no templates found"

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -201,7 +201,15 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             });
         }
 
-        if (language === ProjectLanguage.CSharp || language === ProjectLanguage.Java || language === ProjectLanguage.Python || language === ProjectLanguage.TypeScript) {
+        if (templates.length === 0) {
+            picks.push({
+                label: localize('noTemplates', '$(warning) No templates found'),
+                suppressPersistence: true,
+                data: <IFunctionTemplate | TemplatePromptResult><unknown>undefined,
+                onPicked: () => { /* do nothing */ }
+            })
+        } else if (language === ProjectLanguage.CSharp || language === ProjectLanguage.Java || language === ProjectLanguage.Python || language === ProjectLanguage.TypeScript) {
+            // NOTE: Only show this if we actually found other templates
             picks.push({
                 label: localize('openAPI', 'HTTP trigger(s) from OpenAPI V2/V3 Specification (Preview)'),
                 data: 'openAPI',


### PR DESCRIPTION
Rather than this:
![Screen Shot 2021-07-13 at 9 55 48 AM](https://user-images.githubusercontent.com/11282622/125494010-059c690b-6c91-4add-b86d-4bced0f5af9e.png)

I want to show this:
![Screen Shot 2021-07-13 at 9 53 51 AM](https://user-images.githubusercontent.com/11282622/125494033-431cf21d-a657-40bf-9294-b07af4616cf7.png)
 
The "OpenAPI" template is a bit of an advanced scenario and if we can't find any templates there's likely a bigger problem going on (i.e. they're using v4 and we don't work with that yet). People might try the OpenAPI template just because it's the only one, but I don't want to lead them further down a rabbit hole of failure.