### PR TITLE
Update version of "@azure/functions" package for TypeScript project

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
@@ -15,8 +15,6 @@ export class JavaScriptProjectCreateStep extends ScriptProjectCreateStep {
         start: 'func start',
         test: 'echo \"No tests yet...\"'
     };
-    protected packageJsonDeps: { [key: string]: string } = {};
-    protected packageJsonDevDeps: { [key: string]: string } = {};
 
     constructor() {
         super();
@@ -33,10 +31,14 @@ export class JavaScriptProjectCreateStep extends ScriptProjectCreateStep {
                 version: '1.0.0',
                 description: '',
                 scripts: this.packageJsonScripts,
-                dependencies: this.packageJsonDeps,
-                devDependencies: this.packageJsonDevDeps
+                dependencies: {},
+                devDependencies: this.getPackageJsonDevDeps(context)
             });
         }
+    }
+
+    protected getPackageJsonDevDeps(_context: IProjectWizardContext): { [key: string]: string } {
+        return {};
     }
 }
 


### PR DESCRIPTION
See https://github.com/Azure/azure-functions-nodejs-worker/issues/428 for more information on the versioning strategy for this package. It's a bit confusing for a few reasons:
- The node.js worker version is off-by-one from the host runtime version
- v2 of the package should've been released a long time ago, but never was