### PR TITLE
Support create gradle project in Functions extension

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require('./out/src/extension');
+const extension = require('./dist/extension.bundle');
 
 async function activate(ctx) {
-    return await extension.activateInternal(ctx, perfStats, true /* ignoreBundle */);
+    return await extension.activateInternal(ctx, perfStats);
 }
 
 async function deactivate(ctx) {

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const extension = require('./out/src/extension');
 
 async function activate(ctx) {
-    return await extension.activateInternal(ctx, perfStats);
+    return await extension.activateInternal(ctx, perfStats, true /* ignoreBundle */);
 }
 
 async function deactivate(ctx) {

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ let perfStats = {
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const extension = require('./dist/extension.bundle');
+const extension = require('./out/src/extension');
 
 async function activate(ctx) {
     return await extension.activateInternal(ctx, perfStats);

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -5,7 +5,7 @@
 
 import * as escape from 'escape-string-regexp';
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IActionContext, IAzureQuickPickItem, IAzureQuickPickOptions, IWizardOptions } from 'vscode-azureextensionui';
-import { ProjectLanguage, TemplateFilter, templateFilterSetting } from '../../constants';
+import { JavaBuildTool, ProjectLanguage, TemplateFilter, templateFilterSetting } from '../../constants';
 import { canValidateAzureWebJobStorageOnDebug } from '../../debug/validatePreDebug';
 import { ext } from '../../extensionVariables';
 import { getAzureWebJobsStorage } from '../../funcConfig/local.settings';
@@ -180,7 +180,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     }
 
     public shouldPrompt(context: IFunctionWizardContext): boolean {
-        return !context.functionTemplate;
+        return !context.functionTemplate && context['buildTool'] !== JavaBuildTool.maven;
     }
 
     private async getPicks(context: IFunctionWizardContext, templateFilter: TemplateFilter): Promise<IAzureQuickPickItem<IFunctionTemplate | TemplatePromptResult>[]> {

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -5,7 +5,7 @@
 
 import { QuickPickOptions } from 'vscode';
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, UserCancelledError } from 'vscode-azureextensionui';
-import { ProjectLanguage } from '../../constants';
+import { JavaBuildTool, ProjectLanguage } from '../../constants';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { openUrl } from '../../utils/openUrl';
@@ -13,6 +13,7 @@ import { FunctionListStep } from '../createFunction/FunctionListStep';
 import { addInitVSCodeSteps } from '../initProjectForVSCode/InitVSCodeLanguageStep';
 import { DotnetRuntimeStep } from './dotnetSteps/DotnetRuntimeStep';
 import { IProjectWizardContext } from './IProjectWizardContext';
+import { addJavaCreateProjectSteps } from './javaSteps/addJavaCreateProjectSteps';
 import { JavaAppNameStep } from './javaSteps/JavaAppNameStep';
 import { JavaArtifactIdStep } from './javaSteps/JavaArtifactIdStep';
 import { JavaBuildToolStep } from './javaSteps/JavaBuildToolStep';
@@ -22,7 +23,6 @@ import { JavaProjectVersionStep } from './javaSteps/JavaProjectVersionStep';
 import { JavaVersionStep } from './javaSteps/JavaVersionStep';
 import { CustomProjectCreateStep } from './ProjectCreateStep/CustomProjectCreateStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
-import { JavaProjectCreateStep } from './ProjectCreateStep/JavaProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
 import { PowerShellProjectCreateStep } from './ProjectCreateStep/PowerShellProjectCreateStep';
 import { PythonProjectCreateStep } from './ProjectCreateStep/PythonProjectCreateStep';
@@ -102,7 +102,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 await JavaVersionStep.setDefaultVersion(context);
                 await JavaBuildToolStep.setDefaultBuildTool(context); // Set build tool to maven as other Java project with other build tool is not supported now
                 promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
-                executeSteps.push(await JavaProjectCreateStep.createStep(context));
+                await addJavaCreateProjectSteps(context, promptSteps, executeSteps);
                 break;
             case ProjectLanguage.Custom:
                 executeSteps.push(new CustomProjectCreateStep());
@@ -118,7 +118,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
 
         // All languages except Java support creating a function after creating a project
         // Java needs to fix this issue first: https://github.com/Microsoft/vscode-azurefunctions/issues/81
-        if (language !== ProjectLanguage.Java) {
+        if (context['buildTool'] !== JavaBuildTool.maven) {
             promptSteps.push(await FunctionListStep.create(context, {
                 isProjectWizard: true,
                 templateId: this._templateId,

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -5,7 +5,7 @@
 
 import { QuickPickOptions } from 'vscode';
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, UserCancelledError } from 'vscode-azureextensionui';
-import { JavaBuildTool, ProjectLanguage } from '../../constants';
+import { ProjectLanguage } from '../../constants';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { openUrl } from '../../utils/openUrl';
@@ -108,13 +108,11 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
 
         // All languages except Java support creating a function after creating a project
         // Java needs to fix this issue first: https://github.com/Microsoft/vscode-azurefunctions/issues/81
-        if (context['buildTool'] !== JavaBuildTool.maven) {
-            promptSteps.push(await FunctionListStep.create(context, {
-                isProjectWizard: true,
-                templateId: this._templateId,
-                functionSettings: this._functionSettings
-            }));
-        }
+        promptSteps.push(await FunctionListStep.create(context, {
+            isProjectWizard: true,
+            templateId: this._templateId,
+            functionSettings: this._functionSettings
+        }));
 
         return wizardOptions;
     }

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -14,13 +14,6 @@ import { addInitVSCodeSteps } from '../initProjectForVSCode/InitVSCodeLanguageSt
 import { DotnetRuntimeStep } from './dotnetSteps/DotnetRuntimeStep';
 import { IProjectWizardContext } from './IProjectWizardContext';
 import { addJavaCreateProjectSteps } from './javaSteps/addJavaCreateProjectSteps';
-import { JavaAppNameStep } from './javaSteps/JavaAppNameStep';
-import { JavaArtifactIdStep } from './javaSteps/JavaArtifactIdStep';
-import { JavaBuildToolStep } from './javaSteps/JavaBuildToolStep';
-import { JavaGroupIdStep } from './javaSteps/JavaGroupIdStep';
-import { JavaPackageNameStep } from './javaSteps/JavaPackageNameStep';
-import { JavaProjectVersionStep } from './javaSteps/JavaProjectVersionStep';
-import { JavaVersionStep } from './javaSteps/JavaVersionStep';
 import { CustomProjectCreateStep } from './ProjectCreateStep/CustomProjectCreateStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
@@ -99,9 +92,6 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 executeSteps.push(new PowerShellProjectCreateStep());
                 break;
             case ProjectLanguage.Java:
-                await JavaVersionStep.setDefaultVersion(context);
-                await JavaBuildToolStep.setDefaultBuildTool(context); // Set build tool to maven as other Java project with other build tool is not supported now
-                promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
                 await addJavaCreateProjectSteps(context, promptSteps, executeSteps);
                 break;
             case ProjectLanguage.Custom:

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -6,9 +6,11 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress } from 'vscode';
+import { IActionContext } from 'vscode-azureextensionui';
 import { buildGradleFileName, settingsGradleFileName } from '../../../constants';
 import { localize } from '../../../localize';
 import { confirmOverwriteFile } from '../../../utils/fs';
+import { gradleUtils } from '../../../utils/gradleUtils';
 import { javaUtils } from '../../../utils/javaUtils';
 import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContext';
 import { java11, java8 } from '../javaSteps/JavaVersionStep';
@@ -19,6 +21,15 @@ const metaDataUrl = "https://plugins.gradle.org/m2/com/microsoft/azure/azure-fun
 
 export class GradleProjectCreateStep extends ScriptProjectCreateStep {
     protected gitignore: string = gradleGitignore;
+
+    private constructor() {
+        super();
+    }
+
+    public static async createStep(context: IActionContext): Promise<GradleProjectCreateStep> {
+        await gradleUtils.validateGradleInstalled(context);
+        return new GradleProjectCreateStep();
+    }
 
     public async executeCore(context: IJavaProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         super.executeCore(context, progress);

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -1,0 +1,145 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fse from 'fs-extra';
+import * as path from 'path';
+import { Progress } from 'vscode';
+import { buildGradleFileName, settingsGradleFileName } from '../../../constants';
+import { localize } from '../../../localize';
+import { confirmOverwriteFile } from '../../../utils/fs';
+import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContext';
+import { java11, java8 } from '../javaSteps/JavaVersionStep';
+import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
+
+export class GradleProjectCreateStep extends ScriptProjectCreateStep {
+    protected gitignore: string = gradleGitignore;
+
+    public async executeCore(context: IJavaProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        super.executeCore(context, progress);
+
+        const settingsGradlePath: string = path.join(context.projectPath, settingsGradleFileName);
+        if (await confirmOverwriteFile(context, settingsGradlePath)) {
+            await fse.writeFile(settingsGradlePath, this.getSettingsGradleContent(context));
+        }
+
+        const buildGradlePath: string = path.join(context.projectPath, buildGradleFileName);
+        if (await confirmOverwriteFile(context, buildGradlePath)) {
+            await fse.writeFile(buildGradlePath, this.getBuildGradleContent(context));
+        }
+    }
+
+    getSettingsGradleContent(context: IJavaProjectWizardContext): any {
+        return `rootProject.name = "${context.javaArtifactId}"`;
+    }
+
+    getCompatibilityVersion(javaVersion: string | undefined): string {
+        if (javaVersion === java8) {
+            return "1.8";
+        } else if (javaVersion === java11) {
+            return "11";
+        } else {
+            throw new Error(localize('invalidJavaVersion', 'Invalid Java version "{0}".', javaVersion));
+        }
+    }
+
+    getBuildGradleContent(context: IJavaProjectWizardContext): string {
+        return `plugins {
+  id "com.microsoft.azure.azurefunctions" version "1.6.0"
+}
+apply plugin: 'java'
+apply plugin: "com.microsoft.azure.azurefunctions"
+
+group '${context.javaGroupId}'
+version '${context.javaProjectVersion}'
+
+dependencies {
+    implementation 'com.microsoft.azure.functions:azure-functions-java-library:1.4.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
+}
+
+sourceCompatibility = '${this.getCompatibilityVersion(context.javaVersion)}'
+targetCompatibility = '${this.getCompatibilityVersion(context.javaVersion)}'
+
+compileJava.options.encoding = 'UTF-8'
+
+repositories {
+    mavenCentral()
+}
+
+azurefunctions {
+    resourceGroup = 'java-functions-group'
+    appName = '${context.javaAppName}'
+    pricingTier = 'Consumption'
+    region = 'westus'
+    runtime {
+      os = 'windows'
+      javaVersion = '${context.javaVersion}'
+    }
+    localDebug = "transport=dt_socket,server=y,suspend=n,address=5005"
+}
+`;
+    }
+}
+
+const gradleGitignore: string = `# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Build output
+target/
+
+*.factorypath
+
+# IDE
+.idea/
+*.iml
+.classpath
+.project
+.settings/
+.checkstyle
+.vscode/
+
+# macOS
+.DS_Store
+
+# gradle-wrapper
+!gradle/wrapper/gradle-wrapper.jar
+!gradle/wrapper/gradle-wrapper.properties
+
+# integration test
+*/src/it/*/bin
+
+jacoco.exec
+bin/
+
+# mvnw
+!.mvn/wrapper/maven-wrapper.jar
+
+build/
+
+.gradle/
+`;
+

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -32,7 +32,7 @@ export class GradleProjectCreateStep extends ScriptProjectCreateStep {
     }
 
     public async executeCore(context: IJavaProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
-        super.executeCore(context, progress);
+        await super.executeCore(context, progress);
 
         const settingsGradlePath: string = path.join(context.projectPath, settingsGradleFileName);
         if (await confirmOverwriteFile(context, settingsGradlePath)) {
@@ -47,11 +47,15 @@ export class GradleProjectCreateStep extends ScriptProjectCreateStep {
     }
 
     async getLatestGradlePluginVersion(context: IJavaProjectWizardContext): Promise<string> {
-        const templateVersion: string | undefined = await javaUtils.getLatestArtifactVersionFromMetaData(context, metaDataUrl);
-        return templateVersion ? templateVersion : backupGradlePluginVersion;
+        try {
+            const templateVersion: string | undefined = await javaUtils.getLatestArtifactVersionFromMetaData(context, metaDataUrl);
+            return templateVersion ? templateVersion : backupGradlePluginVersion;
+        } catch (error) {
+            return backupGradlePluginVersion;
+        }
     }
 
-    getSettingsGradleContent(context: IJavaProjectWizardContext): any {
+    getSettingsGradleContent(context: IJavaProjectWizardContext): string {
         return `rootProject.name = "${context.javaArtifactId}"`;
     }
 

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -22,10 +22,6 @@ const metaDataUrl = "https://plugins.gradle.org/m2/com/microsoft/azure/azure-fun
 export class GradleProjectCreateStep extends ScriptProjectCreateStep {
     protected gitignore: string = gradleGitignore;
 
-    private constructor() {
-        super();
-    }
-
     public static async createStep(context: IActionContext): Promise<GradleProjectCreateStep> {
         await gradleUtils.validateGradleInstalled(context);
         return new GradleProjectCreateStep();

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -7,7 +7,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress } from 'vscode';
 import { IActionContext } from 'vscode-azureextensionui';
-import { buildGradleFileName, settingsGradleFileName } from '../../../constants';
+import { buildGradleFileName, JavaBuildTool, settingsGradleFileName } from '../../../constants';
 import { localize } from '../../../localize';
 import { confirmOverwriteFile } from '../../../utils/fs';
 import { gradleUtils } from '../../../utils/gradleUtils';
@@ -44,6 +44,10 @@ export class GradleProjectCreateStep extends ScriptProjectCreateStep {
         if (await confirmOverwriteFile(context, buildGradlePath)) {
             await fse.writeFile(buildGradlePath, buildGradleContent);
         }
+    }
+
+    public shouldExecute(context: IJavaProjectWizardContext): boolean {
+        return context.buildTool === JavaBuildTool.gradle;
     }
 
     async getLatestGradlePluginVersion(context: IJavaProjectWizardContext): Promise<string> {

--- a/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
@@ -14,14 +14,14 @@ import { nonNullProp } from '../../../utils/nonNull';
 import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContext';
 import { ProjectCreateStepBase } from './ProjectCreateStepBase';
 
-export class JavaProjectCreateStep extends ProjectCreateStepBase {
+export class MavenProjectCreateStep extends ProjectCreateStepBase {
     private constructor() {
         super();
     }
 
-    public static async createStep(context: IActionContext): Promise<JavaProjectCreateStep> {
+    public static async createStep(context: IActionContext): Promise<MavenProjectCreateStep> {
         await mavenUtils.validateMavenInstalled(context);
-        return new JavaProjectCreateStep();
+        return new MavenProjectCreateStep();
     }
 
     public async executeCore(context: IJavaProjectWizardContext): Promise<void> {

--- a/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
@@ -7,6 +7,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
+import { JavaBuildTool } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import * as fsUtil from '../../../utils/fs';
 import { mavenUtils } from '../../../utils/mavenUtils';
@@ -22,6 +23,10 @@ export class MavenProjectCreateStep extends ProjectCreateStepBase {
     public static async createStep(context: IActionContext): Promise<MavenProjectCreateStep> {
         await mavenUtils.validateMavenInstalled(context);
         return new MavenProjectCreateStep();
+    }
+
+    public shouldExecute(context: IJavaProjectWizardContext): boolean {
+        return context.buildTool === JavaBuildTool.maven;
     }
 
     public async executeCore(context: IJavaProjectWizardContext): Promise<void> {

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -9,7 +9,8 @@ import { hasMinFuncCliVersion } from "../../../funcCoreTools/hasMinFuncCliVersio
 import { localize } from "../../../localize";
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
 
-const java8: string = '8';
+export const java8: string = '8';
+export const java11: string = '11';
 
 export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
     public static async setDefaultVersion(context: IJavaProjectWizardContext): Promise<void> {
@@ -21,7 +22,7 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
     public async prompt(context: IJavaProjectWizardContext): Promise<void> {
         const picks: IAzureQuickPickItem<string>[] = [
             { label: 'Java 8', data: java8 },
-            { label: 'Java 11', description: previewDescription, data: '11' },
+            { label: 'Java 11', description: previewDescription, data: java11 },
         ];
         const placeHolder: string = localize('selectJavaVersion', 'Select a version of Java');
         context.javaVersion = (await context.ui.showQuickPick(picks, { placeHolder })).data;

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem } from "vscode-azureextensionui";
-import { previewDescription } from "../../../constants";
 import { hasMinFuncCliVersion } from "../../../funcCoreTools/hasMinFuncCliVersion";
 import { localize } from "../../../localize";
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
@@ -22,7 +21,7 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
     public async prompt(context: IJavaProjectWizardContext): Promise<void> {
         const picks: IAzureQuickPickItem<string>[] = [
             { label: 'Java 8', data: java8 },
-            { label: 'Java 11', description: previewDescription, data: java11 },
+            { label: 'Java 11', data: java11 },
         ];
         const placeHolder: string = localize('selectJavaVersion', 'Select a version of Java');
         context.javaVersion = (await context.ui.showQuickPick(picks, { placeHolder })).data;

--- a/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
+++ b/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
@@ -22,7 +22,6 @@ export async function addJavaCreateProjectSteps(
     promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
     executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
     await JavaVersionStep.setDefaultVersion(context);
-
     promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
 
     const picks: IAzureQuickPickItem<JavaBuildTool>[] = [
@@ -32,9 +31,9 @@ export async function addJavaCreateProjectSteps(
     const placeHolder: string = localize('selectJavaBuildTool', 'Select the build tool for Java project');
     context.buildTool = (await context.ui.showQuickPick(picks, { placeHolder })).data;
     if (context.buildTool === JavaBuildTool.maven) {
-        await MavenProjectCreateStep.createStep(context);
+        executeSteps.push(await MavenProjectCreateStep.createStep(context));
     } else if (context.buildTool === JavaBuildTool.gradle) {
-        executeSteps.push(new GradleProjectCreateStep());
+        executeSteps.push(await GradleProjectCreateStep.createStep(context));
     } else {
         throw new Error(localize('invalidJavaBuildTool', 'Internal error: Invalid java build tool "{0}".', context.buildTool));
     }

--- a/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
+++ b/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem } from "vscode-azureextensionui";
+import { JavaBuildTool, previewDescription } from "../../../constants";
+import { localize } from "../../../localize";
+import { IProjectWizardContext } from "../IProjectWizardContext";
+import { GradleProjectCreateStep } from "../ProjectCreateStep/GradleProjectCreateSteps";
+import { MavenProjectCreateStep } from "../ProjectCreateStep/MavenProjectCreateSteps";
+import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
+import { JavaAppNameStep } from "./JavaAppNameStep";
+import { JavaArtifactIdStep } from "./JavaArtifactIdStep";
+import { JavaGroupIdStep } from "./JavaGroupIdStep";
+import { JavaPackageNameStep } from "./JavaPackageNameStep";
+import { JavaProjectVersionStep } from "./JavaProjectVersionStep";
+import { JavaVersionStep } from "./JavaVersionStep";
+
+export async function addJavaCreateProjectSteps(
+    context: IJavaProjectWizardContext,
+    promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
+    executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
+    await JavaVersionStep.setDefaultVersion(context);
+
+    promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
+
+    const picks: IAzureQuickPickItem<JavaBuildTool>[] = [
+        { label: 'Maven', data: JavaBuildTool.maven },
+        { label: 'Gradle', description: previewDescription, data: JavaBuildTool.gradle },
+    ];
+    const placeHolder: string = localize('selectJavaBuildTool', 'Select the build tool for Java project');
+    context.buildTool = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+    if (context.buildTool === JavaBuildTool.maven) {
+        await MavenProjectCreateStep.createStep(context);
+    } else if (context.buildTool === JavaBuildTool.gradle) {
+        executeSteps.push(new GradleProjectCreateStep());
+    } else {
+        throw new Error(localize('invalidJavaBuildTool', 'Internal error: Invalid java build tool "{0}".', context.buildTool));
+    }
+}

--- a/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
+++ b/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem } from "vscode-azureextensionui";
-import { JavaBuildTool, previewDescription } from "../../../constants";
+import { AzureWizardExecuteStep, AzureWizardPromptStep } from "vscode-azureextensionui";
+import { JavaBuildTool } from "../../../constants";
 import { localize } from "../../../localize";
 import { IProjectWizardContext } from "../IProjectWizardContext";
 import { GradleProjectCreateStep } from "../ProjectCreateStep/GradleProjectCreateSteps";
@@ -12,6 +12,7 @@ import { MavenProjectCreateStep } from "../ProjectCreateStep/MavenProjectCreateS
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
 import { JavaAppNameStep } from "./JavaAppNameStep";
 import { JavaArtifactIdStep } from "./JavaArtifactIdStep";
+import { JavaBuildToolStep } from "./JavaBuildToolStep";
 import { JavaGroupIdStep } from "./JavaGroupIdStep";
 import { JavaPackageNameStep } from "./JavaPackageNameStep";
 import { JavaProjectVersionStep } from "./JavaProjectVersionStep";
@@ -24,12 +25,7 @@ export async function addJavaCreateProjectSteps(
     await JavaVersionStep.setDefaultVersion(context);
     promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
 
-    const picks: IAzureQuickPickItem<JavaBuildTool>[] = [
-        { label: 'Maven', data: JavaBuildTool.maven },
-        { label: 'Gradle', description: previewDescription, data: JavaBuildTool.gradle },
-    ];
-    const placeHolder: string = localize('selectJavaBuildTool', 'Select the build tool for Java project');
-    context.buildTool = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+    await new JavaBuildToolStep().prompt(context);
     if (context.buildTool === JavaBuildTool.maven) {
         executeSteps.push(await MavenProjectCreateStep.createStep(context));
     } else if (context.buildTool === JavaBuildTool.gradle) {

--- a/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
+++ b/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep } from "vscode-azureextensionui";
-import { JavaBuildTool } from "../../../constants";
-import { localize } from "../../../localize";
 import { IProjectWizardContext } from "../IProjectWizardContext";
 import { GradleProjectCreateStep } from "../ProjectCreateStep/GradleProjectCreateSteps";
 import { MavenProjectCreateStep } from "../ProjectCreateStep/MavenProjectCreateSteps";
@@ -23,14 +21,6 @@ export async function addJavaCreateProjectSteps(
     promptSteps: AzureWizardPromptStep<IProjectWizardContext>[],
     executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
     await JavaVersionStep.setDefaultVersion(context);
-    promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep());
-
-    await new JavaBuildToolStep().prompt(context);
-    if (context.buildTool === JavaBuildTool.maven) {
-        executeSteps.push(await MavenProjectCreateStep.createStep(context));
-    } else if (context.buildTool === JavaBuildTool.gradle) {
-        executeSteps.push(await GradleProjectCreateStep.createStep(context));
-    } else {
-        throw new Error(localize('invalidJavaBuildTool', 'Internal error: Invalid java build tool "{0}".', context.buildTool));
-    }
+    promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep(), new JavaBuildToolStep());
+    executeSteps.push(await MavenProjectCreateStep.createStep(context), await GradleProjectCreateStep.createStep(context));
 }

--- a/src/commands/initProjectForVSCode/javaSteps/addJavaInitVSCodeSteps.ts
+++ b/src/commands/initProjectForVSCode/javaSteps/addJavaInitVSCodeSteps.ts
@@ -5,7 +5,6 @@
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep } from "vscode-azureextensionui";
 import { JavaBuildTool } from "../../../constants";
-import { localize } from "../../../localize";
 import { IProjectWizardContext } from "../../createNewProject/IProjectWizardContext";
 import { IJavaProjectWizardContext } from "../../createNewProject/javaSteps/IJavaProjectWizardContext";
 import { JavaBuildToolStep } from "../../createNewProject/javaSteps/JavaBuildToolStep";
@@ -19,14 +18,12 @@ export async function addJavaInitVSCodeSteps(
     if (!context.buildTool) {
         const isMaven: boolean = await isMavenProject(context.projectPath);
         const isGradle: boolean = await isGradleProject(context.projectPath);
-        if (isMaven && isGradle) {
+        if (isMaven === isGradle) {
             promptSteps.push(new JavaBuildToolStep());
         } else if (isMaven) {
             context.buildTool = JavaBuildTool.maven;
         } else if (isGradle) {
             context.buildTool = JavaBuildTool.gradle;
-        } else {
-            throw new Error(localize('pomNotFound', 'Cannot find `pom.xml` or `build.gradle` in current project, please make sure the language setting is correct.'));
         }
     }
     executeSteps.push(new JavaInitVSCodeStep());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,6 +50,7 @@ export const requirementsFileName: string = 'requirements.txt';
 export const extensionsCsprojFileName: string = 'extensions.csproj';
 export const pomXmlFileName: string = 'pom.xml';
 export const buildGradleFileName: string = 'build.gradle';
+export const settingsGradleFileName: string = 'settings.gradle';
 export enum JavaBuildTool {
     maven = 'maven',
     gradle = 'gradle'

--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -77,7 +77,7 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     private validateGradleProject(): void {
         const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, this.getProjectPath());
         if (buildTool === JavaBuildTool.gradle) {
-            throw new Error(localize('gradleUpdateTemplate', 'Update function template is not supported for gradle project.'));
+            throw Error('Internal error: Update function template is not supported for gradle project.');
         }
     }
 

--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -6,10 +6,11 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { IActionContext } from 'vscode-azureextensionui';
-import { pomXmlFileName } from '../../constants';
+import { JavaBuildTool, javaBuildTool, pomXmlFileName } from '../../constants';
 import { localize } from '../../localize';
 import { mavenUtils } from '../../utils/mavenUtils';
 import { parseJson } from '../../utils/parseJson';
+import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { ITemplates } from '../ITemplates';
 import { parseScriptTemplates } from '../script/parseScriptTemplates';
 import { ScriptTemplateProvider } from '../script/ScriptTemplateProvider';
@@ -33,6 +34,7 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     }
 
     public async getLatestTemplateVersion(): Promise<string> {
+        await this.validateGradleProject();
         const pomPath: string = path.join(this.getProjectPath(), pomXmlFileName);
         const pomContents: string = (await fse.readFile(pomPath)).toString();
         const match: RegExpMatchArray | null = pomContents.match(/<azure.functions.maven.plugin.version>(.*)<\/azure.functions.maven.plugin.version>/i);
@@ -44,8 +46,8 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     }
 
     public async getLatestTemplates(context: IActionContext): Promise<ITemplates> {
+        await this.validateGradleProject();
         await mavenUtils.validateMavenInstalled(context);
-
         const projectPath: string = this.getProjectPath();
         const commandResult: string = await mavenUtils.executeMvnCommand(context.telemetry.properties, undefined, projectPath, 'azure-functions:list');
         const regExp: RegExp = />> templates begin <<([\S\s]+)^.+INFO.+ >> templates end <<$[\S\s]+>> bindings begin <<([\S\s]+)^.+INFO.+ >> bindings end <<$[\S\s]+>> resources begin <<([\S\s]+)^.+INFO.+ >> resources end <<$/gm;
@@ -70,6 +72,13 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     // eslint-disable-next-line @typescript-eslint/require-await
     protected async getCacheKeySuffix(): Promise<string> {
         return 'Java';
+    }
+
+    private async validateGradleProject(): Promise<void> {
+        const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, this.getProjectPath());
+        if (buildTool === JavaBuildTool.gradle) {
+            throw new Error(localize('gradleUpdateTemplate', 'Update function template is not supported for gradle proeject.'));
+        }
     }
 
     private getProjectPath(): string {

--- a/src/templates/java/JavaTemplateProvider.ts
+++ b/src/templates/java/JavaTemplateProvider.ts
@@ -34,7 +34,7 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     }
 
     public async getLatestTemplateVersion(): Promise<string> {
-        await this.validateGradleProject();
+        this.validateGradleProject();
         const pomPath: string = path.join(this.getProjectPath(), pomXmlFileName);
         const pomContents: string = (await fse.readFile(pomPath)).toString();
         const match: RegExpMatchArray | null = pomContents.match(/<azure.functions.maven.plugin.version>(.*)<\/azure.functions.maven.plugin.version>/i);
@@ -46,7 +46,7 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
     }
 
     public async getLatestTemplates(context: IActionContext): Promise<ITemplates> {
-        await this.validateGradleProject();
+        this.validateGradleProject();
         await mavenUtils.validateMavenInstalled(context);
         const projectPath: string = this.getProjectPath();
         const commandResult: string = await mavenUtils.executeMvnCommand(context.telemetry.properties, undefined, projectPath, 'azure-functions:list');
@@ -74,10 +74,10 @@ export class JavaTemplateProvider extends ScriptTemplateProvider {
         return 'Java';
     }
 
-    private async validateGradleProject(): Promise<void> {
+    private validateGradleProject(): void {
         const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, this.getProjectPath());
         if (buildTool === JavaBuildTool.gradle) {
-            throw new Error(localize('gradleUpdateTemplate', 'Update function template is not supported for gradle proeject.'));
+            throw new Error(localize('gradleUpdateTemplate', 'Update function template is not supported for gradle project.'));
         }
     }
 

--- a/src/utils/gradleUtils.ts
+++ b/src/utils/gradleUtils.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { IActionContext } from "vscode-azureextensionui";
+import { localize } from '../localize';
+import { cpUtils } from './cpUtils';
+
+export namespace gradleUtils {
+    const gradleCommand: string = 'gradle';
+
+    export async function validateGradleInstalled(context: IActionContext): Promise<void> {
+        try {
+            await cpUtils.executeCommand(undefined, undefined, gradleCommand, '--version');
+        } catch (error) {
+            const message: string = localize('gradleNotFound', 'Failed to find "gradle", please ensure that the gradle bin directory is in your system path.');
+
+            if (!context.errorHandling.suppressDisplay) {
+                // don't wait
+                void vscode.window.showErrorMessage(message);
+                context.errorHandling.suppressDisplay = true;
+            }
+
+            throw new Error(message);
+        }
+    }
+}

--- a/src/utils/javaUtils.ts
+++ b/src/utils/javaUtils.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { HttpOperationResponse } from "@azure/ms-rest-js";
+import { IActionContext } from "vscode-azureextensionui";
+import { nonNullProp } from "./nonNull";
+import { requestUtils } from "./requestUtils";
+
+export namespace javaUtils {
+    const cachedVersions: Map<string, string> = new Map<string, string>();
+
+    export async function getLatestArtifactVersionFromMetaData(context: IActionContext, metaDataUrl: string): Promise<string | undefined> {
+        if (!cachedVersions.has(metaDataUrl)) {
+            const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout(context, { method: 'GET', url: metaDataUrl });
+            const metadate: string = nonNullProp(response, 'bodyAsText');
+            const match: RegExpMatchArray | null = metadate.match(/<release>(.*)<\/release>/i);
+            if (match) {
+                cachedVersions.set(metaDataUrl, match[1].trim());
+            }
+        }
+        return cachedVersions.get(metaDataUrl);
+    }
+}

--- a/src/utils/javaUtils.ts
+++ b/src/utils/javaUtils.ts
@@ -14,8 +14,8 @@ export namespace javaUtils {
     export async function getLatestArtifactVersionFromMetaData(context: IActionContext, metaDataUrl: string): Promise<string | undefined> {
         if (!cachedVersions.has(metaDataUrl)) {
             const response: HttpOperationResponse = await requestUtils.sendRequestWithExtTimeout(context, { method: 'GET', url: metaDataUrl });
-            const metadate: string = nonNullProp(response, 'bodyAsText');
-            const match: RegExpMatchArray | null = metadate.match(/<release>(.*)<\/release>/i);
+            const metaData: string = nonNullProp(response, 'bodyAsText');
+            const match: RegExpMatchArray | null = metaData.match(/<release>(.*)<\/release>/i);
             if (match) {
                 cachedVersions.set(metaDataUrl, match[1].trim());
             }

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { runWithTestActionContext, TestInput } from 'vscode-azureextensiondev';
-import { FuncVersion, ProjectLanguage } from '../../extension.bundle';
+import { FuncVersion, JavaBuildTool, ProjectLanguage } from '../../extension.bundle';
 import { addParallelSuite, ParallelTest } from '../addParallelSuite';
 import { allTemplateSources, runForTemplateSource, shouldSkipVersion } from '../global.test';
 import { createAndValidateProject, ICreateProjectTestOptions } from './createAndValidateProject';
@@ -42,13 +42,21 @@ for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
     });
 
     const appName: string = 'javaApp';
-    const javaInputs: (TestInput | string | RegExp)[] = [TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, appName];
+    const javaBaseInputs: (TestInput | string | RegExp)[] = [TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, appName];
     if (version !== FuncVersion.v2) { // v2 doesn't support picking a java version
-        javaInputs.unshift(/11/);
+        javaBaseInputs.unshift(/11/);
     }
+
+    const gradleInputs: (TestInput | string | RegExp)[] = [/Gradle/i];
     testCases.push({
-        ...getJavaValidateOptions(appName, version),
-        inputs: javaInputs
+        ...getJavaValidateOptions(appName, JavaBuildTool.gradle, version),
+        inputs: gradleInputs.concat(javaBaseInputs, /skip for now/i)
+    });
+
+    const mavenInputs: (TestInput | string | RegExp)[] = [/Maven/i];
+    testCases.push({
+        ...getJavaValidateOptions(appName, JavaBuildTool.maven, version),
+        inputs: mavenInputs.concat(javaBaseInputs)
     });
 }
 

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -47,17 +47,15 @@ for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
         javaBaseInputs.unshift(/11/);
     }
 
-    const gradleInputs: (TestInput | string | RegExp)[] = [/Gradle/i];
     testCases.push({
         ...getJavaValidateOptions(appName, JavaBuildTool.gradle, version),
-        inputs: gradleInputs.concat(javaBaseInputs, /skip for now/i),
+        inputs: javaBaseInputs.concat(/Gradle/i, /skip for now/i),
         description: JavaBuildTool.gradle
     });
 
-    const mavenInputs: (TestInput | string | RegExp)[] = [/Maven/i];
     testCases.push({
         ...getJavaValidateOptions(appName, JavaBuildTool.maven, version),
-        inputs: mavenInputs.concat(javaBaseInputs),
+        inputs: javaBaseInputs.concat(/Maven/i),
         description: JavaBuildTool.maven
     });
 }

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -6,7 +6,7 @@
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { runWithTestActionContext, TestInput } from 'vscode-azureextensiondev';
-import { FuncVersion, getRandomHexString, initProjectForVSCode, ProjectLanguage } from '../../extension.bundle';
+import { FuncVersion, getRandomHexString, initProjectForVSCode, JavaBuildTool, ProjectLanguage } from '../../extension.bundle';
 import { cleanTestWorkspace, testFolderPath } from '../global.test';
 import { getCSharpValidateOptions, getCustomValidateOptions, getFSharpValidateOptions, getJavaScriptValidateOptions, getJavaValidateOptions, getPowerShellValidateOptions, getPythonValidateOptions, getTypeScriptValidateOptions, IValidateProjectOptions, validateProject } from './validateProject';
 
@@ -87,7 +87,7 @@ suite('Init Project For VS Code', function (this: Mocha.Suite): void {
         await initAndValidateProject({ ...getFSharpValidateOptions('netstandard2.0', FuncVersion.v2), mockFiles });
     });
 
-    test('Java', async () => {
+    test('Java - Maven', async () => {
         const appName: string = 'javaApp1';
         const mockFiles: MockFile[] = [
             {
@@ -100,7 +100,20 @@ suite('Init Project For VS Code', function (this: Mocha.Suite): void {
             },
             { fsPath: 'src', isDir: true }
         ];
-        await initAndValidateProject({ ...getJavaValidateOptions(appName), mockFiles });
+        await initAndValidateProject({ ...getJavaValidateOptions(appName, JavaBuildTool.maven), mockFiles });
+    });
+
+    test('Java - Gradle', async () => {
+        const appName: string = 'javaApp1';
+        const mockFiles: MockFile[] = [
+            {
+                fsPath: 'build.gradle',
+                contents: `azurefunctions {
+    appName = '${appName}'
+}`
+            }
+        ];
+        await initAndValidateProject({ ...getJavaValidateOptions(appName, JavaBuildTool.gradle), mockFiles });
     });
 
     test('PowerShell', async () => {

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as fse from 'fs-extra';
 import * as globby from 'globby';
 import * as path from 'path';
-import { FuncVersion, getContainingWorkspace, IExtensionsJson, ILaunchJson, ITasksJson, ProjectLanguage } from '../../extension.bundle';
+import { FuncVersion, getContainingWorkspace, IExtensionsJson, ILaunchJson, ITasksJson, JavaBuildTool, ProjectLanguage } from '../../extension.bundle';
 
 export const defaultTestFuncVersion: FuncVersion = FuncVersion.v3;
 
@@ -171,7 +171,7 @@ export function getPythonValidateOptions(venvName: string | undefined, version: 
     };
 }
 
-export function getJavaValidateOptions(appName: string, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
+export function getJavaValidateOptions(appName: string, buildTool: string, version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
     return {
         language: ProjectLanguage.Java,
         version,
@@ -179,19 +179,12 @@ export function getJavaValidateOptions(appName: string, version: FuncVersion = d
             'azureFunctions.projectLanguage': ProjectLanguage.Java,
             'azureFunctions.projectRuntime': version,
             'azureFunctions.preDeployTask': 'package (functions)',
-            'azureFunctions.deploySubpath': `target/azure-functions/${appName}`,
-            'azureFunctions.javaBuildTool': 'maven',
+            'azureFunctions.javaBuildTool': buildTool,
+            'azureFunctions.deploySubpath': buildTool === JavaBuildTool.maven ? `target/azure-functions/${appName}` : `build/azure-functions/${appName}`,
             'debug.internalConsoleOptions': 'neverOpen',
         },
-        expectedPaths: [
-            'src',
-            'pom.xml'
-        ],
         expectedExtensionRecs: [
             'vscjava.vscode-java-debug'
-        ],
-        excludedPaths: [
-            '.funcignore'
         ],
         expectedDebugConfigs: [
             'Attach to Java Functions'
@@ -199,7 +192,9 @@ export function getJavaValidateOptions(appName: string, version: FuncVersion = d
         expectedTasks: [
             'host start',
             'package (functions)'
-        ]
+        ],
+        expectedPaths: buildTool === JavaBuildTool.maven ? ['src', 'pom.xml'] : ['build.gradle'],
+        excludedPaths: buildTool === JavaBuildTool.maven ? ['.funcignore'] : []
     };
 }
 

--- a/test/utils/javaUtils.ts
+++ b/test/utils/javaUtils.ts
@@ -13,7 +13,7 @@ export namespace javaUtils {
     export async function addJavaProjectToWorkspace(testWorkspacePath: string): Promise<void> {
         // Java templates require you to have a project open, so create one here
         if (!await fse.pathExists(path.join(testWorkspacePath, 'pom.xml'))) { // no need if the project is already created
-            const inputs: (string | TestInput | RegExp)[] = [testWorkspacePath, ProjectLanguage.Java, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, 'javaAppName'];
+            const inputs: (string | TestInput | RegExp)[] = [testWorkspacePath, ProjectLanguage.Java, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, 'javaAppName'];
             await cleanTestWorkspace();
             await runWithTestActionContext('createNewProject', async context => {
                 await context.ui.runWithInputs(inputs, async () => {


### PR DESCRIPTION
### Issues to resolve
VSCode could only create maven project when create java functions, this pr enable the ability to create gradle functions.

### Solution
- Using embed template to generate gradle project as there is no tools like maven archetype in gradle
    - Only create required configuration files like `build.gradle` and `settings.gradle`, leverage `FunctionListStep` to create the first trigger
- Ask use to select build tool after choose language as Java when create new project

### Next Steps
We may use embed template for maven so that we could remove the dependency for maven archetype and choose trigger template like other language after project creation
