### PR TITLE
Escape some characters before finding files with globby

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -21,8 +21,13 @@ export function isMultiRootWorkspace(): boolean {
 export async function findFiles(base: vscode.WorkspaceFolder | string, pattern: string): Promise<vscode.Uri[]> {
     // Per globby docs: "Note that glob patterns can only contain forward-slashes, not backward-slashes, so if you want to construct a glob pattern from path components, you need to use path.posix.join() instead of path.join()"
     const posixBase = path.posix.normalize(typeof base === 'string' ? base : base.uri.fsPath).replace(/\\/g, '/');
-    const fullPattern = path.posix.join(posixBase, pattern);
+    const escapedBase = escapeCharacters(posixBase)
+    const fullPattern = path.posix.join(escapedBase, pattern);
     return (await globby(fullPattern)).map(s => vscode.Uri.file(s));
+}
+
+function escapeCharacters(nonPattern: string): string {
+    return nonPattern.replace(/[[\]{}()*+?.,\\^$|#]/g, '\\$&')
 }
 
 export async function selectWorkspaceFolder(context: IActionContext, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {


### PR DESCRIPTION
Sometimes file search bases will have special characters that will unintentionally change the pattern. Removing those special characters gives intended results.

Fixes #3019