### PR TITLE
Add .Net 6 nightly deploy test

### DIFF
--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -12,6 +12,22 @@ steps:
   inputs:
     versionSpec: 3.6.x
 
+- task: UseDotNet@2
+  displayName: 'Use .NET sdk 6.0.x'
+  inputs:
+    version: 6.0.x
+    includePreviewVersions: true
+
+- task: UseDotNet@2
+  displayName: 'Use .NET sdk 5.0.x'
+  inputs:
+    version: 5.0.x
+
+- task: UseDotNet@2
+  displayName: 'Use .NET sdk 3.1.x'
+  inputs:
+    version: 3.1.x
+
 - task: Npm@1
   displayName: 'Test'
   inputs:

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -9,9 +9,9 @@ import * as globby from 'globby';
 import * as path from 'path';
 import { FuncVersion, getContainingWorkspace, IExtensionsJson, ILaunchJson, ITasksJson, ProjectLanguage } from '../../extension.bundle';
 
-const defaultVersion: FuncVersion = FuncVersion.v3;
+export const defaultTestFuncVersion: FuncVersion = FuncVersion.v3;
 
-export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, version: FuncVersion = defaultVersion, projectSubpath?: string, workspaceFolder?: string): IValidateProjectOptions {
+export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, version: FuncVersion = defaultTestFuncVersion, projectSubpath?: string, workspaceFolder?: string): IValidateProjectOptions {
     const expectedSettings: { [key: string]: string } = {
         'azureFunctions.projectLanguage': ProjectLanguage.JavaScript,
         'azureFunctions.projectRuntime': version,
@@ -44,7 +44,7 @@ export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, ve
     };
 }
 
-export function getTypeScriptValidateOptions(version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getTypeScriptValidateOptions(version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.TypeScript,
         version,
@@ -74,7 +74,7 @@ export function getTypeScriptValidateOptions(version: FuncVersion = defaultVersi
     };
 }
 
-export function getCSharpValidateOptions(targetFramework: string, version: FuncVersion = defaultVersion, numCsproj: number = 1): IValidateProjectOptions {
+export function getCSharpValidateOptions(targetFramework: string, version: FuncVersion = defaultTestFuncVersion, numCsproj: number = 1): IValidateProjectOptions {
     return {
         language: ProjectLanguage.CSharp,
         version,
@@ -107,7 +107,7 @@ export function getCSharpValidateOptions(targetFramework: string, version: FuncV
     };
 }
 
-export function getFSharpValidateOptions(targetFramework: string, version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getFSharpValidateOptions(targetFramework: string, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.FSharp,
         version,
@@ -141,7 +141,7 @@ export function getFSharpValidateOptions(targetFramework: string, version: FuncV
     };
 }
 
-export function getPythonValidateOptions(venvName: string | undefined, version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getPythonValidateOptions(venvName: string | undefined, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     const expectedTasks: string[] = ['host start'];
     if (venvName) {
         expectedTasks.push('pip install (functions)');
@@ -171,7 +171,7 @@ export function getPythonValidateOptions(venvName: string | undefined, version: 
     };
 }
 
-export function getJavaValidateOptions(appName: string, version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getJavaValidateOptions(appName: string, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.Java,
         version,
@@ -202,7 +202,7 @@ export function getJavaValidateOptions(appName: string, version: FuncVersion = d
     };
 }
 
-export function getDotnetScriptValidateOptions(language: ProjectLanguage, version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getDotnetScriptValidateOptions(language: ProjectLanguage, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language,
         version,
@@ -226,7 +226,7 @@ export function getDotnetScriptValidateOptions(language: ProjectLanguage, versio
     };
 }
 
-export function getPowerShellValidateOptions(version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getPowerShellValidateOptions(version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.PowerShell,
         version,
@@ -252,7 +252,7 @@ export function getPowerShellValidateOptions(version: FuncVersion = defaultVersi
     };
 }
 
-export function getCustomValidateOptions(version: FuncVersion = defaultVersion): IValidateProjectOptions {
+export function getCustomValidateOptions(version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.Custom,
         displayLanguage: /custom handler/i,


### PR DESCRIPTION
The changes to "SubscriptionTreeItem" are because .NET 6 is the only test using FuncVersion v4, but when we do `getWorkspaceSettingFromAnyFolder`, it's returning v3 from a different folder. In the case of deploy, we know which folder is being used so we can be more specific than just "AnyFolder".

The changes to "test.yml" are to make sure the right .NET sdks are installed on the build machine