### PR TITLE
Remove dependency of functions maven plugin for java templates

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -95,7 +95,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             const executeSteps: AzureWizardExecuteStep<IFunctionWizardContext>[] = [];
             switch (context.language) {
                 case ProjectLanguage.Java:
-                    executeSteps.push(await JavaFunctionCreateStep.createStep(context));
+                    executeSteps.push(new JavaFunctionCreateStep());
                     break;
                 case ProjectLanguage.CSharp:
                 case ProjectLanguage.FSharp:

--- a/src/commands/createFunction/javaSteps/IJavaFunctionWizardContext.ts
+++ b/src/commands/createFunction/javaSteps/IJavaFunctionWizardContext.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IFunctionTemplate } from '../../../templates/IFunctionTemplate';
+import { IFunctionWizardContext } from '../IFunctionWizardContext';
+
+export interface IJavaFunctionWizardContext extends IFunctionWizardContext {
+    functionTemplate?: IJavaFunctionTemplate;
+}
+
+export interface IJavaFunctionTemplate extends IFunctionTemplate {
+    templateFiles: { [filename: string]: string };
+}

--- a/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
@@ -46,7 +46,7 @@ export class JavaFunctionCreateStep extends FunctionCreateStepBase<IFunctionWiza
 }
 
 function substituteParametersInTemplate(template: IJavaFunctionTemplate, args: Map<string, string>): string {
-    var javaTemplate = template.templateFiles["function.java"];
+    let javaTemplate = template.templateFiles["function.java"];
     args.forEach((value: string, key: string) => {
         javaTemplate = javaTemplate.replace(new RegExp(`\\$${key}\\$`, 'g'), value);
     });

--- a/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as fse from 'fs-extra';
-import { IActionContext } from 'vscode-azureextensionui';
-import { mavenUtils } from "../../../utils/mavenUtils";
 import { nonNullProp } from '../../../utils/nonNull';
 import { getJavaFunctionFilePath, IJavaProjectWizardContext } from '../../createNewProject/javaSteps/IJavaProjectWizardContext';
 import { FunctionCreateStepBase } from '../FunctionCreateStepBase';
@@ -12,14 +10,6 @@ import { getBindingSetting, IFunctionWizardContext } from '../IFunctionWizardCon
 import { IJavaFunctionTemplate, IJavaFunctionWizardContext } from './IJavaFunctionWizardContext';
 
 export class JavaFunctionCreateStep extends FunctionCreateStepBase<IFunctionWizardContext & IJavaProjectWizardContext> {
-    private constructor() {
-        super();
-    }
-
-    public static async createStep(context: IActionContext): Promise<JavaFunctionCreateStep> {
-        await mavenUtils.validateMavenInstalled(context);
-        return new JavaFunctionCreateStep();
-    }
 
     public async executeCore(context: IJavaFunctionWizardContext & IJavaProjectWizardContext): Promise<string> {
         const template: IJavaFunctionTemplate = nonNullProp(context, 'functionTemplate');

--- a/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
@@ -21,7 +21,7 @@ export class JavaFunctionCreateStep extends FunctionCreateStepBase<IFunctionWiza
             const value = getBindingSetting(context, setting);
             // NOTE: Explicitly checking against undefined. Empty string is a valid value
             if (value !== undefined) {
-                const fixedValue: string = setting.name === "authLevel" ? String(value).toUpperCase() : String(value);
+                const fixedValue: string = setting.valueType === 'enum' ? String(value).toUpperCase() : String(value);
                 args.set(setting.name, fixedValue);
             }
         }


### PR DESCRIPTION
### Issues to resolve
Currently we use functions maven plugin to get java function templates and generate new function, which has a hard dependency for maven plugin and could not work for java projects with other build tools like gradle. 
Besides, create new function with maven may have poor performance as maven goal may take much time to initialization.

### Solution
- Create Java Function class by ts directly instead of invoke `mvn functions:add`
- Refactor java template provider to get latest template from remote resource

### Next steps
In this PR I still use the version of functions maven plugin as the template version to keep compatibility with history data, we may need set the version for template in the future.
