### PR TITLE
Just use the 1st value for creating python projects

### DIFF
--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -38,7 +38,7 @@ for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
 
     testCases.push({
         ...getPythonValidateOptions('.venv', version),
-        inputs: ['python']
+        inputs: [TestInput.UseDefaultValue]
     });
 
     const appName: string = 'javaApp';


### PR DESCRIPTION
The input choices are different between OS's, so just use the 1st value. I don't think we're testing for any specific version anyway.