### PR TITLE
Use `workspace.findFiles` instead of `fs` methods

### DIFF
--- a/src/commands/addBinding/addBinding.ts
+++ b/src/commands/addBinding/addBinding.ts
@@ -31,7 +31,7 @@ export async function addBinding(context: IActionContext, data: Uri | LocalFunct
         functionJsonPath = data.fsPath;
         workspaceFolder = nonNullValue(getContainingWorkspace(functionJsonPath), 'workspaceFolder');
         workspacePath = workspaceFolder.uri.fsPath;
-        projectPath = await tryGetFunctionProjectRoot(context, workspacePath, 'modalPrompt') || workspacePath;
+        projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt') || workspacePath;
         [language, version] = await verifyInitForVSCode(context, projectPath);
     } else {
         if (!data) {

--- a/src/commands/appSettings/getLocalSettingsFile.ts
+++ b/src/commands/appSettings/getLocalSettingsFile.ts
@@ -15,11 +15,10 @@ import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
  * If only one project is open and the default local settings file exists, return that.
  * Otherwise, prompt
  */
-export async function getLocalSettingsFile(context: IActionContext, message: string, workspacePath?: string): Promise<string> {
-    const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
-    if (workspacePath || folders.length === 1) {
-        workspacePath = workspacePath || folders[0].uri.fsPath;
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath);
+export async function getLocalSettingsFile(context: IActionContext, message: string, workspaceFolder?: WorkspaceFolder): Promise<string> {
+    workspaceFolder ||= workspace.workspaceFolders?.[0];
+    if (workspaceFolder) {
+        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder);
         if (projectPath) {
             const localSettingsFile: string = path.join(projectPath, localSettingsFileName);
             if (await fse.pathExists(localSettingsFile)) {
@@ -29,8 +28,7 @@ export async function getLocalSettingsFile(context: IActionContext, message: str
     }
 
     return await selectWorkspaceFile(context, message, async (f: WorkspaceFolder): Promise<string> => {
-        workspacePath = f.uri.fsPath;
-        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
-        return path.relative(workspacePath, path.join(projectPath, localSettingsFileName));
+        const projectPath: string = await tryGetFunctionProjectRoot(context, f) || f.uri.fsPath;
+        return path.relative(f.uri.fsPath, path.join(projectPath, localSettingsFileName));
     });
 }

--- a/src/commands/appSettings/uploadAppSettings.ts
+++ b/src/commands/appSettings/uploadAppSettings.ts
@@ -18,20 +18,20 @@ import { decryptLocalSettings } from "./decryptLocalSettings";
 import { encryptLocalSettings } from "./encryptLocalSettings";
 import { getLocalSettingsFile } from "./getLocalSettingsFile";
 
-export async function uploadAppSettings(context: IActionContext, node?: AppSettingsTreeItem, workspacePath?: string): Promise<void> {
+export async function uploadAppSettings(context: IActionContext, node?: AppSettingsTreeItem, workspaceFolder?: vscode.WorkspaceFolder): Promise<void> {
     if (!node) {
         node = await ext.tree.showTreeItemPicker<AppSettingsTreeItem>(AppSettingsTreeItem.contextValue, context);
     }
 
     const client: IAppSettingsClient = node.client;
     await node.runWithTemporaryDescription(context, localize('uploading', 'Uploading...'), async () => {
-        await uploadAppSettingsInternal(context, client, workspacePath);
+        await uploadAppSettingsInternal(context, client, workspaceFolder);
     });
 }
 
-export async function uploadAppSettingsInternal(context: IActionContext, client: api.IAppSettingsClient, workspacePath?: string): Promise<void> {
+export async function uploadAppSettingsInternal(context: IActionContext, client: api.IAppSettingsClient, workspaceFolder?: vscode.WorkspaceFolder): Promise<void> {
     const message: string = localize('selectLocalSettings', 'Select the local settings file to upload.');
-    const localSettingsPath: string = await getLocalSettingsFile(context, message, workspacePath);
+    const localSettingsPath: string = await getLocalSettingsFile(context, message, workspaceFolder);
     const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
 
     let localSettings: ILocalSettingsJson = <ILocalSettingsJson>await fse.readJson(localSettingsPath);

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -52,7 +52,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
         workspaceFolder = getContainingWorkspace(workspacePath);
     }
 
-    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspacePath, options);
+    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder || workspacePath, options);
     if (!projectPath) {
         return;
     }

--- a/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
+++ b/src/commands/createFunction/dotnetSteps/DotnetFunctionCreateStep.ts
@@ -49,7 +49,7 @@ export class DotnetFunctionCreateStep extends FunctionCreateStepBase<IDotnetFunc
         let projectTemplateKey = context.projectTemplateKey;
         if (!projectTemplateKey) {
             const templateProvider = ext.templateProvider.get(context);
-            projectTemplateKey = await templateProvider.getProjectTemplateKey(context.projectPath, nonNullProp(context, 'language'), context.version, undefined);
+            projectTemplateKey = await templateProvider.getProjectTemplateKey(context, context.projectPath, nonNullProp(context, 'language'), context.version, undefined);
         }
         await executeDotnetTemplateCommand(context, version, projectTemplateKey, context.projectPath, 'create', '--identity', template.id, ...args);
 

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -61,7 +61,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     const doRemoteBuild: boolean | undefined = getWorkspaceSetting<boolean>(remoteBuildSetting, deployPaths.effectiveDeployFsPath);
     actionContext.telemetry.properties.scmDoBuildDuringDeployment = String(doRemoteBuild);
     if (doRemoteBuild) {
-        await validateRemoteBuild(context, node.root.client, context.workspaceFolder.uri.fsPath, language);
+        await validateRemoteBuild(context, node.root.client, context.workspaceFolder, language);
     }
 
     if (isZipDeploy && node.root.client.isLinux && isConsumption && !doRemoteBuild) {
@@ -83,7 +83,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     }
 
     if (isZipDeploy) {
-        const projectPath = await tryGetFunctionProjectRoot(context, deployPaths.workspaceFolder.uri.fsPath);
+        const projectPath = await tryGetFunctionProjectRoot(context, deployPaths.workspaceFolder);
         await verifyAppSettings(context, node, projectPath, version, language, { doRemoteBuild, isConsumption });
     }
 
@@ -108,15 +108,15 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         }
     );
 
-    await notifyDeployComplete(context, node, context.workspaceFolder.uri.fsPath);
+    await notifyDeployComplete(context, node, context.workspaceFolder);
 }
 
 async function updateWorkerProcessTo64BitIfRequired(context: IDeployContext, siteConfig: WebSiteManagementModels.SiteConfigResource, node: SlotTreeItemBase, language: ProjectLanguage): Promise<void> {
-    const functionProject: string | undefined = await tryGetFunctionProjectRoot(context, context.workspaceFolder.uri.fsPath);
+    const functionProject: string | undefined = await tryGetFunctionProjectRoot(context, context.workspaceFolder);
     if (functionProject === undefined) {
         return;
     }
-    const projectFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(language, functionProject);
+    const projectFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, language, functionProject);
     if (projectFiles.length !== 1) {
         return;
     }

--- a/src/commands/deploy/notifyDeployComplete.ts
+++ b/src/commands/deploy/notifyDeployComplete.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as retry from 'p-retry';
-import { MessageItem, window } from 'vscode';
+import { MessageItem, window, WorkspaceFolder } from 'vscode';
 import { AzExtTreeItem, AzureTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
@@ -14,7 +14,7 @@ import { SlotTreeItemBase } from '../../tree/SlotTreeItemBase';
 import { uploadAppSettings } from '../appSettings/uploadAppSettings';
 import { startStreamingLogs } from '../logstream/startStreamingLogs';
 
-export async function notifyDeployComplete(context: IActionContext, node: SlotTreeItemBase, workspacePath: string): Promise<void> {
+export async function notifyDeployComplete(context: IActionContext, node: SlotTreeItemBase, workspaceFolder: WorkspaceFolder): Promise<void> {
     const deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', node.root.client.fullName);
     const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
     const streamLogs: MessageItem = { title: localize('streamLogs', 'Stream logs') };
@@ -31,7 +31,7 @@ export async function notifyDeployComplete(context: IActionContext, node: SlotTr
             } else if (result === streamLogs) {
                 await startStreamingLogs(postDeployContext, node);
             } else if (result === uploadSettings) {
-                await uploadAppSettings(postDeployContext, node.appSettingsTreeItem, workspacePath);
+                await uploadAppSettings(postDeployContext, node.appSettingsTreeItem, workspaceFolder);
             }
         });
     });

--- a/src/commands/deploy/validateRemoteBuild.ts
+++ b/src/commands/deploy/validateRemoteBuild.ts
@@ -12,19 +12,19 @@ import { updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
 import { ensureGitIgnoreContents } from '../initProjectForVSCode/InitVSCodeStep/PythonInitVSCodeStep';
 
-export async function validateRemoteBuild(context: IDeployContext, client: SiteClient, workspacePath: string, language: ProjectLanguage): Promise<void> {
+export async function validateRemoteBuild(context: IDeployContext, client: SiteClient, workspaceFolder: vscode.WorkspaceFolder, language: ProjectLanguage): Promise<void> {
     if (language === ProjectLanguage.Python && !client.kuduUrl) {
         const message: string = localize('remoteBuildNotSupported', 'The selected Function App doesn\'t support your project\'s configuration. Deploy to a newer Function App or downgrade your config.');
         const learnMoreLink: string = 'https://aka.ms/AA5vsfd';
         const downgrade: vscode.MessageItem = { title: localize('downgrade', 'Downgrade config') };
         await context.ui.showWarningMessage(message, { learnMoreLink, modal: true, stepName: 'validateRemoteBuild' }, downgrade);
 
-        const projectPath: string = await tryGetFunctionProjectRoot(context, workspacePath) || workspacePath;
-        await updateWorkspaceSetting(remoteBuildSetting, false, workspacePath);
-        await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspacePath);
+        const projectPath: string = await tryGetFunctionProjectRoot(context, workspaceFolder) || workspaceFolder.uri.fsPath;
+        await updateWorkspaceSetting(remoteBuildSetting, false, workspaceFolder);
+        await updateWorkspaceSetting(preDeployTaskSetting, packTaskName, workspaceFolder);
         const zipFileName: string = path.basename(projectPath) + '.zip';
         // Always use posix separators for config checked in to source control
-        await updateWorkspaceSetting(deploySubpathSetting, path.posix.join(path.relative(workspacePath, projectPath), zipFileName), workspacePath);
+        await updateWorkspaceSetting(deploySubpathSetting, path.posix.join(path.relative(workspaceFolder.uri.fsPath, projectPath), zipFileName), workspaceFolder);
         await ensureGitIgnoreContents(projectPath, [zipFileName]);
     }
 }

--- a/src/commands/deploy/verifyAppSettings.ts
+++ b/src/commands/deploy/verifyAppSettings.ts
@@ -49,7 +49,7 @@ export async function verifyVersionAndLanguage(context: IActionContext, projectP
     context.telemetry.properties.remoteVersion = azureVersion || 'Unknown';
     context.telemetry.properties.remoteRuntime = isKnownWorkerRuntime(azureWorkerRuntime) ? azureWorkerRuntime : 'Unknown';
 
-    const localWorkerRuntime: string | undefined = await tryGetFunctionsWorkerRuntimeForProject(localLanguage, projectPath);
+    const localWorkerRuntime: string | undefined = await tryGetFunctionsWorkerRuntimeForProject(context, localLanguage, projectPath);
     if (localVersion !== FuncVersion.v1 && isKnownWorkerRuntime(azureWorkerRuntime) && isKnownWorkerRuntime(localWorkerRuntime) && azureWorkerRuntime !== localWorkerRuntime) {
         throw new Error(localize('incompatibleRuntime', 'The remote runtime "{0}" for function app "{1}" does not match your local runtime "{2}".', azureWorkerRuntime, siteName, localWorkerRuntime));
     }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/DotnetInitVSCodeStep.ts
@@ -51,7 +51,7 @@ export class DotnetInitVSCodeStep extends InitVSCodeStepBase {
         const language: ProjectLanguage = nonNullProp(context, 'language');
 
         let projFile: dotnetUtils.ProjectFile;
-        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(language, projectPath);
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, language, projectPath);
         const fileExt: string = language === ProjectLanguage.FSharp ? 'fsproj' : 'csproj';
         if (projFiles.length === 1) {
             projFile = projFiles[0];

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -37,7 +37,7 @@ export async function initProjectForVSCode(context: IActionContext, fsPath?: str
         workspacePath = workspaceFolder ? workspaceFolder.uri.fsPath : fsPath;
     }
 
-    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspacePath);
+    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder || workspacePath);
     if (!projectPath) {
         return;
     }

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -43,7 +43,7 @@ export class FuncTaskProvider implements TaskProvider {
                 let lastError: unknown;
                 for (const folder of workspace.workspaceFolders) {
                     try {
-                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath);
+                        const projectRoot: string | undefined = await tryGetFunctionProjectRoot(context, folder);
                         if (projectRoot) {
                             const language: string | undefined = getWorkspaceSetting(projectLanguageSetting, folder.uri.fsPath);
 

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -82,7 +82,7 @@ export async function getFuncPortFromTaskOrProject(context: IActionContext, func
         if (typeof projectPathOrTaskScope === 'string') {
             projectPath = projectPathOrTaskScope;
         } else if (typeof projectPathOrTaskScope === 'object') {
-            projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope.uri.fsPath);
+            projectPath = await tryGetFunctionProjectRoot(context, projectPathOrTaskScope);
         }
 
         if (projectPath) {

--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -154,18 +154,18 @@ export abstract class TemplateProviderBase implements Disposable {
     /**
      * Optional method if the provider has project-specific templates
      */
-    protected refreshProjKey?(): Promise<string>;
+    protected refreshProjKey?(context: IActionContext): Promise<string>;
 
     /**
      * A key used to identify the templates for the current type of project
      */
-    public async getProjKey(): Promise<string> {
+    public async getProjKey(context: IActionContext): Promise<string> {
         if (!this.refreshProjKey) {
             throw new NotImplementedError('refreshProjKey', this);
         }
 
         if (!this._sessionProjKey) {
-            this._sessionProjKey = await this.refreshProjKey();
+            this._sessionProjKey = await this.refreshProjKey(context);
         }
 
         return this._sessionProjKey;
@@ -178,7 +178,7 @@ export abstract class TemplateProviderBase implements Disposable {
     /**
      * Returns true if the key changed
      */
-    public async updateProjKeyIfChanged(projKey: string | undefined): Promise<boolean> {
+    public async updateProjKeyIfChanged(context: IActionContext, projKey: string | undefined): Promise<boolean> {
         let hasChanged: boolean;
         if (!this.refreshProjKey) {
             hasChanged = false; // proj keys not supported, so it's impossible to have changed
@@ -186,7 +186,7 @@ export abstract class TemplateProviderBase implements Disposable {
             hasChanged = this._sessionProjKey !== projKey;
             this._sessionProjKey = projKey;
         } else if (this._projKeyMayHaveChanged) {
-            const latestProjKey = await this.refreshProjKey();
+            const latestProjKey = await this.refreshProjKey(context);
             hasChanged = this._sessionProjKey !== latestProjKey;
             this._sessionProjKey = latestProjKey;
         } else {
@@ -197,9 +197,9 @@ export abstract class TemplateProviderBase implements Disposable {
         return hasChanged;
     }
 
-    public async doesCachedProjKeyMatch(): Promise<boolean> {
+    public async doesCachedProjKeyMatch(context: IActionContext): Promise<boolean> {
         if (this.refreshProjKey) {
-            const projKey = await this.getProjKey();
+            const projKey = await this.getProjKey(context);
             const cachedProjKey = await this.getCachedValue(TemplateProviderBase.projTemplateKeyCacheKey);
             // If cachedProjKey is not defined, assumes it's a match (the cache is probably from before proj keys were a thing)
             return !cachedProjKey || projKey === cachedProjKey;

--- a/src/templates/dotnet/DotnetTemplateProvider.ts
+++ b/src/templates/dotnet/DotnetTemplateProvider.ts
@@ -44,12 +44,12 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
 
     private _rawTemplates: object[];
 
-    public async refreshProjKey(): Promise<string> {
-        return await dotnetUtils.getTemplateKeyFromProjFile(this.projectPath, this.version, this.language);
+    public async refreshProjKey(context: IActionContext): Promise<string> {
+        return await dotnetUtils.getTemplateKeyFromProjFile(context, this.projectPath, this.version, this.language);
     }
 
     public async getCachedTemplates(context: IActionContext): Promise<ITemplates | undefined> {
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
         const projectFilePath: string = getDotnetProjectTemplatePath(context, this.version, projKey);
         const itemFilePath: string = getDotnetItemTemplatePath(context, this.version, projKey);
         if (!await fse.pathExists(projectFilePath) || !await fse.pathExists(itemFilePath)) {
@@ -65,7 +65,7 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
     }
 
     public async getLatestTemplateVersion(context: IActionContext): Promise<string> {
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
 
         let templateVersion = await cliFeedUtils.getLatestVersion(context, this.version);
         let netRelease = await this.getNetRelease(projKey, templateVersion);
@@ -93,7 +93,7 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
     public async getLatestTemplates(context: IActionContext, latestTemplateVersion: string): Promise<ITemplates> {
         await validateDotnetInstalled(context);
 
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
         const projectFilePath: string = getDotnetProjectTemplatePath(context, this.version, projKey);
         const itemFilePath: string = getDotnetItemTemplatePath(context, this.version, projKey);
 
@@ -112,7 +112,7 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
     }
 
     public async getBackupTemplates(context: IActionContext): Promise<ITemplates> {
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
         const files: string[] = [getDotnetProjectTemplatePath(context, this.version, projKey), getDotnetItemTemplatePath(context, this.version, projKey)];
         for (const file of files) {
             await fse.copy(this.convertToBackupFilePath(projKey, file), file);
@@ -121,7 +121,7 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
     }
 
     public async updateBackupTemplates(context: IActionContext): Promise<void> {
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
         const files: string[] = [getDotnetProjectTemplatePath(context, this.version, projKey), getDotnetItemTemplatePath(context, this.version, projKey)];
         for (const file of files) {
             await fse.copy(file, this.convertToBackupFilePath(projKey, file));
@@ -133,13 +133,13 @@ export class DotnetTemplateProvider extends TemplateProviderBase {
     }
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    public async cacheTemplates(): Promise<void> {
-        const projKey = await this.getProjKey();
+    public async cacheTemplates(context: IActionContext): Promise<void> {
+        const projKey = await this.getProjKey(context);
         await this.updateCachedValue(projKey, this._rawTemplates);
     }
 
     public async clearCachedTemplates(context: IActionContext): Promise<void> {
-        const projKey = await this.getProjKey();
+        const projKey = await this.getProjKey(context);
         await this.deleteCachedValue(projKey);
         await fse.remove(getDotnetTemplateDir(context, this.version, projKey));
     }

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -67,7 +67,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
 
         const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
         for (const folder of folders) {
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder.uri.fsPath);
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder);
             if (projectPath) {
                 try {
                     hasLocalProject = true;
@@ -80,7 +80,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
                         let preCompiledProjectPath: string | undefined;
                         let effectiveProjectPath: string;
                         let isIsolated: boolean | undefined;
-                        const compiledProjectInfo: CompiledProjectInfo | undefined = await getCompiledProjectInfo(projectPath, language);
+                        const compiledProjectInfo: CompiledProjectInfo | undefined = await getCompiledProjectInfo(context, projectPath, language);
                         if (compiledProjectInfo) {
                             preCompiledProjectPath = projectPath;
                             effectiveProjectPath = compiledProjectInfo.compiledProjectPath;
@@ -150,9 +150,9 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
 
 type CompiledProjectInfo = { compiledProjectPath: string; isIsolated: boolean };
 
-async function getCompiledProjectInfo(projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
+async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
     if (projectLanguage === ProjectLanguage.CSharp || projectLanguage === ProjectLanguage.FSharp) {
-        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(projectLanguage, projectPath);
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
         if (projFiles.length === 1) {
             const targetFramework: string = await dotnetUtils.getTargetFramework(projFiles[0]);
             const isIsolated = await dotnetUtils.getIsIsolated(projFiles[0]);

--- a/src/tree/localProject/LocalFunctionsTreeItem.ts
+++ b/src/tree/localProject/LocalFunctionsTreeItem.ts
@@ -6,7 +6,7 @@
 import { WebSiteManagementModels } from '@azure/arm-appservice';
 import * as fse from 'fs-extra';
 import * as path from 'path';
-import { ThemeIcon } from 'vscode';
+import { RelativePattern, ThemeIcon, workspace } from 'vscode';
 import { AzExtTreeItem, GenericTreeItem, IActionContext } from 'vscode-azureextensionui';
 import { functionJsonFileName } from '../../constants';
 import { ParsedFunctionJson } from '../../funcConfig/function';
@@ -14,6 +14,7 @@ import { runningFuncTaskMap } from '../../funcCoreTools/funcHostTask';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { requestUtils } from '../../utils/requestUtils';
+import { telemetryUtils } from '../../utils/telemetryUtils';
 import { FunctionsTreeItemBase } from '../FunctionsTreeItemBase';
 import { LocalFunctionTreeItem } from './LocalFunctionTreeItem';
 import { LocalProjectTreeItem } from './LocalProjectTreeItem';
@@ -35,7 +36,7 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
         if (this.parent.isIsolated) {
             return await this.getChildrenForIsolatedProject(context);
         } else {
-            const functions: string[] = await getFunctionFolders(this.parent.effectiveProjectPath);
+            const functions: string[] = await getFunctionFolders(context, this.parent.effectiveProjectPath);
             const children: AzExtTreeItem[] = await this.createTreeItemsWithErrorHandling(
                 functions,
                 'azFuncInvalidLocalFunction',
@@ -105,15 +106,9 @@ export class LocalFunctionsTreeItem extends FunctionsTreeItemBase {
     }
 }
 
-export async function getFunctionFolders(projectPath: string): Promise<string[]> {
-    const result: string[] = [];
-    if (await fse.pathExists(projectPath)) {
-        const subpaths: string[] = await fse.readdir(projectPath);
-        await Promise.all(subpaths.map(async s => {
-            if (await fse.pathExists(path.join(projectPath, s, functionJsonFileName))) {
-                result.push(s);
-            }
-        }));
-    }
-    return result;
+export async function getFunctionFolders(context: IActionContext, projectPath: string): Promise<string[]> {
+    return await telemetryUtils.runWithDurationTelemetry(context, 'getFuncs', async () => {
+        const funcJsonUris = await workspace.findFiles(new RelativePattern(projectPath, `*/${functionJsonFileName}`));
+        return funcJsonUris.map(uri => path.basename(path.dirname(uri.fsPath)))
+    });
 }

--- a/src/utils/telemetryUtils.ts
+++ b/src/utils/telemetryUtils.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IActionContext } from 'vscode-azureextensionui';
+
+export namespace telemetryUtils {
+    export async function runWithDurationTelemetry<T>(context: IActionContext, prefix: string, callback: () => Promise<T>): Promise<T> {
+        const start = Date.now();
+        try {
+            return await callback();
+        } finally {
+            const end = Date.now();
+            const durationKey = prefix + 'Duration';
+            const countKey = prefix + 'Count';
+            const duration = (end - start) / 1000;
+
+            context.telemetry.measurements[durationKey] = duration + (context.telemetry.measurements[durationKey] || 0);
+            context.telemetry.measurements[countKey] = 1 + (context.telemetry.measurements[countKey] || 0);
+        }
+    }
+}

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration, WorkspaceFolder } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
 import { ProjectLanguage } from '../constants';
 import { ext } from "../extensionVariables";
 import { dotnetUtils } from "../utils/dotnetUtils";
@@ -19,8 +20,8 @@ export async function updateGlobalSetting<T = string>(section: string, value: T,
 /**
  * Uses ext.prefix 'azureFunctions' unless otherwise specified
  */
-export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string, prefix: string = ext.prefix): Promise<void> {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, Uri.file(fsPath));
+export async function updateWorkspaceSetting<T = string>(section: string, value: T, fsPath: string | WorkspaceFolder, prefix: string = ext.prefix): Promise<void> {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, getScope(fsPath));
     await projectConfiguration.update(section, value);
 }
 
@@ -36,9 +37,13 @@ export function getGlobalSetting<T>(key: string, prefix: string = ext.prefix): T
 /**
  * Uses ext.prefix 'azureFunctions' unless otherwise specified
  */
-export function getWorkspaceSetting<T>(key: string, fsPath?: string, prefix: string = ext.prefix): T | undefined {
-    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, fsPath ? Uri.file(fsPath) : undefined);
+export function getWorkspaceSetting<T>(key: string, fsPath?: string | WorkspaceFolder, prefix: string = ext.prefix): T | undefined {
+    const projectConfiguration: WorkspaceConfiguration = workspace.getConfiguration(prefix, getScope(fsPath));
     return projectConfiguration.get<T>(key);
+}
+
+function getScope(fsPath: WorkspaceFolder | string | undefined): Uri | WorkspaceFolder | undefined {
+    return typeof fsPath === 'string' ? Uri.file(fsPath) : fsPath;
 }
 
 /**
@@ -88,11 +93,11 @@ export function getRootFunctionsWorkerRuntime(language: string | undefined): str
     }
 }
 
-export async function tryGetFunctionsWorkerRuntimeForProject(language: string | undefined, projectPath: string | undefined): Promise<string | undefined> {
+export async function tryGetFunctionsWorkerRuntimeForProject(context: IActionContext, language: string | undefined, projectPath: string | undefined): Promise<string | undefined> {
     let runtime = getRootFunctionsWorkerRuntime(language);
     if (language === ProjectLanguage.CSharp || language === ProjectLanguage.FSharp) {
         if (projectPath) {
-            const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(language, projectPath);
+            const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, language, projectPath);
             if (projFiles.length === 1) {
                 if (await dotnetUtils.getIsIsolated(projFiles[0])) {
                     runtime += '-isolated';

--- a/src/vsCodeConfig/verifyTargetFramework.ts
+++ b/src/vsCodeConfig/verifyTargetFramework.ts
@@ -15,7 +15,7 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, fo
     const settingKey: string = 'showTargetFrameworkWarning';
     if (getWorkspaceSetting<boolean>(settingKey)) {
 
-        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(projectLanguage, projectPath);
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
         if (projFiles.length === 1) {
 
             let targetFramework: string;
@@ -40,7 +40,7 @@ export async function verifyTargetFramework(projectLanguage: ProjectLanguage, fo
                 const result: vscode.MessageItem = await context.ui.showWarningMessage(message, update, DialogResponses.dontWarnAgain);
                 if (result === DialogResponses.dontWarnAgain) {
                     context.telemetry.properties.verifyConfigResult = 'dontWarnAgain';
-                    await updateWorkspaceSetting(settingKey, false, folder.uri.fsPath);
+                    await updateWorkspaceSetting(settingKey, false, folder);
                 } else if (result === update) {
                     context.telemetry.properties.verifyConfigResult = 'update';
                     if (tasksResult) {

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -25,7 +25,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
     if (folders) {
         for (const folder of folders) {
             const workspacePath: string = folder.uri.fsPath;
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspacePath, 'prompt');
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder, 'prompt');
             if (projectPath) {
                 context.telemetry.suppressIfSuccessful = false;
 

--- a/test/addBinding.test.ts
+++ b/test/addBinding.test.ts
@@ -35,7 +35,9 @@ suite('Add Binding', () => {
         assert.equal(finalBindingsCount, initialBindingsCount + 3, 'Not all expected bindings were added.');
     });
 
-    test('Command Palette', async () => {
+    test('Command Palette', async function (this: Mocha.Context): Promise<void> {
+        this.timeout(30 * 1000);
+
         const userInputs: string[] = [functionName];
         // https://github.com/microsoft/vscode-azurefunctions/issues/1586
         if (!await ext.azureAccountTreeItem.getIsLoggedIn()) {


### PR DESCRIPTION
The addBinding test is having timeout issues on Windows. I was able to improve the perf a bit in https://github.com/microsoft/vscode-azurefunctions/pull/2890, but the main slowdowns occur when we search the file system. I don't have a "fix" per se, but I thought it would be a good idea to use `workspace.findFiles` instead of `fs` methods. It's simpler code for us and the VS Code team should be able to make it the most performant option. A few notes:
- The VS Code docs for `findFiles` say "It is recommended to pass in a workspace folder if the pattern should match inside the workspace.", so I updated to use the folder instead of the path in several places
- I added duration telemetry so we can monitor this going forward