### PR TITLE
Handle multiple target frameworks when creating function via API

### DIFF
--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -24,7 +24,7 @@ export interface IProjectWizardContext extends IActionContext {
     generateFromOpenAPI?: boolean;
     openApiSpecificationFile?: Uri[];
 
-    targetFramework?: string;
+    targetFrameworks?: string[];
 }
 
 export type OpenBehavior = 'AddToWorkspace' | 'OpenInNewWindow' | 'OpenInCurrentWindow' | 'AlreadyOpen' | 'DontOpen';

--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -24,7 +24,7 @@ export interface IProjectWizardContext extends IActionContext {
     generateFromOpenAPI?: boolean;
     openApiSpecificationFile?: Uri[];
 
-    targetFrameworks?: string[];
+    targetFramework?: string | string[];
 }
 
 export type OpenBehavior = 'AddToWorkspace' | 'OpenInNewWindow' | 'OpenInCurrentWindow' | 'AlreadyOpen' | 'DontOpen';

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -14,13 +14,14 @@ import { IProjectWizardContext } from "../IProjectWizardContext";
 
 export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardContext> {
     public static async createStep(context: IProjectWizardContext): Promise<DotnetRuntimeStep> {
-        if (context.targetFrameworks) {
+        if (context.targetFramework) {
+            context.targetFramework = typeof context.targetFramework === 'string' ? [context.targetFramework] : context.targetFramework;
             const runtimes = await getRuntimes(context);
             // if a targetFramework was provided from createNewProject
-            const workerRuntime = runtimes.find(runtime => context.targetFrameworks?.includes(runtime.targetFramework));
+            const workerRuntime = runtimes.find(runtime => context.targetFramework?.includes(runtime.targetFramework));
             if (!workerRuntime) {
                 throw new Error(localize('unknownFramework', 'Unrecognized target frameworks: "{0}". Available frameworks: {1}.',
-                    context.targetFrameworks.map(tf => `"${tf}"`).join(', '),
+                    context.targetFramework.map(tf => `"${tf}"`).join(', '),
                     runtimes.map(rt => `"${rt.targetFramework}"`).join(', ')));
             }
             setWorkerRuntime(context, workerRuntime);

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -14,12 +14,13 @@ import { IProjectWizardContext } from "../IProjectWizardContext";
 
 export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardContext> {
     public static async createStep(context: IProjectWizardContext): Promise<DotnetRuntimeStep> {
-        if (context.targetFramework) {
+        if (context.targetFrameworks) {
             const runtimes = await getRuntimes(context);
             // if a targetFramework was provided from createNewProject
-            const workerRuntime = runtimes.find(runtime => runtime.targetFramework === context.targetFramework);
+            const workerRuntime = runtimes.find(runtime => context.targetFrameworks?.includes(runtime.targetFramework));
             if (!workerRuntime) {
-                throw new Error(localize('unknownFramework', 'Unrecognized target framework "{0}". Available frameworks: {1}.', context.targetFramework,
+                throw new Error(localize('unknownFramework', 'Unrecognized target frameworks: "{0}". Available frameworks: {1}.',
+                    context.targetFrameworks.map(tf => `"${tf}"`).join(', '),
                     runtimes.map(rt => `"${rt.targetFramework}"`).join(', ')));
             }
             setWorkerRuntime(context, workerRuntime);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         createFunction: createFunctionFromApi,
         downloadAppSettings: downloadAppSettingsFromApi,
         uploadAppSettings: uploadAppSettingsFromApi,
-        apiVersion: '1.6.0'
+        apiVersion: '1.7.0'
     }]);
 }
 

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -82,5 +82,5 @@ export interface ICreateFunctionOptions {
     /**
      * If set, it will automatically select the worker runtime for .NET with the matching targetFramework
      */
-    targetFrameworks?: string[];
+    targetFramework?: string | string[];
 }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -82,5 +82,5 @@ export interface ICreateFunctionOptions {
     /**
      * If set, it will automatically select the worker runtime for .NET with the matching targetFramework
      */
-    targetFramework?: string;
+    targetFrameworks?: string[];
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -36,7 +36,7 @@ suite(`AzureFunctionsExtensionApi`, () => {
                 templateId: 'HttpTrigger',
                 languageFilter: /Python|C\#|^(Java|Type)Script$/i,
                 functionSettings: { authLevel: 'anonymous' },
-                targetFrameworks: ['netcoreapp3.1', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+                targetFramework: ['netcoreapp3.1', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
             });
         });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -36,7 +36,7 @@ suite(`AzureFunctionsExtensionApi`, () => {
                 templateId: 'HttpTrigger',
                 languageFilter: /Python|C\#|^(Java|Type)Script$/i,
                 functionSettings: { authLevel: 'anonymous' },
-                targetFramework: 'netcoreapp3.1' // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
+                targetFrameworks: ['netcoreapp3.1', 'net6.0'] // Will only work on functions api v1.4.0, but won't hurt on v1.3.0
             });
         });
 


### PR DESCRIPTION
Need to be able to specify multiple target frameworks to fix https://github.com/microsoft/vscode-azurestaticwebapps/issues/590.