### PR TITLE
Add OperationalInsights and dont await until needed

### DIFF
--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -85,7 +85,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         context.telemetry.properties.projectLanguage = language;
 
         // Ensure all the providers are registered before
-        await registerProviders(context, subscription);
+        const registerProvidersTask = registerProviders(context, subscription);
 
         const wizardContext: IFunctionAppWizardContext = Object.assign(context, subscription.subscription, {
             newSiteKind: AppKind.functionapp,
@@ -149,6 +149,8 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         const wizard: AzureWizard<IAppServiceWizardContext> = new AzureWizard(wizardContext, { promptSteps, executeSteps, title });
 
         await wizard.prompt();
+        // if the providers aren't registered yet, await it here because it is required by this point
+        await registerProvidersTask;
         if (!context.advancedCreation) {
             const newName: string | undefined = await wizardContext.relatedNameTask;
             if (!newName) {

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -72,7 +72,8 @@ export async function registerProviders(context: ICreateFunctionAppContext, subs
     });
 
     const storageProvider = 'Microsoft.Storage';
-    const providerExecuteSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [new VerifyProvidersStep([webProvider, storageProvider, 'Microsoft.Insights'])];
+    const providerExecuteSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] =
+        [new VerifyProvidersStep([webProvider, storageProvider, 'Microsoft.Insights', 'Microsoft.OperationalInsights'])];
     const providerWizard: AzureWizard<IFunctionAppWizardContext> = new AzureWizard(providerContext, { executeSteps: providerExecuteSteps });
 
     await providerWizard.execute();


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3352

I noticed a pretty long delay if we await the provider task before the prompt. It's a weird experience and causes users to have to sit there and wait for the prompt to come out, so also fixing that.