### PR TITLE
Fix build

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -157,7 +157,7 @@ type ActualUnixPS = unixPsTree.PS & { COMM?: string };
 
 async function getUnixChildren(pid: number): Promise<OSAgnosticProcess[]> {
     const processes: ActualUnixPS[] = await new Promise((resolve, reject): void => {
-        unixPsTree(pid, (error: Error | undefined, result: unixPsTree.PS[]) => {
+        unixPsTree(pid, (error: Error | null, result: unixPsTree.PS[]) => {
             if (error) {
                 reject(error);
             } else {

--- a/src/commands/remoteDebugJava/DebugProxy.ts
+++ b/src/commands/remoteDebugJava/DebugProxy.ts
@@ -65,8 +65,8 @@ export class DebugProxy extends EventEmitter {
                             this.emit('error', err);
                         });
 
-                        connection.on('message', (data: websocket.IMessage) => {
-                            if (data.binaryData) {
+                        connection.on('message', (data: websocket.Message) => {
+                            if ('binaryData' in data && data.binaryData) {
                                 socket.write(data.binaryData);
                             }
                         });


### PR DESCRIPTION
Builds on main are currently failing in Dev Ops with the following:

> src/commands/pickFuncProcess.ts(160,25): error TS2345: Argument of type '(error: Error | undefined, result: unixPsTree.PS[]) => void' is not assignable to parameter of type '(error: Error | null, children: readonly PS[]) => void'.
>   Types of parameters 'error' and 'error' are incompatible.
>     Type 'Error | null' is not assignable to type 'Error | undefined'.
>       Type 'null' is not assignable to type 'Error | undefined'.
> src/commands/remoteDebugJava/DebugProxy.ts(68,67): error TS2724: '"D:/a/1/s/node_modules/@types/websocket/index"' has no exported member named 'IMessage'. Did you mean 'Message'?

Likely caused by https://github.com/microsoft/vscode-azurefunctions/pull/2997 👀