### PR TITLE
Add node types to TS project template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.7.4-alpha.0",
+    "version": "1.7.4-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.7.4-alpha.0",
+            "version": "1.7.4-alpha.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.7.4-alpha.0",
+    "version": "1.7.4-alpha.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",

--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -42,24 +42,31 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
     protected getPackageJsonDevDeps(context: IProjectWizardContext): { [key: string]: string } {
         // NOTE: Types package matches node worker version, not func host version
         // See version matrix here: https://www.npmjs.com/package/@azure/functions
-        let nodeWorkerVersion: string;
+        let funcTypesVersion: string;
+        // For the node types package, we'll use the latest LTS version possible
+        // See version matrix here: https://docs.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-javascript#languages
+        let nodeTypesVersion: string;
         switch (context.version) {
             case FuncVersion.v4:
-                nodeWorkerVersion = '3';
+                funcTypesVersion = '3';
+                nodeTypesVersion = '16';
                 break;
             case FuncVersion.v3:
-                nodeWorkerVersion = '2';
+                funcTypesVersion = '2';
+                nodeTypesVersion = '14';
                 break;
             case FuncVersion.v2:
-                nodeWorkerVersion = '1';
+                funcTypesVersion = '1';
+                nodeTypesVersion = '10';
                 break;
             default:
                 throw new Error(localize('typeScriptNoV1', 'TypeScript projects are not supported on Azure Functions v1.'));
         }
 
         return {
-            '@azure/functions': `^${nodeWorkerVersion}.0.0`,
-            typescript: '^4.0.0'
+            '@azure/functions': `^${funcTypesVersion}.0.0`,
+            '@types/node': `${nodeTypesVersion}.x`,
+            typescript: '^4.0.0',
         };
     }
 }


### PR DESCRIPTION
I used x range (`1.x`) instead of caret (`^1.0.0`) to match ` yo code`, although I don't really care. Decided not to check local node version, just the func version. Didn't seem like Brandon cared about being super exact either.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3199