### PR TITLE
Validate java build tool in create step execution, fix issue #3059

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from "@microsoft/vscode-azext-utils";
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { Progress } from 'vscode';
@@ -16,18 +15,14 @@ import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContex
 import { java11, java8 } from '../javaSteps/JavaVersionStep';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
-const backupGradlePluginVersion = "1.7.0";
+const backupGradlePluginVersion = "1.8.2";
 const metaDataUrl = "https://plugins.gradle.org/m2/com/microsoft/azure/azure-functions-gradle-plugin/maven-metadata.xml";
 
 export class GradleProjectCreateStep extends ScriptProjectCreateStep {
     protected gitignore: string = gradleGitignore;
 
-    public static async createStep(context: IActionContext): Promise<GradleProjectCreateStep> {
-        await gradleUtils.validateGradleInstalled(context);
-        return new GradleProjectCreateStep();
-    }
-
     public async executeCore(context: IJavaProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        await gradleUtils.validateGradleInstalled(context);
         await super.executeCore(context, progress);
 
         const settingsGradlePath: string = path.join(context.projectPath, settingsGradleFileName);

--- a/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
@@ -16,20 +15,14 @@ import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContex
 import { ProjectCreateStepBase } from './ProjectCreateStepBase';
 
 export class MavenProjectCreateStep extends ProjectCreateStepBase {
-    private constructor() {
-        super();
-    }
-
-    public static async createStep(context: IActionContext): Promise<MavenProjectCreateStep> {
-        await mavenUtils.validateMavenInstalled(context);
-        return new MavenProjectCreateStep();
-    }
 
     public shouldExecute(context: IJavaProjectWizardContext): boolean {
         return context.buildTool === JavaBuildTool.maven;
     }
 
     public async executeCore(context: IJavaProjectWizardContext): Promise<void> {
+        await mavenUtils.validateMavenInstalled(context);
+
         const javaVersion: string = nonNullProp(context, 'javaVersion');
         const artifactId: string = nonNullProp(context, 'javaArtifactId');
         const tempFolder: string = path.join(os.tmpdir(), fsUtil.getRandomHexString());

--- a/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
+++ b/src/commands/createNewProject/javaSteps/addJavaCreateProjectSteps.ts
@@ -22,5 +22,5 @@ export async function addJavaCreateProjectSteps(
     executeSteps: AzureWizardExecuteStep<IProjectWizardContext>[]): Promise<void> {
     await JavaVersionStep.setDefaultVersion(context);
     promptSteps.push(new JavaVersionStep(), new JavaGroupIdStep(), new JavaArtifactIdStep(), new JavaProjectVersionStep(), new JavaPackageNameStep(), new JavaAppNameStep(), new JavaBuildToolStep());
-    executeSteps.push(await MavenProjectCreateStep.createStep(context), await GradleProjectCreateStep.createStep(context));
+    executeSteps.push(new MavenProjectCreateStep(), new GradleProjectCreateStep());
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3059

We used to validate build tool(maven) installed during `JavaProjectCreateStep.createStep()`, however, now we support two build tools(maven/gradle) and missing any of them will break the project creation wizard. So, move the validation to `executeCore` in case user only have one java build tool in their path.

**Next Steps**
May refactor `JavaBuildToolStep` to auto select the build tool if use only have one of them
