### PR TITLE
Update `appservice` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@azure/arm-storage": "^17.0.0",
                 "@azure/ms-rest-js": "^2.2.1",
                 "@azure/storage-blob": "^12.5.0",
-                "@microsoft/vscode-azext-azureappservice": "^0.7.3",
+                "@microsoft/vscode-azext-azureappservice": "^0.7.4",
                 "@microsoft/vscode-azext-azureutils": "^0.3.4",
                 "@microsoft/vscode-azext-utils": "^0.3.12",
                 "escape-string-regexp": "^4.0.0",
@@ -911,9 +911,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappservice": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-0.7.3.tgz",
-            "integrity": "sha512-uaSGt4wwUWv6QqZvVqCzRjTa9U3Nz4XndZfETPPshVP5MPkoSU8T4s+3YIDyE6qpw5/r+13t3GugImjWg4foyQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-0.7.4.tgz",
+            "integrity": "sha512-nN1VWM3Y0bnn9p5eRd9QwVag2UXULYfTRcZ9/elV6/CSOwWinf5FViiA9OOMD6/XhxWoRCJ9PUI6QDqFYaLFOA==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^5.0.0-beta.4",
@@ -14378,9 +14378,9 @@
             }
         },
         "@microsoft/vscode-azext-azureappservice": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-0.7.3.tgz",
-            "integrity": "sha512-uaSGt4wwUWv6QqZvVqCzRjTa9U3Nz4XndZfETPPshVP5MPkoSU8T4s+3YIDyE6qpw5/r+13t3GugImjWg4foyQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-0.7.4.tgz",
+            "integrity": "sha512-nN1VWM3Y0bnn9p5eRd9QwVag2UXULYfTRcZ9/elV6/CSOwWinf5FViiA9OOMD6/XhxWoRCJ9PUI6QDqFYaLFOA==",
             "requires": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^5.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -1099,7 +1099,7 @@
         "@azure/arm-storage": "^17.0.0",
         "@azure/ms-rest-js": "^2.2.1",
         "@azure/storage-blob": "^12.5.0",
-        "@microsoft/vscode-azext-azureappservice": "^0.7.3",
+        "@microsoft/vscode-azext-azureappservice": "^0.7.4",
         "@microsoft/vscode-azext-azureutils": "^0.3.4",
         "@microsoft/vscode-azext-utils": "^0.3.12",
         "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
Fixes #3188 

Change made here: [AppService #1234](https://github.com/microsoft/vscode-azuretools/pull/1234)

When I was testing again today, it seemed like it was mostly happening with .NET runtimes... not sure why but it has been harder to repro today than previously... however, when running the old and new implementation side-by-side, this change seems to fix it when it does occur while the old implementation will just hang on the service unavailable error...