### PR TITLE
Don't use subpath when creating projects in a workspace

### DIFF
--- a/src/commands/createNewProject/FolderListStep.ts
+++ b/src/commands/createNewProject/FolderListStep.ts
@@ -13,7 +13,7 @@ export class FolderListStep extends AzureWizardPromptStep<IProjectWizardContext>
 
     public static setProjectPath(context: Partial<IProjectWizardContext>, projectPath: string): void {
         context.projectPath = projectPath;
-        context.workspaceFolder = getContainingWorkspace(projectPath);
+        context.workspaceFolder = getContainingWorkspace(projectPath, false);
         context.workspacePath = (context.workspaceFolder && context.workspaceFolder.uri.fsPath) || projectPath;
         if (context.workspaceFolder) {
             context.openBehavior = 'AlreadyOpen';

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -82,9 +82,9 @@ export async function selectWorkspaceItem(context: IActionContext, placeHolder: 
     return folder && folder.data ? folder.data : (await context.ui.showOpenDialog(options))[0].fsPath;
 }
 
-export function getContainingWorkspace(fsPath: string): vscode.WorkspaceFolder | undefined {
+export function getContainingWorkspace(fsPath: string, acceptSubpath = true): vscode.WorkspaceFolder | undefined {
     const openFolders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
     return openFolders.find((f: vscode.WorkspaceFolder): boolean => {
-        return fsUtils.isPathEqual(f.uri.fsPath, fsPath) || fsUtils.isSubpath(f.uri.fsPath, fsPath);
+        return fsUtils.isPathEqual(f.uri.fsPath, fsPath) || (acceptSubpath && fsUtils.isSubpath(f.uri.fsPath, fsPath));
     });
 }

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -293,14 +293,14 @@ const commonExpectedProjectPaths: string[] = [
     'local.settings.json',
     '.funcignore',
     '.gitignore',
-];
-
-const commonExpectedRootPaths: string[] = [
-    '.git',
     '.vscode/tasks.json',
     '.vscode/launch.json',
     '.vscode/extensions.json',
     '.vscode/settings.json'
+];
+
+const commonExpectedRootPaths: string[] = [
+    '.git'
 ];
 
 type ExpectedPath = string | { globPattern: string; numMatches: number };


### PR DESCRIPTION
When creating a new project in a workspace it doesn't respect the project picker if the parent folder is added as a workspace folder as well. This PR solves this.