### PR TITLE
Add net6.0 to JsonCli

### DIFF
--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -31,18 +31,25 @@ jobs:
     inputs:
       version: 5.0.x
 
-  - task: NuGetCommand@2
-    displayName: 'restore'
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 6.0.x'
     inputs:
-      restoreSolution: '$(ProjectPath)'
+      version: 6.0.x
+      includePreviewVersions: true
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: '$(ProjectPath)'
       feedsToUse: config
       nugetConfigPath: '$(NugetConfigPath)'
 
-  - task: MSBuild@1
-    displayName: 'build'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build'
     inputs:
-      solution: '$(ProjectPath)'
-      configuration: '$(BuildConfiguration)'
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration)'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet publish 2.0'
@@ -74,6 +81,16 @@ jobs:
       zipAfterPublish: false
       modifyOutputPath: false
 
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 6.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework net6.0 --no-build'
+      zipAfterPublish: false
+      modifyOutputPath: false
+
   - task: DeleteFiles@1
     displayName: 'Delete unneeded publish files'
     inputs:
@@ -83,23 +100,26 @@ jobs:
         bin/**/publish/**/*.pdb
 
   # Run before we build the signing project, because we don't want to analyze that
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
     displayName: 'Run Roslyn Analyzers'
     continueOnError: true
     condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
-
-  - task: NuGetCommand@2
-    displayName: 'restore signing project'
     inputs:
-      restoreSolution: '$(SigningProjectPath)'
+      msBuildCommandline: '$(Agent.ToolsDirectory)\dotnet\dotnet.exe build "$(Build.SourcesDirectory)\$(ProjectPath)" --configuration $(BuildConfiguration)'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore signing'
+    inputs:
+      command: restore
+      projects: '$(SigningProjectPath)'
       feedsToUse: config
       nugetConfigPath: '$(NugetConfigPath)'
 
-  - task: MSBuild@1
-    displayName: 'build signing project'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build signing'
     inputs:
-      solution: '$(SigningProjectPath)'
-      configuration: '$(BuildConfiguration)'
+      projects: '$(SigningProjectPath)'
+      arguments: '--configuration $(BuildConfiguration)'
 
   - task: CopyFiles@2
     displayName: 'Copy Files to Staging'

--- a/tools/JsonCli/.vscode/tasks.json
+++ b/tools/JsonCli/.vscode/tasks.json
@@ -58,6 +58,22 @@
                 "${workspaceFolder}/src/Microsoft.TemplateEngine.JsonCli.csproj"
             ],
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish (6.0)",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "--configuration",
+                "Release",
+                "--framework",
+                "net6.0",
+                "--output",
+                "${workspaceFolder}/../../resources/dotnetJsonCli/net6.0/",
+                "${workspaceFolder}/src/Microsoft.TemplateEngine.JsonCli.csproj"
+            ],
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
+++ b/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\resources\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
         <DelaySign>true</DelaySign>

--- a/tools/JsonCli/src/Signing.csproj
+++ b/tools/JsonCli/src/Signing.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
         <!-- Since this project is just for signing, we don't want to actually build anything -->
         <DefaultItemExcludes>$(DefaultItemExcludes);**/*.cs</DefaultItemExcludes>
     </PropertyGroup>

--- a/tools/JsonCli/src/nuget.config
+++ b/tools/JsonCli/src/nuget.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <!-- based off of this repo's nuget config https://github.com/dotnet/sdk/blob/master/NuGet.config -->
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <!-- used for signing -->


### PR DESCRIPTION
The NuGet and MSBuild tasks didn't play well with .NET 6 (I think because it's still in preview), so I switched to DotNetCoreCLI tasks and that seemed to fix it.