### PR TITLE
Add Execute Step in createFunction API 

### DIFF
--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -49,6 +49,7 @@ export async function createNewProjectInternal(context: IActionContext, options:
     const version: string = options.version || getGlobalSetting(funcVersionSetting) || await tryGetLocalFuncVersion(context, undefined) || latestGAVersion;
     const projectTemplateKey: string | undefined = getGlobalSetting(projectTemplateKeySetting);
     const wizardContext: Partial<IFunctionWizardContext> & IActionContext = Object.assign(context, options, { language, version: tryParseFuncVersion(version), projectTemplateKey });
+    const optionalExecuteStep = options.executeStep;
 
     if (options.folderPath) {
         FolderListStep.setProjectPath(wizardContext, options.folderPath);
@@ -64,7 +65,7 @@ export async function createNewProjectInternal(context: IActionContext, options:
     const wizard: AzureWizard<IFunctionWizardContext> = new AzureWizard(wizardContext, {
         title: localize('createNewProject', 'Create new project'),
         promptSteps: [new FolderListStep(), new NewProjectLanguageStep(options.templateId, options.functionSettings), new OpenBehaviorStep()],
-        executeSteps: [new OpenFolderStep()]
+        ...(optionalExecuteStep !== undefined ? { executeSteps: [optionalExecuteStep, new OpenFolderStep()] } : { executeSteps: [new OpenFolderStep()] }),
     });
     await wizard.prompt();
     await wizard.execute();

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -65,7 +65,7 @@ export async function createNewProjectInternal(context: IActionContext, options:
     const wizard: AzureWizard<IFunctionWizardContext> = new AzureWizard(wizardContext, {
         title: localize('createNewProject', 'Create new project'),
         promptSteps: [new FolderListStep(), new NewProjectLanguageStep(options.templateId, options.functionSettings), new OpenBehaviorStep()],
-        ...(optionalExecuteStep !== undefined ? { executeSteps: [optionalExecuteStep, new OpenFolderStep()] } : { executeSteps: [new OpenFolderStep()] }),
+        executeSteps: optionalExecuteStep ? [optionalExecuteStep, new OpenFolderStep()] : [new OpenFolderStep()]
     });
     await wizard.prompt();
     await wizard.execute();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,7 +99,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         createFunction: createFunctionFromApi,
         downloadAppSettings: downloadAppSettingsFromApi,
         uploadAppSettings: uploadAppSettingsFromApi,
-        apiVersion: '1.7.0'
+        apiVersion: '1.8.0'
     }]);
 }
 

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -87,7 +87,7 @@ export interface ICreateFunctionOptions {
     targetFramework?: string | string[];
 
     /**
-     * If set, it will include a step that will be executed prior to OpenFolderStep
+     * If set, it will include a step that will be executed prior to OpenFolderStep based on the priority of the step
      */
     executeStep?: AzureWizardExecuteStep<IActionContext>;
 }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -87,7 +87,8 @@ export interface ICreateFunctionOptions {
     targetFramework?: string | string[];
 
     /**
-     * If set, it will include a step that will be executed prior to OpenFolderStep based on the priority of the step
+     * If set, it will include a step that will be executed prior to OpenFolderStep determined by the priority of the step
+     * OpenFolder priority is 250 (https://github.com/microsoft/vscode-azurefunctions/blob/main/src/commands/createNewProject/OpenFolderStep.ts#L11)
      */
     executeStep?: AzureWizardExecuteStep<IActionContext>;
 }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzureWizardExecuteStep, IActionContext } from "@microsoft/vscode-azext-utils";
+
 export interface AzureFunctionsExtensionApi {
     apiVersion: string;
 
@@ -83,4 +85,9 @@ export interface ICreateFunctionOptions {
      * If set, it will automatically select the worker runtime for .NET with the matching targetFramework
      */
     targetFramework?: string | string[];
+
+    /**
+     * If set, it will include a step that will be executed prior to OpenFolderStep
+     */
+    executeStep?: AzureWizardExecuteStep<IActionContext>;
 }


### PR DESCRIPTION
This additional API property would allow users to execute logic in relation to the azure function project they are creating prior to the OpenFolderStep by setting the priority accordingly. 

This will aid in the creation of Azure Function with SQL Bindings as a user will need to create new azure function project and the logic to add SQL connection string to local.settings.json would not run due to the vscode extension host reloading based on the user choosing to `Open in current window` or `Open in new window`: 
<img width="513" alt="Screen Shot 2022-04-22 at 1 03 10 PM" src="https://user-images.githubusercontent.com/23587151/166647577-7a89169a-bdfd-4045-8c3e-49694fd75290.png">

This would benefit our users greatly and would be a much-improved user experience as a whole. 

Tested this locally via https://github.com/microsoft/azuredatastudio/pull/19293. 