### PR TITLE
Limit opening documents to certain scenarios.

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/PysteinProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/PysteinProjectCreateStep.ts
@@ -75,14 +75,18 @@ export class PysteinProjectCreateStep extends ScriptProjectCreateStep {
 
         const functionAppPath = Uri.file(path.join(context.projectPath, pythonFunctionAppFileName));
 
-        if (await fileExists(functionAppPath)) {
-            await window.showTextDocument(await workspace.openTextDocument(functionAppPath));
-        }
+        // Only open the documents if they're part of the existing/new workspace.
+        // NOTE: We don't currently have a way to open specific documents in the new (or reloaded) window.
+        if (context.openBehavior === 'AddToWorkspace' || context.openBehavior === 'AlreadyOpen') {
+            if (await fileExists(functionAppPath)) {
+                await window.showTextDocument(await workspace.openTextDocument(functionAppPath));
+            }
 
-        const gettingStartedPath = Uri.file(path.join(context.projectPath, gettingStartedFileName));
+            const gettingStartedPath = Uri.file(path.join(context.projectPath, gettingStartedFileName));
 
-        if (await fileExists(gettingStartedPath)) {
-            await showMarkdownPreviewFile(gettingStartedPath, /* openToSide: */ true);
+            if (await fileExists(gettingStartedPath)) {
+                await showMarkdownPreviewFile(gettingStartedPath, /* openToSide: */ true);
+            }
         }
     }
 


### PR DESCRIPTION
Only open the documents if the folder is already open or the new folder is added to the existing workspace.  In the other scenarios (e.g. open in current or new window), VS Code will reload the current window or open a new window, making it inappropriate to open the documents in the current window (i.e. before the reload).

Resolves #3307