### PR TITLE
Release preparation work for v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.6.0 - 2021-11-04
+### Added
+- Remove preview flag from Azure Functions v4
+- Option to change Azure Functions runtime version when selecting runtime
+
+### Removed
+- AzureFunctionsExtensionApi command `validateFuncCoreToolsInstalled`
+
 ## 1.5.2 - 2021-10-12
 ### Added
 - AzureFunctionsExtensionApi command `validateFuncCoreToolsInstalled`

--- a/NOTICE.html
+++ b/NOTICE.html
@@ -34,7 +34,7 @@
             <li>
     <details>
         <summary>
-            tslib 1.14.1 - 0BSD
+            tslib 2.2.0 - 0BSD
         </summary>
         <p><a href="https://www.typescriptlang.org/">https://www.typescriptlang.org/</a></p>
         <ul><li>Copyright (c) Microsoft Corporation.</li></ul>
@@ -57,7 +57,7 @@ PERFORMANCE OF THIS SOFTWARE.
 <li>
     <details>
         <summary>
-            tslib 2.2.0 - 0BSD
+            tslib 1.14.1 - 0BSD
         </summary>
         <p><a href="https://www.typescriptlang.org/">https://www.typescriptlang.org/</a></p>
         <ul><li>Copyright (c) Microsoft Corporation.</li></ul>
@@ -1214,6 +1214,29 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <li>
     <details>
         <summary>
+            domutils 2.5.2 - BSD-2-Clause
+        </summary>
+        <p><a href="https://github.com/fb55/domutils#readme">https://github.com/fb55/domutils#readme</a></p>
+        <ul><li>Copyright (c) Felix Bohm</li></ul>
+        <pre>
+        Copyright (c) Felix B&#246;hm
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             domutils 1.7.0 - BSD-2-Clause
         </summary>
         <p><a href="https://github.com/FB55/domutils#readme">https://github.com/FB55/domutils#readme</a></p>
@@ -1237,9 +1260,9 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <li>
     <details>
         <summary>
-            domutils 2.5.2 - BSD-2-Clause
+            entities 2.0.3 - BSD-2-Clause
         </summary>
-        <p><a href="https://github.com/fb55/domutils#readme">https://github.com/fb55/domutils#readme</a></p>
+        <p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p>
         <ul><li>Copyright (c) Felix Bohm</li></ul>
         <pre>
         Copyright (c) Felix B&#246;hm
@@ -1265,29 +1288,6 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p>
         <ul><li>Copyright (c) Felix Bohm</li>
 <li>(c) // http://mathiasbynens.be/notes/javascript-encoding</li></ul>
-        <pre>
-        Copyright (c) Felix B&#246;hm
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS,
-EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            entities 2.0.3 - BSD-2-Clause
-        </summary>
-        <p><a href="https://github.com/fb55/entities#readme">https://github.com/fb55/entities#readme</a></p>
-        <ul><li>Copyright (c) Felix Bohm</li></ul>
         <pre>
         Copyright (c) Felix B&#246;hm
 All rights reserved.
@@ -1365,6 +1365,31 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <li>
     <details>
         <summary>
+            tough-cookie 4.0.0 - BSD-3-Clause
+        </summary>
+        <p><a href="https://github.com/salesforce/tough-cookie">https://github.com/salesforce/tough-cookie</a></p>
+        <ul><li>Copyright (c) 2015, Salesforce.com, Inc.</li>
+<li>Copyright (c) 2018, Salesforce.com, Inc.</li></ul>
+        <pre>
+        Copyright (c) 2015, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             tough-cookie 3.0.1 - BSD-3-Clause
         </summary>
         <p><a href="https://github.com/salesforce/tough-cookie">https://github.com/salesforce/tough-cookie</a></p>
@@ -1391,31 +1416,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
     <details>
         <summary>
             tough-cookie 2.5.0 - BSD-3-Clause
-        </summary>
-        <p><a href="https://github.com/salesforce/tough-cookie">https://github.com/salesforce/tough-cookie</a></p>
-        <ul><li>Copyright (c) 2015, Salesforce.com, Inc.</li>
-<li>Copyright (c) 2018, Salesforce.com, Inc.</li></ul>
-        <pre>
-        Copyright (c) 2015, Salesforce.com, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            tough-cookie 4.0.0 - BSD-3-Clause
         </summary>
         <p><a href="https://github.com/salesforce/tough-cookie">https://github.com/salesforce/tough-cookie</a></p>
         <ul><li>Copyright (c) 2015, Salesforce.com, Inc.</li>
@@ -2656,7 +2656,7 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/core-tracing 1.0.0-preview.10 - MIT
+            @azure/core-tracing 1.0.0-preview.11 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-tracing/README.md">https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-tracing/README.md</a></p>
         <ul><li>Copyright (c) Microsoft Corporation.</li>
