### PR TITLE
Drop unsupported .NET versions from JsonCli tool

### DIFF
--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -17,14 +17,9 @@ jobs:
       TeamName: 'AzureTools'
 
   - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 2.0.x'
+    displayName: 'Use .NET Core sdk 3.1.x'
     inputs:
-      version: 2.0.x
-
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 3.0.x'
-    inputs:
-      version: 3.0.x
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: 'Use .NET sdk 5.0.x'
@@ -52,22 +47,12 @@ jobs:
       arguments: '--configuration $(BuildConfiguration)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'dotnet publish 2.0'
+    displayName: 'dotnet publish 3.1'
     inputs:
       command: publish
       publishWebProjects: false
       projects: '$(ProjectPath)'
-      arguments: '--configuration $(BuildConfiguration) --framework netcoreapp2.0 --no-build'
-      zipAfterPublish: false
-      modifyOutputPath: false
-
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet publish 3.0'
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: '$(ProjectPath)'
-      arguments: '--configuration $(BuildConfiguration) --framework netcoreapp3.0 --no-build'
+      arguments: '--configuration $(BuildConfiguration) --framework netcoreapp3.1 --no-build'
       zipAfterPublish: false
       modifyOutputPath: false
 

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -30,7 +30,6 @@ jobs:
     displayName: 'Use .NET sdk 6.0.x'
     inputs:
       version: 6.0.x
-      includePreviewVersions: true
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet restore'

--- a/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
+++ b/tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\resources\FinalPublicKey.snk</AssemblyOriginatorKeyFile>
         <DelaySign>true</DelaySign>

--- a/tools/JsonCli/src/Signing.csproj
+++ b/tools/JsonCli/src/Signing.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>netcoreapp2.0;netcoreapp3.0;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <!-- Since this project is just for signing, we don't want to actually build anything -->
         <DefaultItemExcludes>$(DefaultItemExcludes);**/*.cs</DefaultItemExcludes>
     </PropertyGroup>


### PR DESCRIPTION
.NET Core 2.* and 3.0 are EOL; it'd be best to stop building and stop shipping them. I removed the 2.0 entirely and bumped the 3.0 to 3.1, which is supported until 3 Dec 2022.