### PR TITLE
Bring 1.8.3 release changes back to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.8.3 - 2022-10-25
+
+### Changed
+
+- Revert addition of PyStein "feature flag" setting. [#3386](https://github.com/microsoft/vscode-azurefunctions/pull/3386)
+
+## 1.8.2 - 2022-10-18
+
+### Fixed
+
+- Deployment failures initialized from "Deploy..." button on Workspace ribbon [#3369](https://github.com/microsoft/vscode-azurefunctions/issues/3369)
+
 ## 1.8.1 - 2022-09-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.8.3-alpha.0",
+    "version": "1.8.4-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.8.3-alpha.0",
+            "version": "1.8.4-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.8.3-alpha.0",
+    "version": "1.8.4-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
@@ -1032,12 +1032,6 @@
                         "scope": "resource",
                         "type": "string",
                         "description": "%azureFunctions.funcCliPath%"
-                    },
-                    "azureFunctions.showPysteinModel": {
-                        "scope": "resource",
-                        "type": "boolean",
-                        "default": false,
-                        "description": "%azureFunctions.showPysteinModel%"
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -100,6 +100,5 @@
     "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",
-    "azureFunctions.viewProperties": "View Properties",
-    "azureFunctions.showPysteinModel": "Enable Python (New Model Preview)"
+    "azureFunctions.viewProperties": "View Properties"
 }

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -5,12 +5,11 @@
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { QuickPickOptions } from 'vscode';
-import { previewPythonModel, ProjectLanguage, pysteinModelSetting, pythonNewModelPreview } from '../../constants';
+import { previewPythonModel, ProjectLanguage, pythonNewModelPreview } from '../../constants';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
 import { openUrl } from '../../utils/openUrl';
 import { isPythonV2Plus } from '../../utils/pythonUtils';
-import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { FunctionListStep } from '../createFunction/FunctionListStep';
 import { addInitVSCodeSteps } from '../initProjectForVSCode/InitVSCodeLanguageStep';
 import { DotnetRuntimeStep } from './dotnetSteps/DotnetRuntimeStep';
@@ -56,12 +55,6 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
             languagePicks = languagePicks.filter(p => {
                 return p.data !== undefined && context.languageFilter?.test(p.data.language);
             });
-        }
-
-        if (!getWorkspaceSetting(pysteinModelSetting)) {
-            languagePicks = languagePicks.filter(p => {
-                return p.label !== pythonNewModelPreview;
-            })
         }
 
         const options: QuickPickOptions = { placeHolder: localize('selectLanguage', 'Select a language') };

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -5,9 +5,8 @@
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions } from '@microsoft/vscode-azext-utils';
 import { QuickPickOptions } from 'vscode';
-import { previewPythonModel, ProjectLanguage, pysteinModelSetting, pythonNewModelPreview } from '../../constants';
+import { previewPythonModel, ProjectLanguage, pythonNewModelPreview } from '../../constants';
 import { localize } from '../../localize';
-import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { IProjectWizardContext } from '../createNewProject/IProjectWizardContext';
 import { DotnetInitVSCodeStep } from './InitVSCodeStep/DotnetInitVSCodeStep';
 import { DotnetScriptInitVSCodeStep } from './InitVSCodeStep/DotnetScriptInitVSCodeStep';
@@ -23,7 +22,7 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
 
     public async prompt(context: IProjectWizardContext): Promise<void> {
         // Display all languages, even if we don't have full support for them
-        let languagePicks: IAzureQuickPickItem<{ language: ProjectLanguage, model?: number }>[] = [
+        const languagePicks: IAzureQuickPickItem<{ language: ProjectLanguage, model?: number }>[] = [
             { label: ProjectLanguage.CSharp, data: { language: ProjectLanguage.CSharp } },
             { label: ProjectLanguage.CSharpScript, data: { language: ProjectLanguage.CSharpScript } },
             { label: ProjectLanguage.FSharp, data: { language: ProjectLanguage.FSharp } },
@@ -36,12 +35,6 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.TypeScript, data: { language: ProjectLanguage.TypeScript } },
             { label: ProjectLanguage.Custom, data: { language: ProjectLanguage.Custom } }
         ];
-
-        if (!getWorkspaceSetting(pysteinModelSetting)) {
-            languagePicks = languagePicks.filter(p => {
-                return p.label !== pythonNewModelPreview;
-            })
-        }
 
         const options: QuickPickOptions = { placeHolder: localize('selectLanguage', "Select your project's language") };
         const option = await context.ui.showQuickPick(languagePicks, options);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,6 @@ export const hiddenStacksSetting: string = 'showHiddenStacks';
 export const projectTemplateKeySetting: string = 'projectTemplateKey';
 export const remoteBuildSetting: string = 'scmDoBuildDuringDeployment';
 export const javaBuildTool: string = 'javaBuildTool';
-export const pysteinModelSetting: string = "showPysteinModel";
 
 export enum ProjectLanguage {
     CSharp = 'C#',


### PR DESCRIPTION
Brings changes made in `rel/1.8.3` back to `main`.

Also bumps the version number.