### PR TITLE
Hide openInPortal command from palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.6.3-alpha.7",
+    "version": "1.6.3-alpha.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.6.3-alpha.7",
+            "version": "1.6.3-alpha.8",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -626,6 +626,10 @@
             ],
             "commandPalette": [
                 {
+                    "command": "azureFunctions.openInPortal",
+                    "when": "never"
+                },
+                {
                     "command": "azureFunctions.pickProcess",
                     "when": "never"
                 },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.6.3-alpha.7",
+    "version": "1.6.3-alpha.8",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/openInPortal.ts
+++ b/src/commands/openInPortal.ts
@@ -5,17 +5,7 @@
 
 import { openInPortal as uiOpenInPortal } from '@microsoft/vscode-azext-azureutils';
 import { AzExtTreeItem, IActionContext, nonNullProp } from '@microsoft/vscode-azext-utils';
-import { functionFilter } from '../constants';
-import { ext } from '../extensionVariables';
-import { ResolvedFunctionAppResource } from '../tree/ResolvedFunctionAppResource';
 
-export async function openDeploymentInPortal(context: IActionContext, node?: AzExtTreeItem): Promise<void> {
-    if (!node) {
-        node = await ext.rgApi.pickAppResource<AzExtTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
-        });
-    }
-
+export async function openDeploymentInPortal(_context: IActionContext, node: AzExtTreeItem): Promise<void> {
     await uiOpenInPortal(node, `${nonNullProp(node, 'parent').parent?.id}/Deployments/${nonNullProp(node, 'id')}`);
 }


### PR DESCRIPTION
This command now only handles opening deployments in the portal, so I think it's ok to remove from the palette.

Alternatively, we could rebrand this command as "Open Deployment in Portal", but we don't have any other commands like that so I felt it wasn't necessary.