### PR TITLE
Check if the passed in node is a LocalProjectTreeItem

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -15,6 +15,7 @@ import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResou
 import { SlotTreeItem } from '../../tree/SlotTreeItem';
 import { dotnetUtils } from '../../utils/dotnetUtils';
 import { isPathEqual } from '../../utils/fs';
+import { treeUtils } from '../../utils/treeUtils';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
 import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
@@ -37,6 +38,14 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     addLocalFuncTelemetry(actionContext, deployPaths.workspaceFolder.uri.fsPath);
 
     const context: IDeployContext = Object.assign(actionContext, deployPaths, { defaultAppSetting: 'defaultFunctionAppToDeploy' });
+    if (treeUtils.isAzExtTreeItem(arg1)) {
+        if (!arg1.contextValue.match(ResolvedFunctionAppResource.pickSlotContextValue) &&
+            !arg1.contextValue.match(ResolvedFunctionAppResource.productionContextValue)) {
+            // if the user uses the deploy button, it's possible for the local project node to be passed in, so we should reset it to undefined
+            arg1 = undefined;
+        }
+    }
+
     const node: SlotTreeItem = await getDeployNode(context, ext.rgApi.tree, arg1, arg2, async () => ext.rgApi.pickAppResource(context, {
         filter: functionFilter,
         expectedChildContextValue: expectedContextValue

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -23,6 +23,7 @@ export namespace treeUtils {
         return ext.context.asAbsolutePath('resources');
     }
 
+    // replace with azext-utils when it's released
     export function isAzExtTreeItem(ti: unknown): ti is AzExtTreeItem {
         return !!ti && (ti as AzExtTreeItem).fullId !== undefined && (ti as AzExtTreeItem).fullId !== null;
     }

--- a/src/utils/treeUtils.ts
+++ b/src/utils/treeUtils.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TreeItemIconPath } from '@microsoft/vscode-azext-utils';
+import { AzExtTreeItem, TreeItemIconPath } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { ext } from '../extensionVariables';
 
@@ -21,5 +21,9 @@ export namespace treeUtils {
 
     function getResourcesPath(): string {
         return ext.context.asAbsolutePath('resources');
+    }
+
+    export function isAzExtTreeItem(ti: unknown): ti is AzExtTreeItem {
+        return !!ti && (ti as AzExtTreeItem).fullId !== undefined && (ti as AzExtTreeItem).fullId !== null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3369

Because of this [change](https://code.visualstudio.com/updates/v1_72#_selected-tree-items-passed-to-viewtitle-actions), the Local Project tree item will get passed in to deploy which is what's causing the error.

I think when we use the new wrapper, since we pass in `node` and `nodes` , it might be easier for us to tell when a node was right-clicked vs. just selected, though I'm not sure how VS Code passes us those args yet.

I assume that once that changes, we can change how we do this check.