### PR TITLE
Support java 17 runtime when create function project

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -7,12 +7,12 @@ import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { Progress } from 'vscode';
 import { buildGradleFileName, JavaBuildTool, settingsGradleFileName } from '../../../constants';
-import { localize } from '../../../localize';
 import { confirmOverwriteFile } from '../../../utils/fs';
 import { gradleUtils } from '../../../utils/gradleUtils';
 import { javaUtils } from '../../../utils/javaUtils';
+import { nonNullProp } from '../../../utils/nonNull';
 import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContext';
-import { java11, java8 } from '../javaSteps/JavaVersionStep';
+import { java8 } from '../javaSteps/JavaVersionStep';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
 const backupGradlePluginVersion = "1.8.2";
@@ -54,14 +54,9 @@ export class GradleProjectCreateStep extends ScriptProjectCreateStep {
         return `rootProject.name = "${context.javaArtifactId}"`;
     }
 
-    getCompatibilityVersion(javaVersion: string | undefined): string {
-        if (javaVersion === java8) {
-            return "1.8";
-        } else if (javaVersion === java11) {
-            return "11";
-        } else {
-            throw new Error(localize('invalidJavaVersion', 'Invalid Java version "{0}".', javaVersion));
-        }
+    getCompatibilityVersion(context: IJavaProjectWizardContext): string {
+        const javaVersion: string = nonNullProp(context, 'javaVersion');
+        return javaVersion === java8 ? "1.8" : javaVersion;
     }
 
     async getBuildGradleContent(context: IJavaProjectWizardContext): Promise<string> {
@@ -80,8 +75,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.3.3'
 }
 
-sourceCompatibility = '${this.getCompatibilityVersion(context.javaVersion)}'
-targetCompatibility = '${this.getCompatibilityVersion(context.javaVersion)}'
+sourceCompatibility = '${this.getCompatibilityVersion(context)}'
+targetCompatibility = '${this.getCompatibilityVersion(context)}'
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GradleProjectCreateSteps.ts
@@ -15,7 +15,7 @@ import { IJavaProjectWizardContext } from '../javaSteps/IJavaProjectWizardContex
 import { java8 } from '../javaSteps/JavaVersionStep';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
-const backupGradlePluginVersion = "1.8.2";
+const backupGradlePluginVersion = "1.11.0";
 const metaDataUrl = "https://plugins.gradle.org/m2/com/microsoft/azure/azure-functions-gradle-plugin/maven-metadata.xml";
 
 export class GradleProjectCreateStep extends ScriptProjectCreateStep {
@@ -70,7 +70,7 @@ group '${context.javaGroupId}'
 version '${context.javaProjectVersion}'
 
 dependencies {
-    implementation 'com.microsoft.azure.functions:azure-functions-java-library:1.4.2'
+    implementation 'com.microsoft.azure.functions:azure-functions-java-library:2.0.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
     testImplementation 'org.mockito:mockito-core:3.3.3'
 }

--- a/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/MavenProjectCreateSteps.ts
@@ -37,6 +37,7 @@ export class MavenProjectCreateStep extends ProjectCreateStepBase {
                 'archetype:generate',
                 mavenUtils.formatMavenArg('DarchetypeGroupId', 'com.microsoft.azure'),
                 mavenUtils.formatMavenArg('DarchetypeArtifactId', 'azure-functions-archetype'),
+                mavenUtils.formatMavenArg('DarchetypeVersion', 'LATEST'),
                 mavenUtils.formatMavenArg('DjavaVersion', javaVersion),
                 mavenUtils.formatMavenArg('DgroupId', nonNullProp(context, 'javaGroupId')),
                 mavenUtils.formatMavenArg('DartifactId', artifactId),

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -4,14 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizardPromptStep, IAzureQuickPickItem } from "@microsoft/vscode-azext-utils";
+import { previewDescription } from "../../../constants";
 import { hasMinFuncCliVersion } from "../../../funcCoreTools/hasMinFuncCliVersion";
 import { localize } from "../../../localize";
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
 
 export const java8: string = '8';
 export const java11: string = '11';
+export const java17: string = '17';
+
+const versionInfo: [string, string, string, string?][] = [
+    [java8, 'Java 8', '1.0.0'],
+    [java11, 'Java 11', '3.0.2630'],
+    [java17, 'Java 17', '4.0.0', previewDescription]
+];
 
 export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
+
     public static async setDefaultVersion(context: IJavaProjectWizardContext): Promise<void> {
         if (!await hasMinFuncCliVersion(context, '3.0.2630', context.version)) {
             context.javaVersion = java8;
@@ -19,12 +28,20 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
     }
 
     public async prompt(context: IJavaProjectWizardContext): Promise<void> {
-        const picks: IAzureQuickPickItem<string>[] = [
-            { label: 'Java 8', data: java8 },
-            { label: 'Java 11', data: java11 },
-        ];
+        const picks: IAzureQuickPickItem<string>[] = await this.getPicks(context);
         const placeHolder: string = localize('selectJavaVersion', 'Select a version of Java');
         context.javaVersion = (await context.ui.showQuickPick(picks, { placeHolder })).data;
+    }
+
+    // todo: get runtime from Get Function App Stacks API and validate local java version
+    async getPicks(context: IJavaProjectWizardContext): Promise<IAzureQuickPickItem<string>[]> {
+        const result: IAzureQuickPickItem<string>[] = [];
+        for (const [javaVersion, displayName, miniFunc, description] of versionInfo) {
+            if (await hasMinFuncCliVersion(context, miniFunc, context.version)) {
+                result.push({ label: displayName, data: javaVersion, description: description });
+            }
+        }
+        return result;
     }
 
     public shouldPrompt(context: IJavaProjectWizardContext): boolean {

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -8,15 +8,23 @@ import { previewDescription } from "../../../constants";
 import { hasMinFuncCliVersion } from "../../../funcCoreTools/hasMinFuncCliVersion";
 import { localize } from "../../../localize";
 import { IJavaProjectWizardContext } from "./IJavaProjectWizardContext";
+import { getJavaVersion } from "./JavaVersions";
 
 export const java8: string = '8';
 export const java11: string = '11';
 export const java17: string = '17';
 
-const versionInfo: [string, string, string, string?][] = [
-    [java8, 'Java 8', '1.0.0'],
-    [java11, 'Java 11', '3.0.2630'],
-    [java17, 'Java 17', '4.0.0', previewDescription]
+type javaVersionInfo = {
+    label: string,
+    data: string,
+    description?: string,
+    miniFunc: string
+}
+
+const versionInfo: javaVersionInfo[] = [
+    { label: 'Java 8', data: java8, miniFunc: '1.0.0' },
+    { label: 'Java 11', data: java11, miniFunc: '3.0.2630' },
+    { label: 'Java 17', data: java17, miniFunc: '4.0.0', description: previewDescription }
 ];
 
 export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {
@@ -33,12 +41,12 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
         context.javaVersion = (await context.ui.showQuickPick(picks, { placeHolder })).data;
     }
 
-    // todo: get runtime from Get Function App Stacks API and validate local java version
     async getPicks(context: IJavaProjectWizardContext): Promise<IAzureQuickPickItem<string>[]> {
+        const javaVersion: number = await getJavaVersion();
         const result: IAzureQuickPickItem<string>[] = [];
-        for (const [javaVersion, displayName, miniFunc, description] of versionInfo) {
-            if (await hasMinFuncCliVersion(context, miniFunc, context.version)) {
-                result.push({ label: displayName, data: javaVersion, description: description });
+        for (const version of versionInfo) {
+            if (await hasMinFuncCliVersion(context, version.miniFunc, context.version) && javaVersion >= Number(version.data)) {
+                result.push(version);
             }
         }
         return result;

--- a/src/commands/createNewProject/javaSteps/JavaVersions.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersions.ts
@@ -2,11 +2,11 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import * as fse from 'fs-extra';
+import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import { localize } from '../../../localize';
 import { cpUtils } from "../../../utils/cpUtils";
 
-import path = require("path");
+import * as path from 'path';
 
 export async function getJavaVersion(): Promise<number> {
     const javaHome: string | undefined = process.env['JAVA_HOME'];
@@ -15,8 +15,8 @@ export async function getJavaVersion(): Promise<number> {
         javaVersion = await checkVersionByCLI(javaHome ? path.join(javaHome, 'bin', 'java') : 'java');
     }
     if (!javaVersion) {
-        const message: string = localize('javaNotFound', 'Failed to get java version, please ensure that java is installed and JAVA_HOME is set correctly.');
-        throw Error(message);
+        const message: string = localize('javaNotFound', 'Failed to get Java version. Please ensure that Java is installed and JAVA_HOME environment variable is set.');
+        throw new Error(message);
     }
     return javaVersion;
 }
@@ -26,12 +26,12 @@ async function checkVersionInReleaseFile(javaHome: string): Promise<number | und
         return undefined;
     }
     const releaseFile = path.join(javaHome, "release");
-    if (!fse.existsSync(releaseFile)) {
+    if (!await AzExtFsExtra.pathExists(releaseFile)) {
         return undefined;
     }
 
     try {
-        const content = fse.readFileSync(releaseFile);
+        const content = await AzExtFsExtra.readFile(releaseFile);
         const regexp = /^JAVA_VERSION="(.*)"/gm;
         const match = regexp.exec(content.toString());
         return match ? flattenMajorVersion(match[1]) : undefined;

--- a/src/commands/createNewProject/javaSteps/JavaVersions.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersions.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as fse from 'fs-extra';
+import { localize } from '../../../localize';
+import { cpUtils } from "../../../utils/cpUtils";
+
+import path = require("path");
+
+export async function getJavaVersion(): Promise<number> {
+    const javaHome: string | undefined = process.env['JAVA_HOME'];
+    let javaVersion = javaHome ? await checkVersionInReleaseFile(javaHome) : undefined;
+    if (!javaVersion) {
+        javaVersion = await checkVersionByCLI(javaHome ? path.join(javaHome, 'bin', 'java') : 'java');
+    }
+    if (!javaVersion) {
+        const message: string = localize('javaNotFound', 'Failed to get java version, please ensure that java is installed and JAVA_HOME is set correctly.');
+        throw Error(message);
+    }
+    return javaVersion;
+}
+
+async function checkVersionInReleaseFile(javaHome: string): Promise<number | undefined> {
+    if (!javaHome) {
+        return undefined;
+    }
+    const releaseFile = path.join(javaHome, "release");
+    if (!fse.existsSync(releaseFile)) {
+        return undefined;
+    }
+
+    try {
+        const content = fse.readFileSync(releaseFile);
+        const regexp = /^JAVA_VERSION="(.*)"/gm;
+        const match = regexp.exec(content.toString());
+        return match ? flattenMajorVersion(match[1]) : undefined;
+    } catch (error) {
+        // ignore
+        return undefined;
+    }
+}
+
+async function checkVersionByCLI(javaExec: string): Promise<number | undefined> {
+    if (!javaExec) {
+        return undefined;
+    }
+    const result: cpUtils.ICommandResult = await cpUtils.tryExecuteCommand(undefined, undefined, javaExec, '-version');
+    const output: string = result.cmdOutputIncludingStderr;
+    const regexp = /version "(.*)"/g;
+    const match = regexp.exec(output);
+    return match ? flattenMajorVersion(match[1]) : undefined;
+}
+
+function flattenMajorVersion(version: string): number {
+    // Ignore '1.' prefix for legacy Java versions
+    if (version.startsWith("1.")) {
+        version = version.substring(2);
+    }
+
+    const regexp = /\d+/g;
+    const match = regexp.exec(version);
+    let javaVersion = 0;
+    if (match) {
+        javaVersion = parseInt(match[0], 10);
+    }
+
+    return javaVersion;
+}

--- a/src/commands/deploy/verifyAppSettings.ts
+++ b/src/commands/deploy/verifyAppSettings.ts
@@ -27,7 +27,7 @@ export async function verifyAppSettings(context: IActionContext, node: SlotTreeI
         await verifyVersionAndLanguage(context, projectPath, node.site.fullName, version, language, appSettings.properties);
 
         // update the settings if the remote runtime was changed
-        let updateAppSettings: boolean = appSettings[workerRuntimeKey] !== remoteRuntime;
+        let updateAppSettings: boolean = appSettings.properties[workerRuntimeKey] !== remoteRuntime;
         if (node.site.isLinux) {
             const remoteBuildSettingsChanged = verifyLinuxRemoteBuildSettings(context, appSettings.properties, bools);
             updateAppSettings ||= remoteBuildSettingsChanged;
@@ -38,7 +38,7 @@ export async function verifyAppSettings(context: IActionContext, node: SlotTreeI
         if (updateAppSettings) {
             await client.updateApplicationSettings(appSettings);
             // if the user cancels the deployment, the app settings node doesn't reflect the updated settings
-            await node.appSettingsTreeItem.refresh(context);
+            await node.appSettingsTreeItem?.refresh(context);
         }
     }
 }

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -45,7 +45,7 @@ for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
     const appName: string = 'javaApp';
     const javaBaseInputs: (TestInput | string | RegExp)[] = [TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, TestInput.UseDefaultValue, appName];
     if (version !== FuncVersion.v2) { // v2 doesn't support picking a java version
-        javaBaseInputs.unshift(/11/);
+        javaBaseInputs.unshift(/8/);
     }
 
     testCases.push({


### PR DESCRIPTION
Add new Java 17 runtime in function creation steps, fixes https://github.com/microsoft/vscode-azurefunctions/issues/3245

![image](https://user-images.githubusercontent.com/12445236/188308075-e4fd490f-990a-4123-8f86-4471ef13ce84.png)
