### PR TITLE
Check for sql binding triggers and skip storage prompt if so

### DIFF
--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -109,7 +109,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                     break;
             }
 
-            if (!template.isHttpTrigger && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context, context.projectPath)) {
+            if ((!template.isHttpTrigger && !template.isSqlBindingTrigger) && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context, context.projectPath)) {
                 promptSteps.push(new AzureWebJobsStoragePromptStep());
                 executeSteps.push(new AzureWebJobsStorageExecuteStep());
             }

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -109,7 +109,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                     break;
             }
 
-            if ((!template.isHttpTrigger && !template.isSqlBindingTrigger) && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context, context.projectPath)) {
+            if ((!template.isHttpTrigger && !template.isSqlBindingTemplate) && !canValidateAzureWebJobStorageOnDebug(context.language) && !await getAzureWebJobsStorage(context, context.projectPath)) {
                 promptSteps.push(new AzureWebJobsStoragePromptStep());
                 executeSteps.push(new AzureWebJobsStorageExecuteStep());
             }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -98,3 +98,4 @@ export const viewOutput: string = localize('viewOutput', 'View Output');
 export const previewDescription: string = localize('preview', '(Preview)');
 
 export const webProvider: string = 'Microsoft.Web';
+export const sqlBindingTemplateRegex: RegExp = /Sql.*Binding/i;

--- a/src/templates/IFunctionTemplate.ts
+++ b/src/templates/IFunctionTemplate.ts
@@ -19,6 +19,7 @@ export interface IFunctionTemplate {
     language: string;
     isHttpTrigger: boolean;
     isTimerTrigger: boolean;
+    isSqlBindingTrigger: boolean;
     userPromptedSettings: IBindingSetting[];
     categories: TemplateCategory[];
 }

--- a/src/templates/IFunctionTemplate.ts
+++ b/src/templates/IFunctionTemplate.ts
@@ -19,7 +19,7 @@ export interface IFunctionTemplate {
     language: string;
     isHttpTrigger: boolean;
     isTimerTrigger: boolean;
-    isSqlBindingTrigger: boolean;
+    isSqlBindingTemplate: boolean;
     userPromptedSettings: IBindingSetting[];
     categories: TemplateCategory[];
 }

--- a/src/templates/dotnet/parseDotnetTemplates.ts
+++ b/src/templates/dotnet/parseDotnetTemplates.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
-import { ProjectLanguage, TemplateFilter } from '../../constants';
+import { ProjectLanguage, sqlBindingTemplateRegex, TemplateFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { FuncVersion } from '../../FuncVersion';
 import { localize } from '../../localize';
@@ -74,7 +74,7 @@ function parseDotnetTemplate(rawTemplate: IRawTemplate): IFunctionTemplate {
     return {
         isHttpTrigger: /^http/i.test(rawTemplate.Name) || /webhook$/i.test(rawTemplate.Name),
         isTimerTrigger: /^timer/i.test(rawTemplate.Name),
-        isSqlBindingTrigger: /Sql.*Binding/i.test(rawTemplate.Name),
+        isSqlBindingTemplate: sqlBindingTemplateRegex.test(rawTemplate.Name),
         id: rawTemplate.Identity,
         name: rawTemplate.Name,
         defaultFunctionName: rawTemplate.DefaultName,

--- a/src/templates/dotnet/parseDotnetTemplates.ts
+++ b/src/templates/dotnet/parseDotnetTemplates.ts
@@ -74,6 +74,7 @@ function parseDotnetTemplate(rawTemplate: IRawTemplate): IFunctionTemplate {
     return {
         isHttpTrigger: /^http/i.test(rawTemplate.Name) || /webhook$/i.test(rawTemplate.Name),
         isTimerTrigger: /^timer/i.test(rawTemplate.Name),
+        isSqlBindingTrigger: /Sql.*Binding/i.test(rawTemplate.Name),
         id: rawTemplate.Identity,
         name: rawTemplate.Name,
         defaultFunctionName: rawTemplate.DefaultName,

--- a/src/templates/script/parseScriptTemplates.ts
+++ b/src/templates/script/parseScriptTemplates.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isString } from 'util';
-import { ProjectLanguage } from '../../constants';
+import { ProjectLanguage, sqlBindingTemplateRegex } from '../../constants';
 import { IFunctionBinding, ParsedFunctionJson } from '../../funcConfig/function';
 import { localize } from '../../localize';
 import { IBindingSetting, IBindingTemplate, IEnumValue, ResourceType, ValueType } from '../IBindingTemplate';
@@ -221,7 +221,7 @@ export function parseScriptTemplate(rawTemplate: IRawTemplate, resources: IResou
         functionJson,
         isHttpTrigger: functionJson.isHttpTrigger,
         isTimerTrigger: functionJson.isTimerTrigger,
-        isSqlBindingTrigger: /Sql.*Binding/i.test(rawTemplate.id),
+        isSqlBindingTemplate: sqlBindingTemplateRegex.test(rawTemplate.id),
         id: rawTemplate.id,
         name: getResourceValue(resources, rawTemplate.metadata.name),
         defaultFunctionName: rawTemplate.metadata.defaultFunctionName,

--- a/src/templates/script/parseScriptTemplates.ts
+++ b/src/templates/script/parseScriptTemplates.ts
@@ -221,6 +221,7 @@ export function parseScriptTemplate(rawTemplate: IRawTemplate, resources: IResou
         functionJson,
         isHttpTrigger: functionJson.isHttpTrigger,
         isTimerTrigger: functionJson.isTimerTrigger,
+        isSqlBindingTrigger: /Sql.*Binding/i.test(rawTemplate.id),
         id: rawTemplate.id,
         name: getResourceValue(resources, rawTemplate.metadata.name),
         defaultFunctionName: rawTemplate.metadata.defaultFunctionName,


### PR DESCRIPTION
SqlInputBinding triggers and SqlOutputBinding triggers both don't actually need a storage account for debugging, but we do a blanket check of it not being an httpTrigger, then prompt for an Azure storage account.

A partner team is using the Functions API to create a project for their users and having that prompt is a bit of a roadblocker for their UI.  This should hopefully fix that.