### PR TITLE
Fixes some issues related to the functionality of the "Connect to Github" command

### DIFF
--- a/src/commands/deployments/connectToGitHub.ts
+++ b/src/commands/deployments/connectToGitHub.ts
@@ -5,20 +5,29 @@
 
 import { DeploymentsTreeItem, editScmType } from "@microsoft/vscode-azext-azureappservice";
 import { GenericTreeItem, IActionContext } from "@microsoft/vscode-azext-utils";
-import { functionFilter, ScmType } from "../../constants";
+import { connectToGithubContextValue, functionFilter, ScmType } from "../../constants";
 import { ext } from "../../extensionVariables";
+import { ResolvedFunctionAppResource } from "../../tree/ResolvedFunctionAppResource";
 import { isSlotTreeItem, SlotTreeItem } from "../../tree/SlotTreeItem";
+import { treeUtils } from "../../utils/treeUtils";
 
 export async function connectToGitHub(context: IActionContext, target?: GenericTreeItem): Promise<void> {
-    const parentNode: SlotTreeItem = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-        filter: functionFilter,
-    });
-
+    let parentNode: SlotTreeItem;
     let connectToNode: GenericTreeItem;
 
     if (!target) {
-        connectToNode = await ext.rgApi.appResourceTree.showTreeItemPicker<GenericTreeItem>('ConnectToGithub', context, parentNode);
+        parentNode = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
+            filter: functionFilter,
+        });
+
+        try {
+            connectToNode = await ext.rgApi.appResourceTree.showTreeItemPicker<GenericTreeItem>(connectToGithubContextValue, context, parentNode);
+        } catch (_err) {
+            // Swallow an edge-case error where running from command palette causes showTreeItemPicker to sometimes queue running an extra time after finishing command execution
+            return;
+        }
     } else {
+        parentNode = treeUtils.findNearestParent<SlotTreeItem>(target, ResolvedFunctionAppResource.productionContextValue);
         connectToNode = target;
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -115,3 +115,5 @@ export const functionFilter = {
     kind: 'functionapp',
 };
 export const sqlBindingTemplateRegex: RegExp = /Sql.*Binding/i;
+
+export const connectToGithubContextValue: string = 'ConnectToGithub';

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -53,6 +53,8 @@ export class ResolvedFunctionAppResource implements ResolvedAppResourceBase {
     public static productionContextValue: string = 'azFuncProductionSlot';
     public static slotContextValue: string = 'azFuncSlot';
 
+    public readonly childTypeLabel: string = localize('functionOption', 'a function option');
+
     commandId?: string | undefined;
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;

--- a/src/tree/SlotTreeItem.ts
+++ b/src/tree/SlotTreeItem.ts
@@ -25,6 +25,7 @@ export class SlotTreeItem extends AzExtParentTreeItem implements IProjectTreeIte
     public site: ParsedSite;
 
     public readonly contextValue: string;
+    public readonly childTypeLabel: string;
 
     public resolved: ResolvedFunctionAppResource;
 
@@ -37,6 +38,7 @@ export class SlotTreeItem extends AzExtParentTreeItem implements IProjectTreeIte
         this.contextValue = Array.from(new Set(contextValues)).sort().join(';');
         this.site = this.resolved.site;
         this.iconPath = treeUtils.getIconPath(slotContextValue);
+        this.childTypeLabel = this.resolved.childTypeLabel;
     }
 
     public get label(): string {

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -3,11 +3,32 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, NoResourceFoundError, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { ext } from '../extensionVariables';
 
 export namespace treeUtils {
+    export function findNearestParent<T extends AzExtTreeItem>(node: AzExtTreeItem, parentContextValues: string | RegExp | (string | RegExp)[]): T {
+        parentContextValues = Array.isArray(parentContextValues) ? parentContextValues : [parentContextValues];
+        if (!parentContextValues.length) throw new NoResourceFoundError();
+
+        let currentNode: AzExtTreeItem = node;
+        let foundParent: boolean = false;
+        while (currentNode.parent) {
+            for (const contextValue of parentContextValues) {
+                const parentRegex: RegExp = contextValue instanceof RegExp ? contextValue : new RegExp(contextValue);
+                if (parentRegex.test(currentNode.contextValue)) {
+                    foundParent = true;
+                    break;
+                }
+            }
+            if (foundParent) break;
+            currentNode = currentNode.parent;
+        }
+        if (!foundParent) throw new NoResourceFoundError();
+        return currentNode as T;
+    }
+
     export function getIconPath(iconName: string): TreeItemIconPath {
         return path.join(getResourcesPath(), `${iconName}.svg`);
     }


### PR DESCRIPTION
Second Edit:  I'm liking this version of the implementation less and less.  I realized the edge-case I was running into had to do with how `showTreeItemPicker` is automatically executing its associated 'Connect To Github' command which is putting two calls to the same command on the stack.  I'm hoping v2 picker will handle this case better so we can just root directly into the `DeploymentsTreeItem` node.. let me convert this to a draft PR until discussed further...

------------------------------------------------------------------

Fixes #3214 
Edit:  Also now fixes #3325 

A lot of these changes ended up being slightly outside the scope of just fixing the issue.  I noticed that the command palette version of this command was always throwing an error and not functioning the way I would expect it to function, so I went ahead and added some support for it so it doesn't do that every time.  

There were a few tricky nuances to implementing due to the nature of how our tree item pickers work and how the nodes we are interested in are nested.  For example, I couldn't just `showTreeItem` or `pickAppResource` on `DeploymentTreeItem.contextValue` because there is a deployment node tucked away under `Slots` that is also a valid option and it would never allow the user to select it this way.... so, begrudgingly I ended up using the context on the `GenericTreeItem` representing `ConnectToGithub` as the anchor point instead.  I tested all combinations and I think it works in all situations now.

I would have also been open to removing it from the command palette entirely but seeing as it was still there, I assumed people wanted to keep it there as well.

Note:  This kind of issue might be a possible good idea/test case for v2 tree picker?

Edit:  Oh also, I am using the `SlotTreeItem` as the parent node to trigger for refresh due to some slightly inconsistent UI refresh behavior I noticed when refreshing the deployment node from under the `SlotsTreeItem` (basically when refreshing close to `SlotsTreeItem` deployment, the commit children won't show up without a slight wait and additional refresh... I assumed this must be related to some sort of timing issue).  The UI inconsistency may not be a huge deal though, so if for performance reasons we want to refresh closer to the node of interest, I'm happy to go in and change it to do so.