### PR TITLE
Fix build related to v1 moving to net48

### DIFF
--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as semver from 'semver';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext, TemplateSource } from '../extensionVariables';
 import { FuncVersion, getMajorVersion, isPreviewVersion } from '../FuncVersion';
@@ -68,6 +69,13 @@ export namespace cliFeedUtils {
             throw new Error(localize('unsupportedVersion', 'Azure Functions v{0} does not support this operation.', majorVersion));
         }
         return releaseData.release;
+    }
+
+    export async function getSortedVersions(version: FuncVersion): Promise<string[]> {
+        const cliFeed: ICliFeed = await getCliFeed();
+        const majorVersion = parseInt(getMajorVersion(version));
+        const versions = Object.keys(cliFeed.releases).filter(v => semver.valid(v) && semver.major(v) === majorVersion);
+        return semver.rsort(versions).map(v => typeof v === 'string' ? v : v.version);
     }
 
     export async function getRelease(templateVersion: string): Promise<IRelease> {


### PR DESCRIPTION
Looks like Functions v1 switched from net461 by default to net48, but this breaks our tests because we're assuming net461 in a few places. It's also problematic because plenty of our users probably still have net461 projects. I added logic to find the latest version that works for their target framework. The warning will look like this:

> WARNING: "net461" does not support the latest templates. Use "net48" for the latest.