@@ -2690,7 +2690,7 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/core-tracing 1.0.0-preview.11 - MIT
+            @azure/core-tracing 1.0.0-preview.10 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-tracing/README.md">https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/core/core-tracing/README.md</a></p>
         <ul><li>Copyright (c) Microsoft Corporation.</li>
@@ -2790,10 +2790,11 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/ms-rest-azure-js 1.4.0 - MIT
+            @azure/ms-rest-azure-js 2.1.0 - MIT
         </summary>
         <p><a href="https://github.com/Azure/ms-rest-azure-js">https://github.com/Azure/ms-rest-azure-js</a></p>
-        
+        <ul><li>Copyright (c) 2017</li>
+<li>Copyright (c) Microsoft Corporation.</li></ul>
         <pre>
         MIT License
 
@@ -2823,11 +2824,10 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            @azure/ms-rest-azure-js 2.1.0 - MIT
+            @azure/ms-rest-azure-js 1.4.0 - MIT
         </summary>
         <p><a href="https://github.com/Azure/ms-rest-azure-js">https://github.com/Azure/ms-rest-azure-js</a></p>
-        <ul><li>Copyright (c) 2017</li>
-<li>Copyright (c) Microsoft Corporation.</li></ul>
+        
         <pre>
         MIT License
 
@@ -2962,7 +2962,7 @@ SOFTWARE.
             @babel/runtime-corejs3 7.13.10 - MIT
         </summary>
         
-        
+        <ul><li>Copyright (c) 2014-present Sebastian McKenzie and other contributors</li></ul>
         <pre>
         MIT License
 
@@ -3695,6 +3695,38 @@ SOFTWARE.
 <li>
     <details>
         <summary>
+            debug 3.2.7 - MIT
+        </summary>
+        <p><a href="https://github.com/visionmedia/debug#readme">https://github.com/visionmedia/debug#readme</a></p>
+        <ul><li>Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li>
+<li>Copyright (c) 2014-2017 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li></ul>
+        <pre>
+        (The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the &#39;Software&#39;), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED &#39;AS IS&#39;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             debug 2.6.9 - MIT
         </summary>
         <p><a href="https://github.com/visionmedia/debug#readme">https://github.com/visionmedia/debug#readme</a></p>
@@ -3728,38 +3760,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <details>
         <summary>
             debug 4.3.1 - MIT
-        </summary>
-        <p><a href="https://github.com/visionmedia/debug#readme">https://github.com/visionmedia/debug#readme</a></p>
-        <ul><li>Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li>
-<li>Copyright (c) 2014-2017 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li></ul>
-        <pre>
-        (The MIT License)
-
-Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-and associated documentation files (the &#39;Software&#39;), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial 
-portions of the Software.
-
-THE SOFTWARE IS PROVIDED &#39;AS IS&#39;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            debug 3.2.7 - MIT
         </summary>
         <p><a href="https://github.com/visionmedia/debug#readme">https://github.com/visionmedia/debug#readme</a></p>
         <ul><li>Copyright (c) 2014 TJ Holowaychuk &lt;tj@vision-media.ca&gt;</li>
@@ -6052,7 +6052,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            process-nextick-args 1.0.7 - MIT
+            process-nextick-args 2.0.1 - MIT
         </summary>
         <p><a href="https://github.com/calvinmetcalf/process-nextick-args">https://github.com/calvinmetcalf/process-nextick-args</a></p>
         <ul><li>Copyright (c) 2015 Calvin Metcalf</li></ul>
@@ -6083,7 +6083,7 @@ SOFTWARE.**
 <li>
     <details>
         <summary>
-            process-nextick-args 2.0.1 - MIT
+            process-nextick-args 1.0.7 - MIT
         </summary>
         <p><a href="https://github.com/calvinmetcalf/process-nextick-args">https://github.com/calvinmetcalf/process-nextick-args</a></p>
         <ul><li>Copyright (c) 2015 Calvin Metcalf</li></ul>
@@ -6169,7 +6169,7 @@ THE SOFTWARE.
 <li>
     <details>
         <summary>
-            pump 2.0.1 - MIT
+            pump 3.0.0 - MIT
         </summary>
         <p><a href="https://github.com/mafintosh/pump#readme">https://github.com/mafintosh/pump#readme</a></p>
         <ul><li>Copyright (c) 2014 Mathias Buus</li></ul>
@@ -6201,7 +6201,7 @@ THE SOFTWARE.
 <li>
     <details>
         <summary>
-            pump 3.0.0 - MIT
+            pump 2.0.1 - MIT
         </summary>
         <p><a href="https://github.com/mafintosh/pump#readme">https://github.com/mafintosh/pump#readme</a></p>
         <ul><li>Copyright (c) 2014 Mathias Buus</li></ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "1.5.2",
+            "version": "1.6.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",


### PR DESCRIPTION
I decided that it would be worth making this a minor release due to the following reasons:
- v4 will now be the recommended.  This won't break any current users, but it seems like a big enough change to warrant a minor (rather than patch)
- We're removing an API command.  While very unlikely that anyone is using it, if they were, upgrading would break them so better not to be a patch