### PR TITLE
Add setting for funcCliPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1052,6 +1052,11 @@
                             "%azureFunctions.templateSource.staging%",
                             "%azureFunctions.templateSource.backup%"
                         ]
+                    },
+                    "azureFunctions.funcCliPath": {
+                        "scope": "resource",
+                        "type": "string",
+                        "description": "%azureFunctions.funcCliPath%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -34,6 +34,7 @@
     "azureFunctions.enableOutputTimestamps": "Prepends each line displayed in the output channel with a timestamp.",
     "azureFunctions.enableRemoteDebugging": "Enable remote debugging for Node.js Function Apps running on Linux App Service plans. Consumption plans are not supported. (experimental)",
     "azureFunctions.executeFunction": "Execute Function Now...",
+    "azureFunctions.funcCliPath": "The path to the 'func' executable to use for debug and deploy tasks. For example, set it to 'node_modules/.bin/func' if using the func cli installed as a local npm package.",
     "azureFunctions.initProjectForVSCode": "Initialize Project for Use with VS Code...",
     "azureFunctions.installOrUpdateFuncCoreTools": "Install or Update Azure Functions Core Tools",
     "azureFunctions.loadMore": "Load More",

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -41,8 +41,6 @@ export async function createFunctionFromCommand(
 }
 
 export async function createFunctionInternal(context: IActionContext, options: api.ICreateFunctionOptions): Promise<void> {
-    addLocalFuncTelemetry(context);
-
     let workspaceFolder: WorkspaceFolder | undefined;
     let workspacePath: string | undefined = options.folderPath;
     if (workspacePath === undefined) {
@@ -51,6 +49,8 @@ export async function createFunctionInternal(context: IActionContext, options: a
     } else {
         workspaceFolder = getContainingWorkspace(workspacePath);
     }
+
+    addLocalFuncTelemetry(context, workspacePath);
 
     const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder || workspacePath, options);
     if (!projectPath) {

--- a/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PowerShellProjectCreateStep.ts
@@ -67,7 +67,7 @@ export class PowerShellProjectCreateStep extends ScriptProjectCreateStep {
     private readonly azModuleGalleryUrl: string = `https://aka.ms/PwshPackageInfo?id='${this.azModuleName}'`;
 
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        if (await hasMinFuncCliVersion('3.0.2534', context.version)) {
+        if (await hasMinFuncCliVersion(context, '3.0.2534', context.version)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             this.localSettingsJson.Values![workerRuntimeVersionKey] = '~7';
         }

--- a/src/commands/createNewProject/ProjectCreateStep/PythonProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PythonProjectCreateStep.ts
@@ -40,7 +40,7 @@ export class PythonProjectCreateStep extends ScriptProjectCreateStep {
         if (await confirmOverwriteFile(context, requirementsPath)) {
             let isOldFuncCli: boolean;
             try {
-                const currentVersion: string | null = await getLocalFuncCoreToolsVersion();
+                const currentVersion: string | null = await getLocalFuncCoreToolsVersion(context, context.workspacePath);
                 isOldFuncCli = !!currentVersion && semver.lte(currentVersion, oldFuncVersion);
             } catch {
                 isOldFuncCli = false;

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -43,10 +43,10 @@ export async function createNewProjectFromCommand(
 }
 
 export async function createNewProjectInternal(context: IActionContext, options: api.ICreateFunctionOptions): Promise<void> {
-    addLocalFuncTelemetry(context);
+    addLocalFuncTelemetry(context, undefined);
 
     const language: ProjectLanguage | undefined = <ProjectLanguage>options.language || getGlobalSetting(projectLanguageSetting);
-    const version: string = options.version || getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion() || latestGAVersion;
+    const version: string = options.version || getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion(context, undefined) || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
     const wizardContext: Partial<IFunctionWizardContext> & IActionContext = Object.assign(context, options, { language, version: tryParseFuncVersion(version), projectTemplateKey });
 

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -13,7 +13,7 @@ const java8: string = '8';
 
 export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
     public static async setDefaultVersion(context: IJavaProjectWizardContext): Promise<void> {
-        if (!await hasMinFuncCliVersion('3.0.2630', context.version)) {
+        if (!await hasMinFuncCliVersion(context, '3.0.2630', context.version)) {
             context.javaVersion = java8;
         }
     }

--- a/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
+++ b/src/commands/createNewProject/pythonSteps/EnterPythonAliasStep.ts
@@ -13,7 +13,7 @@ export class EnterPythonAliasStep extends AzureWizardPromptStep<IPythonVenvWizar
 
     public async prompt(context: IPythonVenvWizardContext): Promise<void> {
         const prompt: string = localize('pyAliasPlaceholder', 'Enter the Python interpreter or full path');
-        const supportedVersions: string[] = await getSupportedPythonVersions(context.version);
+        const supportedVersions: string[] = await getSupportedPythonVersions(context, context.version);
         context.pythonAlias = await context.ui.showInputBox({ prompt, validateInput: async (value: string): Promise<string | undefined> => await validatePythonAlias(supportedVersions, value) });
     }
 

--- a/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
+++ b/src/commands/createNewProject/pythonSteps/PythonAliasListStep.ts
@@ -42,7 +42,7 @@ export class PythonAliasListStep extends AzureWizardPromptStep<IPythonVenvWizard
 }
 
 async function getPicks(context: IPythonVenvWizardContext): Promise<IAzureQuickPickItem<string | boolean>[]> {
-    const supportedVersions: string[] = await getSupportedPythonVersions(context.version);
+    const supportedVersions: string[] = await getSupportedPythonVersions(context, context.version);
 
     const aliasesToTry: string[] = ['python3', 'python', 'py'];
     for (const version of supportedVersions) {

--- a/src/commands/createNewProject/pythonSteps/pythonVersion.ts
+++ b/src/commands/createNewProject/pythonSteps/pythonVersion.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as semver from 'semver';
+import { IActionContext } from 'vscode-azureextensionui';
 import { ext } from '../../../extensionVariables';
 import { getLocalFuncCoreToolsVersion } from '../../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { FuncVersion, getMajorVersion } from '../../../FuncVersion';
@@ -24,9 +25,9 @@ export async function getPythonVersion(pyAlias: string): Promise<string> {
     }
 }
 
-export async function getSupportedPythonVersions(funcVersionFromSetting: FuncVersion): Promise<string[]> {
+export async function getSupportedPythonVersions(context: IActionContext, funcVersionFromSetting: FuncVersion): Promise<string[]> {
     // Cache the task so we're not waiting on this every time
-    const localVersionTask: Promise<string | null> = getLocalFuncCoreToolsVersion();
+    const localVersionTask: Promise<string | null> = getLocalFuncCoreToolsVersion(context, undefined);
 
     const result: string[] = [];
 

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -34,9 +34,10 @@ export async function deploySlot(context: IActionContext, target?: vscode.Uri | 
 }
 
 async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string | SlotTreeItemBase | undefined, arg2: string | {} | undefined, expectedContextValue: string): Promise<void> {
-    addLocalFuncTelemetry(actionContext);
-
     const deployPaths: IDeployPaths = await getDeployFsPath(actionContext, arg1);
+
+    addLocalFuncTelemetry(actionContext, deployPaths.workspaceFolder.uri.fsPath);
+
     const context: IDeployContext = Object.assign(actionContext, deployPaths, { defaultAppSetting: 'defaultFunctionAppToDeploy' });
     const node: SlotTreeItemBase = await getDeployNode(context, ext.tree, arg1, arg2, expectedContextValue);
 

--- a/src/commands/deploy/runPreDeployTask.ts
+++ b/src/commands/deploy/runPreDeployTask.ts
@@ -17,7 +17,7 @@ export async function runPreDeployTask(context: IDeployContext, deployFsPath: st
     const preDeployTask: string | undefined = getWorkspaceSetting(preDeployTaskSetting, deployFsPath);
     if (preDeployTask && preDeployTask.startsWith('func:')) {
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to run preDeployTask "{0}".', preDeployTask);
-        if (!await validateFuncCoreToolsInstalled(context, message, deployFsPath)) {
+        if (!await validateFuncCoreToolsInstalled(context, message, context.workspaceFolder.uri.fsPath)) {
             throw new UserCancelledError('validateFuncCoreToolsInstalled');
         }
     }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/ScriptInitVSCodeStep.ts
@@ -39,7 +39,7 @@ export class ScriptInitVSCodeStep extends InitVSCodeStepBase {
                 this.useFuncExtensionsInstall = true;
                 context.telemetry.properties.hasExtensionsCsproj = 'true';
             } else if (context.version === FuncVersion.v2) { // no need to check v1 or v3+
-                const currentVersion: string | null = await getLocalFuncCoreToolsVersion();
+                const currentVersion: string | null = await getLocalFuncCoreToolsVersion(context, context.workspacePath);
                 // Starting after this version, projects can use extension bundle instead of running "func extensions install"
                 this.useFuncExtensionsInstall = !!currentVersion && semver.lte(currentVersion, '2.5.553');
             }

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -43,7 +43,7 @@ export async function initProjectForVSCode(context: IActionContext, fsPath?: str
     }
 
     language = language || getGlobalSetting(projectLanguageSetting) || await detectProjectLanguage(context, projectPath);
-    const version: FuncVersion = getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion() || latestGAVersion;
+    const version: FuncVersion = getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion(context, workspacePath) || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
 
     const wizardContext: IProjectWizardContext = Object.assign(context, { projectPath, workspacePath, language, version, workspaceFolder, projectTemplateKey });

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -49,7 +49,7 @@ export namespace ext {
     export let azureAccountTreeItem: AzureAccountTreeItemWithProjects;
     export let outputChannel: IAzExtOutputChannel;
     // eslint-disable-next-line prefer-const
-    export let funcCliPath: string = func;
+    export let defaultFuncCliPath: string = func;
     export let ignoreBundle: boolean | undefined;
     export const prefix: string = 'azureFunctions';
     export let experimentationService: IExperimentationServiceAdapter;

--- a/src/funcCoreTools/getFuncCliPath.ts
+++ b/src/funcCoreTools/getFuncCliPath.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { WorkspaceFolder } from "vscode";
+import { IActionContext } from "vscode-azureextensionui";
+import { ext } from "../extensionVariables";
+import { localize } from "../localize";
+import { getWorkspaceSetting } from "../vsCodeConfig/settings";
+
+const settingKey = 'funcCliPath';
+
+export async function getFuncCliPath(context: IActionContext, workspacePath: WorkspaceFolder | string | undefined): Promise<string> {
+    const valueFromSetting = getWorkspaceSetting<string>(settingKey, workspacePath);
+    if (valueFromSetting) {
+        context.telemetry.properties.funcCliSource = 'setting';
+        return valueFromSetting;
+    } else {
+        return ext.defaultFuncCliPath;
+    }
+}
+
+export function validateNoFuncCliSetting(): void {
+    if (hasFuncCliSetting()) {
+        throw new Error(localize('notSupportedWithSetting', 'This operation is not supported when "{0}.{1}" is set.', ext.prefix, settingKey));
+    }
+}
+
+export function hasFuncCliSetting(): boolean {
+    return !!getWorkspaceSetting<string>(settingKey);
+}

--- a/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
+++ b/src/funcCoreTools/getLocalFuncCoreToolsVersion.ts
@@ -5,11 +5,12 @@
 
 import * as semver from 'semver';
 import { IActionContext } from 'vscode-azureextensionui';
-import { ext } from '../extensionVariables';
 import { cpUtils } from '../utils/cpUtils';
+import { getFuncCliPath } from './getFuncCliPath';
 
-export async function getLocalFuncCoreToolsVersion(): Promise<string | null> {
-    const output: string = await cpUtils.executeCommand(undefined, undefined, ext.funcCliPath, '--version');
+export async function getLocalFuncCoreToolsVersion(context: IActionContext, workspacePath: string | undefined): Promise<string | null> {
+    const funcCliPath = await getFuncCliPath(context, workspacePath);
+    const output: string = await cpUtils.executeCommand(undefined, workspacePath, funcCliPath, '--version');
     const version: string | null = semver.clean(output);
     if (version) {
         return version;
@@ -28,10 +29,10 @@ export async function getLocalFuncCoreToolsVersion(): Promise<string | null> {
     }
 }
 
-export function addLocalFuncTelemetry(context: IActionContext): void {
+export function addLocalFuncTelemetry(context: IActionContext, workspacePath: string | undefined): void {
     context.telemetry.properties.funcCliVersion = 'unknown';
 
-    getLocalFuncCoreToolsVersion().then((version: string) => {
+    getLocalFuncCoreToolsVersion(context, workspacePath).then((version: string) => {
         context.telemetry.properties.funcCliVersion = version || 'none';
     }).catch(() => {
         context.telemetry.properties.funcCliVersion = 'none';

--- a/src/funcCoreTools/hasMinFuncCliVersion.ts
+++ b/src/funcCoreTools/hasMinFuncCliVersion.ts
@@ -5,10 +5,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as semver from 'semver';
+import { IActionContext } from 'vscode-azureextensionui';
 import { FuncVersion, getMajorVersion } from "../FuncVersion";
 import { getLocalFuncCoreToolsVersion } from './getLocalFuncCoreToolsVersion';
 
-export async function hasMinFuncCliVersion(minVersion: string, projectVersion: FuncVersion): Promise<boolean> {
+export async function hasMinFuncCliVersion(context: IActionContext, minVersion: string, projectVersion: FuncVersion): Promise<boolean> {
     const majorVersion: string = getMajorVersion(projectVersion);
     if (semver.gtr(minVersion, majorVersion)) {
         return false;
@@ -16,7 +17,7 @@ export async function hasMinFuncCliVersion(minVersion: string, projectVersion: F
         return true;
     } else {
         try {
-            const localCliVersion: string | null = await getLocalFuncCoreToolsVersion();
+            const localCliVersion: string | null = await getLocalFuncCoreToolsVersion(context, undefined);
             if (localCliVersion) {
                 return semver.gte(localCliVersion, minVersion);
             }

--- a/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
+++ b/src/funcCoreTools/installOrUpdateFuncCoreTools.ts
@@ -7,6 +7,7 @@ import { IActionContext, IAzureQuickPickItem } from 'vscode-azureextensionui';
 import { PackageManager } from '../constants';
 import { FuncVersion, promptForFuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
+import { validateNoFuncCliSetting } from './getFuncCliPath';
 import { getFuncPackageManagers } from './getFuncPackageManagers';
 import { installFuncCoreTools } from './installFuncCoreTools';
 import { tryGetLocalFuncVersion } from './tryGetLocalFuncVersion';
@@ -14,7 +15,9 @@ import { updateFuncCoreTools } from './updateFuncCoreTools';
 import { funcToolsInstalled, getInstallUrl } from './validateFuncCoreToolsInstalled';
 
 export async function installOrUpdateFuncCoreTools(context: IActionContext): Promise<void> {
-    const isFuncInstalled: boolean = await funcToolsInstalled();
+    validateNoFuncCliSetting();
+
+    const isFuncInstalled: boolean = await funcToolsInstalled(context, undefined);
     const packageManagers: PackageManager[] = await getFuncPackageManagers(isFuncInstalled);
     if (packageManagers.length === 0) {
         context.errorHandling.suppressReportIssue = true;
@@ -31,7 +34,7 @@ export async function installOrUpdateFuncCoreTools(context: IActionContext): Pro
             packageManager = (await context.ui.showQuickPick(picks, { placeHolder, stepName: 'multipleFuncInstalls' })).data;
         }
 
-        let version: FuncVersion | undefined = await tryGetLocalFuncVersion();
+        let version: FuncVersion | undefined = await tryGetLocalFuncVersion(context, undefined);
         if (version === undefined) {
             version = await promptForFuncVersion(context, localize('selectLocalVersion', 'Failed to detect local version automatically. Select your version to update'));
         }

--- a/src/funcCoreTools/tryGetLocalFuncVersion.ts
+++ b/src/funcCoreTools/tryGetLocalFuncVersion.ts
@@ -3,12 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IActionContext } from 'vscode-azureextensionui';
 import { FuncVersion, tryParseFuncVersion } from '../FuncVersion';
 import { getLocalFuncCoreToolsVersion } from './getLocalFuncCoreToolsVersion';
 
-export async function tryGetLocalFuncVersion(): Promise<FuncVersion | undefined> {
+export async function tryGetLocalFuncVersion(context: IActionContext, workspacePath: string | undefined): Promise<FuncVersion | undefined> {
     try {
-        const version: string | null = await getLocalFuncCoreToolsVersion();
+        const version: string | null = await getLocalFuncCoreToolsVersion(context, workspacePath);
         if (version) {
             return tryParseFuncVersion(version);
         }

--- a/src/funcCoreTools/uninstallFuncCoreTools.ts
+++ b/src/funcCoreTools/uninstallFuncCoreTools.ts
@@ -11,10 +11,13 @@ import { localize } from '../localize';
 import { cpUtils } from '../utils/cpUtils';
 import { nonNullValue } from '../utils/nonNull';
 import { tryGetInstalledBrewPackageName } from './getBrewPackageName';
+import { validateNoFuncCliSetting } from './getFuncCliPath';
 import { getFuncPackageManagers } from './getFuncPackageManagers';
 import { tryGetLocalFuncVersion } from './tryGetLocalFuncVersion';
 
 export async function uninstallFuncCoreTools(context: IActionContext, packageManagers?: PackageManager[]): Promise<void> {
+    validateNoFuncCliSetting();
+
     ext.outputChannel.show();
     packageManagers = packageManagers || await getFuncPackageManagers(true /* isFuncInstalled */);
     let packageManager: PackageManager;
@@ -33,7 +36,7 @@ export async function uninstallFuncCoreTools(context: IActionContext, packageMan
             await cpUtils.executeCommand(ext.outputChannel, undefined, 'npm', 'uninstall', '-g', funcPackageName);
             break;
         case PackageManager.brew:
-            const version: FuncVersion = nonNullValue(await tryGetLocalFuncVersion(), 'localFuncVersion');
+            const version: FuncVersion = nonNullValue(await tryGetLocalFuncVersion(context, undefined), 'localFuncVersion');
             const brewPackageName: string = nonNullValue(await tryGetInstalledBrewPackageName(version), 'brewPackageName');
             await cpUtils.executeCommand(ext.outputChannel, undefined, 'brew', 'uninstall', brewPackageName);
             break;

--- a/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
+++ b/src/funcCoreTools/validateFuncCoreToolsIsLatest.ts
@@ -15,6 +15,7 @@ import { openUrl } from '../utils/openUrl';
 import { requestUtils } from '../utils/requestUtils';
 import { getWorkspaceSetting, updateGlobalSetting } from '../vsCodeConfig/settings';
 import { getBrewPackageName } from './getBrewPackageName';
+import { validateNoFuncCliSetting } from './getFuncCliPath';
 import { getFuncPackageManagers } from './getFuncPackageManagers';
 import { getLocalFuncCoreToolsVersion } from './getLocalFuncCoreToolsVersion';
 import { getNpmDistTag } from "./getNpmDistTag";
@@ -33,6 +34,8 @@ export async function validateFuncCoreToolsIsLatest(): Promise<void> {
         const showCoreToolsWarning: boolean = !!getWorkspaceSetting<boolean>(showCoreToolsWarningKey);
 
         if (showCoreToolsWarning || showMultiCoreToolsWarning) {
+            validateNoFuncCliSetting();
+
             const packageManagers: PackageManager[] = await getFuncPackageManagers(true /* isFuncInstalled */);
             let packageManager: PackageManager;
             if (packageManagers.length === 0) {
@@ -57,7 +60,7 @@ export async function validateFuncCoreToolsIsLatest(): Promise<void> {
             }
 
             if (showCoreToolsWarning) {
-                const localVersion: string | null = await getLocalFuncCoreToolsVersion();
+                const localVersion: string | null = await getLocalFuncCoreToolsVersion(context, undefined);
                 if (!localVersion) {
                     return;
                 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -170,7 +170,7 @@ async function getDefaultFuncVersion(context: IActionContext): Promise<FuncVersi
 
     if (version === undefined) {
         // Try to get the version that matches their local func cli
-        version = await tryGetLocalFuncVersion();
+        version = await tryGetLocalFuncVersion(context, undefined);
         context.telemetry.properties.runtimeSource = 'LocalFuncCli';
     }
 

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -54,7 +54,7 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
     });
 
     // Use prerelease func cli installed from gulp task (unless otherwise specified in env)
-    ext.funcCliPath = process.env.FUNC_PATH || path.join(os.homedir(), 'tools', 'func', 'func');
+    ext.defaultFuncCliPath = process.env.FUNC_PATH || path.join(os.homedir(), 'tools', 'func', 'func');
 
     if (!updateBackupTemplates) {
         await preLoadTemplates();

--- a/test/hasMinFuncCliVersion.test.ts
+++ b/test/hasMinFuncCliVersion.test.ts
@@ -4,26 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { createTestActionContext } from 'vscode-azureextensiondev';
 import { FuncVersion, hasMinFuncCliVersion } from '../extension.bundle';
 
 suite('hasMinFuncCliVersion', () => {
     test('Smaller major version', async () => {
-        const result: boolean = await hasMinFuncCliVersion('2.0.3', FuncVersion.v1);
+        const result: boolean = await hasMinFuncCliVersion(await createTestActionContext(), '2.0.3', FuncVersion.v1);
         assert.strictEqual(result, false);
     });
 
     test('Greater major version', async () => {
-        const result: boolean = await hasMinFuncCliVersion('2.0.3', FuncVersion.v3);
+        const result: boolean = await hasMinFuncCliVersion(await createTestActionContext(), '2.0.3', FuncVersion.v3);
         assert.strictEqual(result, true);
     });
 
     test('Same major version, meets minimum', async () => {
-        const result: boolean = await hasMinFuncCliVersion('3.0.0', FuncVersion.v3);
+        const result: boolean = await hasMinFuncCliVersion(await createTestActionContext(), '3.0.0', FuncVersion.v3);
         assert.strictEqual(result, true);
     });
 
     test('Same major version, doesn\'t meet minimum', async () => {
-        const result: boolean = await hasMinFuncCliVersion('3.9999.0', FuncVersion.v3);
+        const result: boolean = await hasMinFuncCliVersion(await createTestActionContext(), '3.9999.0', FuncVersion.v3);
         assert.strictEqual(result, false);
     });
 });


### PR DESCRIPTION
The main use-case is for users to install the func cli as a dev dependency rather than having to install it globally. Then they would update the new setting to this:

> "azureFunctions.funcCliPath": "node_modules/.bin/func"

However, the setting will also just be a good backup for any users with PATH issues.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2905