### PR TITLE
Handle "pwa-node" debug type

### DIFF
--- a/src/vsCodeConfig/launch.ts
+++ b/src/vsCodeConfig/launch.ts
@@ -35,11 +35,11 @@ function isTypeEqual(type1: string, type2: string): boolean {
 }
 
 /**
- * Special case node debug type because it can be either "node" or "node2"
+ * Special case node debug type because it can be either "node", "node2", or "pwa-node"
  * https://github.com/microsoft/vscode-azurefunctions/issues/1259
  */
 function isNodeType(t: string): boolean {
-    return /^node2?$/i.test(t);
+    return /node/i.test(t);
 }
 
 function getLaunchConfig(folder: WorkspaceFolder): WorkspaceConfiguration {


### PR DESCRIPTION
I'm seeing this error in telemetry - I believe related to the release of VS Code 1.60 (aka not one of our releases):
> Failed to find launch config matching name "Attach to Node Functions", request "attach", and type "pwa-node".

We're not actually showing this error to the user and it doesn't block debugging. The only downside is we won't perform our pre-debug validation. It's basically the exact same issue as https://github.com/microsoft/vscode-azurefunctions/issues/1259

I believe this fixes https://github.com/microsoft/vscode-azurefunctions/issues/2926