### PR TITLE
Add net7 tests

### DIFF
--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -47,6 +47,7 @@ for (const source of allTemplateSources) {
     addSuite(FuncVersion.v4, 'net5.0', source, true);
     addSuite(FuncVersion.v4, 'net6.0', source, true);
     addSuite(FuncVersion.v4, 'net6.0', source, false);
+    addSuite(FuncVersion.v4, 'net7.0', source, true);
 }
 
 function addSuite(version: FuncVersion, targetFramework: string, source: TemplateSource, isIsolated?: boolean): void {

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -117,7 +117,7 @@ async function preLoadTemplates(): Promise<void> {
  * Not worth testing older versions for every build
  */
 export function isLongRunningVersion(version: FuncVersion): boolean {
-    return version === FuncVersion.v1 || version === FuncVersion.v2;
+    return version === FuncVersion.v1 || version === FuncVersion.v2 || version === FuncVersion.v3;
 }
 
 export function shouldSkipVersion(version: FuncVersion): boolean {

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -22,7 +22,7 @@ const testCases: CreateProjectTestCase[] = [
     // { ...getCSharpValidateOptions('net5.0', FuncVersion.v4), inputs: [/5/], description: 'net5.0 isolated v4' },
     { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/6/], description: 'net6.0' },
     { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/6.*isolated/i], description: 'net6.0 isolated' },
-    { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/7.*isolated/i], description: 'net7.0 isolated' },
+    { ...getCSharpValidateOptions('net7.0', FuncVersion.v4), inputs: [/7.*isolated/i], description: 'net7.0 isolated' },
     { ...getFSharpValidateOptions('netcoreapp2.1', FuncVersion.v2), isHiddenLanguage: true },
     { ...getFSharpValidateOptions('netcoreapp3.1', FuncVersion.v3), inputs: [/3/], isHiddenLanguage: true },
 ];

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -22,6 +22,7 @@ const testCases: CreateProjectTestCase[] = [
     // { ...getCSharpValidateOptions('net5.0', FuncVersion.v4), inputs: [/5/], description: 'net5.0 isolated v4' },
     { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/6/], description: 'net6.0' },
     { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/6.*isolated/i], description: 'net6.0 isolated' },
+    { ...getCSharpValidateOptions('net6.0', FuncVersion.v4), inputs: [/7.*isolated/i], description: 'net7.0 isolated' },
     { ...getFSharpValidateOptions('netcoreapp2.1', FuncVersion.v2), isHiddenLanguage: true },
     { ...getFSharpValidateOptions('netcoreapp3.1', FuncVersion.v3), inputs: [/3/], isHiddenLanguage: true },
 ];


### PR DESCRIPTION
Also as v4 is the recommend runtime now, skip v3 unless it's a long running test.