### PR TITLE
Ensure file before create java function with template

### DIFF
--- a/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
+++ b/src/commands/createFunction/javaSteps/JavaFunctionCreateStep.ts
@@ -30,7 +30,8 @@ export class JavaFunctionCreateStep extends FunctionCreateStepBase<IFunctionWiza
         args.set("className", functionName.replace('-', '_'));
         const content: string = substituteParametersInTemplate(template, args);
         const path: string = getJavaFunctionFilePath(context.projectPath, packageName, functionName);
-        await fse.writeFile(path, content)
+        await fse.ensureFile(path);
+        await fse.writeFile(path, content);
         return getJavaFunctionFilePath(context.projectPath, packageName, functionName);
     }
 }


### PR DESCRIPTION
Ensure file before create java function, fix `No such directory` issue when create function in a new package.