### PR TITLE
Support create project/function for v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
                 "vinyl-buffer": "^1.0.1",
                 "vinyl-source-stream": "^2.0.0",
                 "vsce": "^1.87.0",
-                "vscode-azureextensiondev": "^0.9.6",
+                "vscode-azureextensiondev": "^0.9.7",
                 "vscode-test": "^1.5.2",
                 "webpack": "^5.28.0",
                 "webpack-cli": "^4.6.0"
@@ -12196,9 +12196,9 @@
             }
         },
         "node_modules/vscode-azureextensiondev": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.6.tgz",
-            "integrity": "sha512-4hl5Ybo992s9ZiSfzlxNbgBvrGC/f4XAbvJuQBIae/tvGxlu5BTiioyPbsgUR3Sjuy/Q0TuaoBKwFDJuwcfomw==",
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.7.tgz",
+            "integrity": "sha512-BNheU7Kjdn+WcYsocYxE2Kbo72KdDUTKGirRIUQBrTxfTI5NjwWpu0zzIQaUp7ZvwTKF77k56BCXZwVhcgjbPg==",
             "dev": true,
             "dependencies": {
                 "@azure/arm-subscriptions": "^2.0.0",
@@ -22914,9 +22914,9 @@
             }
         },
         "vscode-azureextensiondev": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.6.tgz",
-            "integrity": "sha512-4hl5Ybo992s9ZiSfzlxNbgBvrGC/f4XAbvJuQBIae/tvGxlu5BTiioyPbsgUR3Sjuy/Q0TuaoBKwFDJuwcfomw==",
+            "version": "0.9.7",
+            "resolved": "https://registry.npmjs.org/vscode-azureextensiondev/-/vscode-azureextensiondev-0.9.7.tgz",
+            "integrity": "sha512-BNheU7Kjdn+WcYsocYxE2Kbo72KdDUTKGirRIUQBrTxfTI5NjwWpu0zzIQaUp7ZvwTKF77k56BCXZwVhcgjbPg==",
             "dev": true,
             "requires": {
                 "@azure/arm-subscriptions": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1105,7 +1105,7 @@
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0",
         "vsce": "^1.87.0",
-        "vscode-azureextensiondev": "^0.9.6",
+        "vscode-azureextensiondev": "^0.9.7",
         "vscode-test": "^1.5.2",
         "webpack": "^5.28.0",
         "webpack-cli": "^4.6.0"

--- a/src/FuncVersion.ts
+++ b/src/FuncVersion.ts
@@ -51,10 +51,6 @@ export function tryParseFuncVersion(data: string | undefined): FuncVersion | und
     return undefined;
 }
 
-export function isPreviewVersion(version: FuncVersion): boolean {
-    return version === FuncVersion.v4;
-}
-
 function osSupportsVersion(version: FuncVersion | undefined): boolean {
     return version !== FuncVersion.v1 || process.platform === 'win32';
 }

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -74,8 +74,8 @@ export class CentralTemplateProvider implements Disposable {
                 return templates.functionTemplates.filter((t: IFunctionTemplate) => t.categories.find((c: TemplateCategory) => c === TemplateCategory.Core) !== undefined);
             case TemplateFilter.Verified:
             default:
-                const verifiedTemplateIds: string[] = getScriptVerifiedTemplateIds(version).concat(getDotnetVerifiedTemplateIds(version)).concat(getJavaVerifiedTemplateIds());
-                return templates.functionTemplates.filter((t: IFunctionTemplate) => verifiedTemplateIds.find((vt: string) => vt === t.id));
+                const verifiedTemplateIds = getScriptVerifiedTemplateIds(version).concat(getDotnetVerifiedTemplateIds(version)).concat(getJavaVerifiedTemplateIds());
+                return templates.functionTemplates.filter((t: IFunctionTemplate) => verifiedTemplateIds.find(vt => typeof vt === 'string' ? vt === t.id : vt.test(t.id)));
         }
     }
 

--- a/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
+++ b/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { FuncVersion, getMajorVersion } from "../../FuncVersion";
+import { FuncVersion } from "../../FuncVersion";
 
