### PR TITLE
Scope CG detection to JSON CLI tool only

### DIFF
--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -142,6 +142,12 @@ jobs:
       AllTools: true
     condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+    inputs:
+      sourceScanPath: tools/JsonCli # Scope only to the JSON CLI tool, since that's all this build is for
+
 trigger: none
 
 pr: none


### PR DESCRIPTION
This should scope the component governance detection to only the JSON CLI tool for that build. The net effect is that we stop getting duplicate CG alerts in the internal tenant.