### PR TITLE
Push Framework argument for .net7.0 

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -42,9 +42,8 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         const functionsVersion: string = 'v' + majorVersion;
         const projTemplateKey = nonNullProp(context, 'projectTemplateKey');
         const args = ['--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion];
-        if (/net7.[0-9]/.test(projTemplateKey)) {
-            args.push('--arg:Framework', cpUtils.wrapArgInQuotes('net7.0'));
-        }
+        // defaults to net6.0 if there is no targetFramework
+        args.push('--arg:Framework', cpUtils.wrapArgInQuotes(context.workerRuntime?.targetFramework));
 
         await executeDotnetTemplateCommand(context, version, projTemplateKey, context.projectPath, 'create', ...args);
 

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -41,7 +41,12 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         }
         const functionsVersion: string = 'v' + majorVersion;
         const projTemplateKey = nonNullProp(context, 'projectTemplateKey');
-        await executeDotnetTemplateCommand(context, version, projTemplateKey, context.projectPath, 'create', '--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion);
+        const args = ['--identity', identity, '--arg:name', cpUtils.wrapArgInQuotes(projectName), '--arg:AzureFunctionsVersion', functionsVersion];
+        if (/net7.[0-9]/.test(projTemplateKey)) {
+            args.push('--arg:Framework', cpUtils.wrapArgInQuotes('net7.0'));
+        }
+
+        await executeDotnetTemplateCommand(context, version, projTemplateKey, context.projectPath, 'create', ...args);
 
         await setLocalAppSetting(context, context.projectPath, azureWebJobsStorageKey, '', MismatchBehavior.Overwrite);
     }

--- a/src/utils/cpUtils.ts
+++ b/src/utils/cpUtils.ts
@@ -86,7 +86,8 @@ export namespace cpUtils {
     /**
      * Ensures spaces and special characters (most notably $) are preserved
      */
-    export function wrapArgInQuotes(arg: string | boolean | number): string {
+    export function wrapArgInQuotes(arg?: string | boolean | number): string {
+        arg ??= '';
         return typeof arg === 'string' ? quotationMark + arg + quotationMark : String(arg);
     }
 }


### PR DESCRIPTION
@ejizba Just wanted to check with you on this-- so I should only have to pass `--arg: Framework net7.0` on project creation since that is when the `.csproj` is generated and that's where `Framework` is actually replacing `TargetFrameworkValue`.

On a `FunctionCreate`, assumedly the project is already created with the appropriate `.csproj` file.