-export function getDotnetVerifiedTemplateIds(version: string): string[] {
+export function getDotnetVerifiedTemplateIds(version: string): RegExp[] {
     let verifiedTemplateIds: string[] = [
         'EventHubTrigger',
         'HttpTrigger',
@@ -32,26 +32,7 @@ export function getDotnetVerifiedTemplateIds(version: string): string[] {
         ]);
     }
 
-    let ids: string[] = convertToFullIds(verifiedTemplateIds, version);
-    if (version === FuncVersion.v3) {
-        // Also include v2 ids since v3 templates still use '2' in the id and it's not clear if/when that'll change
-        // https://github.com/microsoft/vscode-azurefunctions/issues/1602
-        ids = ids.concat(convertToFullIds(verifiedTemplateIds, FuncVersion.v2));
-
-        // And include Isolated templates
-        ids = ids.concat(convertToFullIds(verifiedTemplateIds, version, true));
-    }
-    return ids;
-}
-
-function convertToFullIds(ids: string[], version: string, isIsolated: boolean = false): string[] {
-    const majorVersion: string = getMajorVersion(version);
-    return ids.map(id => {
-        let fullId = `Azure.Function.CSharp.`;
-        if (isIsolated) {
-            fullId += 'Isolated.';
-        }
-        fullId += `${id}.${majorVersion}.x`;
-        return fullId;
+    return verifiedTemplateIds.map(id => {
+        return new RegExp(`^azure\\.function\\.csharp\\.(?:isolated\\.|)${id}\\.[0-9]+\\.x$`, 'i');
     });
 }

--- a/src/templates/script/getScriptVerifiedTemplateIds.ts
+++ b/src/templates/script/getScriptVerifiedTemplateIds.ts
@@ -5,44 +5,38 @@
 
 import { FuncVersion } from '../../FuncVersion';
 
-export function getScriptVerifiedTemplateIds(version: string): string[] {
+export function getScriptVerifiedTemplateIds(version: string): (string | RegExp)[] {
     let verifiedTemplateIds: string[] = [
-        'BlobTrigger-JavaScript',
-        'HttpTrigger-JavaScript',
-        'QueueTrigger-JavaScript',
-        'TimerTrigger-JavaScript'
+        'BlobTrigger',
+        'HttpTrigger',
+        'QueueTrigger',
+        'TimerTrigger'
     ];
 
     if (version === FuncVersion.v1) {
         verifiedTemplateIds = verifiedTemplateIds.concat([
-            'GenericWebHook-JavaScript',
-            'GitHubWebHook-JavaScript',
-            'HttpTriggerWithParameters-JavaScript',
-            'ManualTrigger-JavaScript'
+            'GenericWebHook',
+            'GitHubWebHook',
+            'HttpTriggerWithParameters',
+            'ManualTrigger'
         ]);
+        return verifiedTemplateIds.map(t => `${t}-JavaScript`);
     } else {
         // For JavaScript, only include triggers that require extensions in v2. v1 doesn't have the same support for 'func extensions install'
         verifiedTemplateIds = verifiedTemplateIds.concat([
-            'CosmosDBTrigger-JavaScript',
-            'DurableFunctionsActivity-JavaScript',
-            'DurableFunctionsHttpStart-JavaScript',
-            'DurableFunctionsOrchestrator-JavaScript',
-            'EventGridTrigger-JavaScript',
-            'EventHubTrigger-JavaScript',
-            'ServiceBusQueueTrigger-JavaScript',
-            'ServiceBusTopicTrigger-JavaScript',
-            'SendGrid-JavaScript',
-            'IoTHubTrigger-JavaScript',
+            'CosmosDBTrigger',
+            'DurableFunctionsActivity',
+            'DurableFunctionsHttpStart',
+            'DurableFunctionsOrchestrator',
+            'EventGridTrigger',
+            'EventHubTrigger',
+            'ServiceBusQueueTrigger',
+            'ServiceBusTopicTrigger',
+            'SendGrid',
+            'IoTHubTrigger',
         ]);
 
-        const javaScriptTemplateIds: string[] = verifiedTemplateIds;
-
         // These languages are only supported in v2+ - same functions as JavaScript, with a few minor exceptions that aren't worth distinguishing here
-        verifiedTemplateIds = verifiedTemplateIds.concat(javaScriptTemplateIds.map(t => t.replace('JavaScript', 'Python')));
-        verifiedTemplateIds = verifiedTemplateIds.concat(javaScriptTemplateIds.map(t => t.replace('JavaScript', 'TypeScript')));
-        verifiedTemplateIds = verifiedTemplateIds.concat(javaScriptTemplateIds.map(t => t.replace('JavaScript', 'PowerShell')));
-        verifiedTemplateIds = verifiedTemplateIds.concat(javaScriptTemplateIds.map(t => t.replace('JavaScript', 'Custom')));
+        return verifiedTemplateIds.map(t => new RegExp(`^${t}-(JavaScript|TypeScript|Python|PowerShell|Custom)$`, 'i'));
     }
-
-    return verifiedTemplateIds;
 }

--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -6,7 +6,7 @@
 import * as semver from 'semver';
 import { IActionContext } from 'vscode-azureextensionui';
 import { ext, TemplateSource } from '../extensionVariables';
-import { FuncVersion, getMajorVersion, isPreviewVersion } from '../FuncVersion';
+import { FuncVersion, getMajorVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { feedUtils } from './feedUtils';
 
@@ -58,10 +58,13 @@ export namespace cliFeedUtils {
         const majorVersion: string = getMajorVersion(version);
         let tag: string = 'v' + majorVersion;
         const templateProvider = ext.templateProvider.get(context);
-        if (isPreviewVersion(version)) {
-            tag = tag + '-preview';
-        } else if (templateProvider.templateSource === TemplateSource.Staging) {
-            tag = tag + '-prerelease';
+        if (templateProvider.templateSource === TemplateSource.Staging) {
+            const newTag = tag + '-prerelease';
+            if (cliFeed.tags[newTag]) {
+                tag = newTag;
+            } else {
+                ext.outputChannel.appendLog(localize('versionWithoutStaging', 'WARNING: Azure Functions v{0} does not support the staging template source. Using default template source instead.', majorVersion))
+            }
         }
 
         const releaseData = cliFeed.tags[tag];

--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
-import { allTemplateSources } from '../global.test';
+import { allTemplateSources, isLongRunningVersion } from '../global.test';
 import { getRotatingAuthLevel } from '../nightly/getRotatingValue';
 import { runWithFuncSetting } from '../runWithSetting';
 import { CreateFunctionTestCase, FunctionTesterBase } from './FunctionTesterBase';
@@ -44,6 +44,9 @@ for (const source of allTemplateSources) {
     addSuite(FuncVersion.v2, 'netcoreapp2.1', source);
     addSuite(FuncVersion.v3, 'netcoreapp3.1', source);
     addSuite(FuncVersion.v3, 'net5.0', source, true);
+    addSuite(FuncVersion.v4, 'net5.0', source, true);
+    addSuite(FuncVersion.v4, 'net6.0', source, true);
+    addSuite(FuncVersion.v4, 'net6.0', source, false);
 }
 
 function addSuite(version: FuncVersion, targetFramework: string, source: TemplateSource, isIsolated?: boolean): void {
@@ -76,8 +79,7 @@ function addSuite(version: FuncVersion, targetFramework: string, source: Templat
             functionName: 'Azure Event Grid trigger',
             inputs: [
                 'TestCompany.TestFunction'
-            ],
-            skip: version === FuncVersion.v2 // https://github.com/microsoft/vscode-azurefunctions/issues/792
+            ]
         },
         {
             functionName: 'Azure Event Hub trigger',
@@ -154,6 +156,7 @@ function addSuite(version: FuncVersion, targetFramework: string, source: Templat
     tester.addParallelSuite(testCases, {
         title,
         timeoutMS: 60 * 1000,
+        isLongRunning: isLongRunningVersion(version),
         suppressParallel: true, // lots of errors like "The process cannot access the file because it is being used by another process" 😢
         addTests: () => {
             if (version === FuncVersion.v2) {

--- a/test/createFunction/createFunction.CSharpScript.test.ts
+++ b/test/createFunction/createFunction.CSharpScript.test.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
-import { allTemplateSources } from '../global.test';
+import { allTemplateSources, shouldSkipVersion } from '../global.test';
 import { getDotnetScriptValidateOptions, validateProject } from '../project/validateProject';
 import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
@@ -30,12 +30,18 @@ for (const source of allTemplateSources) {
     // NOTE: Only need to test v1 since v2+ emphasizes C# class libraries instead of C#Script
     const tester: CSharpScriptFunctionTester = new CSharpScriptFunctionTester(source);
     suite(tester.suiteName, function (this: Mocha.Suite): void {
-        suiteSetup(async () => {
+        suiteSetup(async function (this: Mocha.Context): Promise<void> {
+            if (shouldSkipVersion(tester.version)) {
+                this.skip();
+            }
+
             await tester.initAsync();
         });
 
         suiteTeardown(async () => {
-            await tester.dispose();
+            if (!shouldSkipVersion(tester.version)) {
+                await tester.dispose();
+            }
         });
 
         // Intentionally testing IoTHub trigger since a partner team plans to use that

--- a/test/createFunction/createFunction.JavaScript.v1.test.ts
+++ b/test/createFunction/createFunction.JavaScript.v1.test.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting, TemplateSource } from '../../extension.bundle';
-import { allTemplateSources } from '../global.test';
+import { allTemplateSources, shouldSkipVersion } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { FunctionTesterBase } from './FunctionTesterBase';
 
@@ -28,12 +28,18 @@ class JSFunctionTesterV1 extends FunctionTesterBase {
 for (const source of allTemplateSources) {
     const jsTester: JSFunctionTesterV1 = new JSFunctionTesterV1(source);
     suite(jsTester.suiteName, function (this: Mocha.Suite): void {
-        suiteSetup(async () => {
+        suiteSetup(async function (this: Mocha.Context): Promise<void> {
+            if (shouldSkipVersion(jsTester.version)) {
+                this.skip();
+            }
+
             await jsTester.initAsync();
         });
 
         suiteTeardown(async () => {
-            await jsTester.dispose();
+            if (!shouldSkipVersion(jsTester.version)) {
+                await jsTester.dispose();
+            }
         });
 
         const blobTrigger: string = 'Blob trigger';

--- a/test/createFunction/createFunction.Script.v2.test.ts
+++ b/test/createFunction/createFunction.Script.v2.test.ts
@@ -6,7 +6,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../../extension.bundle';
-import { allTemplateSources } from '../global.test';
+import { allTemplateSources, isLongRunningVersion } from '../global.test';
 import { getRotatingAuthLevel } from '../nightly/getRotatingValue';
 import { runWithFuncSetting } from '../runWithSetting';
 import { CreateFunctionTestCase, FunctionTesterBase } from './FunctionTesterBase';
@@ -55,7 +55,7 @@ class PowerShellFunctionTester extends FunctionTesterBase {
     }
 }
 
-for (const version of [FuncVersion.v2, FuncVersion.v3]) {
+for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
     for (const source of allTemplateSources) {
         addSuite(new JavaScriptFunctionTester(version, source));
         addSuite(new TypeScriptFunctionTester(version, source));
@@ -162,6 +162,7 @@ function addSuite(tester: FunctionTesterBase): void {
     ];
 
     tester.addParallelSuite(testCases, {
+        isLongRunning: isLongRunningVersion(tester.version),
         addTests: () => {
             // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-local-function
             test('createFunction API (deprecated)', async () => {

--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -6,7 +6,7 @@
 import * as assert from 'assert';
 import { runWithTestActionContext } from 'vscode-azureextensiondev';
 import { CentralTemplateProvider, FuncVersion, IFunctionTemplate, ProjectLanguage, TemplateFilter, TemplateSource } from '../extension.bundle';
-import { getTestWorkspaceFolder, longRunningTestsEnabled, runForTemplateSource, skipStagingTemplateSource } from './global.test';
+import { getTestWorkspaceFolder, longRunningTestsEnabled, runForTemplateSource, shouldSkipVersion, skipStagingTemplateSource } from './global.test';
 import { javaUtils } from './utils/javaUtils';
 
 addSuite(undefined);
@@ -27,16 +27,23 @@ function addSuite(source: TemplateSource | undefined): void {
             { language: ProjectLanguage.JavaScript, version: FuncVersion.v1, expectedCount: 8 },
             { language: ProjectLanguage.JavaScript, version: FuncVersion.v2, expectedCount: 14 },
             { language: ProjectLanguage.JavaScript, version: FuncVersion.v3, expectedCount: 14 },
+            { language: ProjectLanguage.JavaScript, version: FuncVersion.v4, expectedCount: 14 },
             { language: ProjectLanguage.CSharp, version: FuncVersion.v1, expectedCount: 12 },
-            { language: ProjectLanguage.CSharp, version: FuncVersion.v2, expectedCount: 10 },
+            { language: ProjectLanguage.CSharp, version: FuncVersion.v2, expectedCount: 11 },
             { language: ProjectLanguage.CSharp, version: FuncVersion.v3, expectedCount: 12, projectTemplateKey: 'netcoreapp3.1' },
             { language: ProjectLanguage.CSharp, version: FuncVersion.v3, expectedCount: 9, projectTemplateKey: 'net5.0-isolated' },
+            { language: ProjectLanguage.CSharp, version: FuncVersion.v4, expectedCount: 12, projectTemplateKey: 'net6.0' },
+            { language: ProjectLanguage.CSharp, version: FuncVersion.v4, expectedCount: 9, projectTemplateKey: 'net5.0-isolated' },
+            { language: ProjectLanguage.CSharp, version: FuncVersion.v4, expectedCount: 9, projectTemplateKey: 'net6.0-isolated' },
             { language: ProjectLanguage.Python, version: FuncVersion.v2, expectedCount: 12 },
             { language: ProjectLanguage.Python, version: FuncVersion.v3, expectedCount: 12 },
+            { language: ProjectLanguage.Python, version: FuncVersion.v4, expectedCount: 12 },
             { language: ProjectLanguage.TypeScript, version: FuncVersion.v2, expectedCount: 14 },
             { language: ProjectLanguage.TypeScript, version: FuncVersion.v3, expectedCount: 14 },
+            { language: ProjectLanguage.TypeScript, version: FuncVersion.v4, expectedCount: 14 },
             { language: ProjectLanguage.PowerShell, version: FuncVersion.v2, expectedCount: 14 },
             { language: ProjectLanguage.PowerShell, version: FuncVersion.v3, expectedCount: 14 },
+            { language: ProjectLanguage.PowerShell, version: FuncVersion.v4, expectedCount: 14 },
             { language: ProjectLanguage.Java, version: FuncVersion.v2, expectedCount: 4 }
             // https://github.com/microsoft/vscode-azurefunctions/issues/1605
             // { language: ProjectLanguage.Java, version: FuncVersion.v3, expectedCount: 4}]
@@ -53,7 +60,7 @@ function addSuite(source: TemplateSource | undefined): void {
                 testName += ` ${projectTemplateKey}`;
             }
             test(testName, async function (this: Mocha.Context): Promise<void> {
-                if (source === TemplateSource.Staging && skipStagingTemplateSource) {
+                if ((source === TemplateSource.Staging && skipStagingTemplateSource) || shouldSkipVersion(version)) {
                     this.skip();
                 }
 

--- a/test/test.code-workspace
+++ b/test/test.code-workspace
@@ -32,6 +32,7 @@
         }
     ],
     "settings": {
-        "debug.internalConsoleOptions": "neverOpen"
+        "debug.internalConsoleOptions": "neverOpen",
+        "azureFunctions.showHiddenStacks": true
     }
 }

--- a/test/updateBackupTemplates.ts
+++ b/test/updateBackupTemplates.ts
@@ -31,17 +31,14 @@ suite('Backup templates', () => {
             { language: ProjectLanguage.JavaScript, versions: allVersions },
             { language: ProjectLanguage.CSharp, versions: [FuncVersion.v1, FuncVersion.v2] },
             { language: ProjectLanguage.CSharp, projectTemplateKey: 'netcoreapp3.1', versions: [FuncVersion.v3] },
-            { language: ProjectLanguage.CSharp, projectTemplateKey: 'net5.0-isolated', versions: [FuncVersion.v3] },
-            { language: ProjectLanguage.Java, versions: [FuncVersion.v2, FuncVersion.v3] }
+            { language: ProjectLanguage.CSharp, projectTemplateKey: 'net5.0-isolated', versions: [FuncVersion.v3, FuncVersion.v4] },
+            { language: ProjectLanguage.CSharp, projectTemplateKey: 'net6.0', versions: [FuncVersion.v4] },
+            { language: ProjectLanguage.CSharp, projectTemplateKey: 'net6.0-isolated', versions: [FuncVersion.v4] },
+            { language: ProjectLanguage.Java, versions: [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4] }
         ];
 
         for (const worker of workers) {
             for (const version of Object.values(FuncVersion)) {
-                if (version === FuncVersion.v4) {
-                    // v4 doesn't have templates yet
-                    continue;
-                }
-
                 if (!worker.versions?.includes(version)) {
                     continue;
                 }


### PR DESCRIPTION
I had to make the following changes for v4 templates to work:
1. Ignore the version in the c# template id (i.e. `Azure.Function.CSharp.HttpTrigger.3.x`) instead of trying to filter by it. That version isn't staying up to date and as of https://github.com/microsoft/vscode-azurefunctions/pull/2709 the templates are cached separately for each version anyways
2. The cli-feed will not be using "v4-preview" as a tag (similar to what they did for v3). Instead they will just use "v4" and "v4-prerelease" (for staging). I updated our logic accordingly

The rest is just updating unit tests to cover v4. I decided to move v1 & v2 tests to nightly-only to keep PR builds from getting even longer