### PR TITLE
Fix debugging issue when a function spawns a child process

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -51,7 +51,8 @@ export function registerFuncHostTaskEvents(): void {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
 
-        if (getWorkspaceSetting<boolean>('stopFuncTaskPostDebug') && debugSession.workspaceFolder) {
+        // NOTE: Only stop the func task if this is the root debug session (aka does not have a parentSession) to fix https://github.com/microsoft/vscode-azurefunctions/issues/2925
+        if (getWorkspaceSetting<boolean>('stopFuncTaskPostDebug') && !debugSession.parentSession && debugSession.workspaceFolder) {
             stopFuncTaskIfRunning(debugSession.workspaceFolder);
         }
     });


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/2925

There's apparently an entire tree of debugSessions, and a new leaf gets created each time a new child process is created. When a user's function leverages a child process and that child process ends, an `onDidTerminateDebugSession` event is fired and we incorrectly assume the entire debug session has ended and stop the func task.
