### PR TITLE
Ignore Azurite Files in Function App

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -63,7 +63,12 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
 bin
 obj
 appsettings.json
-local.settings.json`));
+local.settings.json
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json`));
         }
 
         const funcIgnorePath: string = path.join(context.projectPath, '.funcignore');


### PR DESCRIPTION
When using the Azurite Extension in Visual Studio Code (<https://marketplace.visualstudio.com/items?itemName=Azurite.azurite>) several files get created by this extension in the Azure Functions project directory that are only relevant for _local development_. In analogy to e.g.  `local.settings.json` they should be ignored by git by default and therefore be part of the standard `.gitignore` template of the extension. 

This pull request contains the required enhancement of the creation step of the `.gitignore` file for scripting languages.

As far as I saw the .NET language fetches the `.gitignore template from the repository <https://github.com/Azure/azure-functions-templates>, so the enhancement must be done there.  

 