### PR TITLE
Respect folderPath option in createFunction api

### DIFF
--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -95,7 +95,7 @@ export async function verifyAndPromptToCreateProject(context: IActionContext, wo
             await context.ui.showWarningMessage(message, { modal: true, stepName: 'notAProject' }, DialogResponses.yes);
         }
 
-        options.folderPath = typeof workspaceFolder === 'string' ? workspaceFolder : workspaceFolder.uri.fsPath;
+        options.folderPath ||= typeof workspaceFolder === 'string' ? workspaceFolder : workspaceFolder.uri.fsPath;
         await createNewProjectInternal(context, options);
         return undefined;
     } else {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -25,8 +25,8 @@ suite(`AzureFunctionsExtensionApi`, () => {
         const functionName: string = 'endpoint1';
         const language: string = ProjectLanguage.JavaScript;
         const workspaceFolder = getTestWorkspaceFolder();
-        const relativeProjectFolder = 'api';
-        const folderPath: string = path.join(workspaceFolder, relativeProjectFolder);
+        const projectSubpath = 'api';
+        const folderPath: string = path.join(workspaceFolder, projectSubpath);
 
         await runWithInputs('api.createFunction', [language, functionName], registerOnActionStartHandler, async () => {
             await api.createFunction({
@@ -40,16 +40,14 @@ suite(`AzureFunctionsExtensionApi`, () => {
             });
         });
 
-        const validateOptions: IValidateProjectOptions = getJavaScriptValidateOptions(true, undefined, relativeProjectFolder);
+        const validateOptions: IValidateProjectOptions = getJavaScriptValidateOptions(true, undefined, projectSubpath, workspaceFolder);
         validateOptions.expectedPaths.push(
-            path.join(relativeProjectFolder, functionName, 'index.js'),
-            path.join(relativeProjectFolder, functionName, 'function.json'),
-            path.join(relativeProjectFolder, 'package.json')
+            path.join(projectSubpath, functionName, 'index.js'),
+            path.join(projectSubpath, functionName, 'function.json'),
+            path.join(projectSubpath, 'package.json')
         );
-        validateOptions.expectedSettings
         // Exclude .git because the test workspace folders are already inside a git repo so we don't do git init.
         validateOptions.excludedPaths?.push('.git');
-        validateOptions.workspaceFolder = workspaceFolder;
         await validateProject(folderPath, validateOptions);
     });
 

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -11,11 +11,11 @@ import { FuncVersion, getContainingWorkspace, IExtensionsJson, ILaunchJson, ITas
 
 const defaultVersion: FuncVersion = FuncVersion.v3;
 
-export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, version: FuncVersion = defaultVersion, relativeProjectFolder?: string): IValidateProjectOptions {
+export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, version: FuncVersion = defaultVersion, projectSubpath?: string, workspaceFolder?: string): IValidateProjectOptions {
     const expectedSettings: { [key: string]: string } = {
         'azureFunctions.projectLanguage': ProjectLanguage.JavaScript,
         'azureFunctions.projectRuntime': version,
-        'azureFunctions.deploySubpath': relativeProjectFolder ?? '.',
+        'azureFunctions.deploySubpath': projectSubpath ?? '.',
         'debug.internalConsoleOptions': 'neverOpen',
     };
     const expectedPaths: string[] = [];
@@ -24,7 +24,7 @@ export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, ve
     if (hasPackageJson) {
         expectedSettings['azureFunctions.preDeployTask'] = 'npm prune (functions)';
         expectedSettings['azureFunctions.postDeployTask'] = 'npm install (functions)';
-        expectedPaths.push(path.join(relativeProjectFolder ?? '.', 'package.json'));
+        expectedPaths.push(path.join(projectSubpath ?? '.', 'package.json'));
         expectedTasks.push('npm install (functions)', 'npm prune (functions)');
     }
 
@@ -39,7 +39,8 @@ export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, ve
             'Attach to Node Functions'
         ],
         expectedTasks,
-        excludedPaths: []
+        excludedPaths: [],
+        workspaceFolder
     };
 }
 


### PR DESCRIPTION
This bug causes unwanted behavior in SWA when adding an HTTP Function (if there isn't already a Functions project in the workspace). 

<!-- Possibly introduced in https://github.com/microsoft/vscode-azurefunctions/pull/2891 -->

A note about the test:

I've added a bare minimum test that will ensure the `createFunction` api respects the folderPath option.

I wanted to add more robust tests that would test each project language and ensure the proper files are created at the root path and the project path. However, I found some things we might want to change with how we create projects in a subpath of a workspace.

Example: Currently creating a JavaScript/TypeScript functions project always creates a package.json at the project path. I'm not sure we want to create nested package.json for users by default. It might be best to edit the existing package.json if it exists in the workspace already.