### PR TITLE
Use language model in template provider caching.

### DIFF
--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -124,8 +124,8 @@ export class CentralTemplateProvider implements Disposable {
     }
 
     private getCachedProvidersKey(language: ProjectLanguage, languageModel: number | undefined, version: FuncVersion): string {
-        // NOTE: VS Code treats lack of a language model project setting as a 0, so treat undefined === 0.
-        return `${language}:${languageModel !== undefined ? languageModel : 0}:${version}`;
+        // NOTE: VS Code treats lack of a language model project setting as a 0, so treat undefined === null === 0.
+        return `${language}:${languageModel ?? 0}:${version}`;
     }
 
     private tryGetCachedProviders(projectPath: string | undefined, language: ProjectLanguage, languageModel: number | undefined, version: FuncVersion): CachedProviders | undefined {


### PR DESCRIPTION
Use the language model in the template provider cache key to differentiate providers of templates of different models (e.g. Python from Python V2).

Resolves #3300.
