### PR TITLE
Load siteConfig on resolve

### DIFF
--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -5,21 +5,15 @@ import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource"
 import { createWebSiteClient } from "./utils/azureClients";
 
 export class FunctionAppResolver implements AppResourceResolver {
-    public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | null> {
+    public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
-            try {
-                const client = await createWebSiteClient({ ...context, ...subContext });
-                const rg = getResourceGroupFromId(nonNullProp(resource, 'id'));
-                const name = nonNullProp(resource, 'name');
-                const site = await client.webApps.get(rg, name);
-                site.siteConfig = await client.webApps.getConfiguration(rg, name)
-                return new ResolvedFunctionAppResource(subContext, site);
-
-            } catch (e) {
-                console.error({ ...context, ...subContext });
-                throw e;
-            }
-        }) ?? null;
+            const client = await createWebSiteClient({ ...context, ...subContext });
+            const rg = getResourceGroupFromId(nonNullProp(resource, 'id'));
+            const name = nonNullProp(resource, 'name');
+            const site = await client.webApps.get(rg, name);
+            site.siteConfig = await client.webApps.getConfiguration(rg, name)
+            return new ResolvedFunctionAppResource(subContext, site);
+        });
     }
 
     public matchesResource(resource: AppResource): boolean {

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -9,7 +9,10 @@ export class FunctionAppResolver implements AppResourceResolver {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
             try {
                 const client = await createWebSiteClient({ ...context, ...subContext });
-                const site = await client.webApps.get(getResourceGroupFromId(nonNullProp(resource, 'id')), nonNullProp(resource, 'name'));
+                const rg = getResourceGroupFromId(nonNullProp(resource, 'id'));
+                const name = nonNullProp(resource, 'name');
+                const site = await client.webApps.get(rg, name);
+                site.siteConfig = await client.webApps.getConfiguration(rg, name)
                 return new ResolvedFunctionAppResource(subContext, site);
 
             } catch (e) {

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -10,9 +10,9 @@ export class FunctionAppResolver implements AppResourceResolver {
             const client = await createWebSiteClient({ ...context, ...subContext });
             const rg = getResourceGroupFromId(nonNullProp(resource, 'id'));
             const name = nonNullProp(resource, 'name');
+
             const site = await client.webApps.get(rg, name);
-            site.siteConfig = await client.webApps.getConfiguration(rg, name)
-            return new ResolvedFunctionAppResource(subContext, site);
+            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, site);
         });
     }
 

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -26,6 +26,8 @@ export function isResolvedFunctionApp(ti: unknown): ti is ResolvedAppResourceBas
 
 export class ResolvedFunctionAppResource implements ResolvedAppResourceBase {
     public site: ParsedSite;
+    public data: Site;
+
     private _subscription: ISubscriptionContext;
     public logStreamPath: string = '';
     public appSettingsTreeItem: AppSettingsTreeItem;
@@ -57,6 +59,7 @@ export class ResolvedFunctionAppResource implements ResolvedAppResourceBase {
 
     public constructor(subscription: ISubscriptionContext, site: Site) {
         this.site = new ParsedSite(site, subscription);
+        this.data = this.site.rawSite;
         this._subscription = subscription;
         this.contextValuesToAdd = [this.site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue];
 

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -77,6 +77,12 @@ export class ResolvedFunctionAppResource implements ResolvedAppResourceBase {
         }
     }
 
+    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site): ResolvedFunctionAppResource {
+        const resource = new ResolvedFunctionAppResource(subscription, site);
+        void resource.site.createClient(context).then(async (client) => resource.data.siteConfig = await client.getSiteConfig())
+        return resource;
+    }
+
     public get name(): string {
         return this.label;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3264

It's easier to just add the siteConfig on resolve than to try to call `viewProperties` from the Functions extension. It makes the resolve a little bit slower, but it doesn't seem to be that noticeable.