### PR TITLE
Remove deprecated `createFunctionApp` API

### DIFF
--- a/src/commands/createFunctionApp/createFunctionApp.ts
+++ b/src/commands/createFunctionApp/createFunctionApp.ts
@@ -5,19 +5,13 @@
 
 import { AzExtParentTreeItem, IActionContext } from '@microsoft/vscode-azext-utils';
 import { ext } from '../../extensionVariables';
-import { localize } from '../../localize';
 import { SlotTreeItem } from '../../tree/SlotTreeItem';
 import { ICreateFunctionAppContext, SubscriptionTreeItem } from '../../tree/SubscriptionTreeItem';
 import { ISiteCreatedOptions } from './showSiteCreated';
 
-export async function createFunctionApp(context: IActionContext & Partial<ICreateFunctionAppContext>, subscription?: AzExtParentTreeItem | string, newResourceGroupName?: string): Promise<string> {
+export async function createFunctionApp(context: IActionContext & Partial<ICreateFunctionAppContext>, subscription?: AzExtParentTreeItem, newResourceGroupName?: string): Promise<string> {
     let node: AzExtParentTreeItem | undefined;
-    if (typeof subscription === 'string') {
-        node = await ext.rgApi.tree.findTreeItem(`/subscriptions/${subscription}`, context);
-        if (!node) {
-            throw new Error(localize('noMatchingSubscription', 'Failed to find a subscription matching id "{0}".', subscription));
-        }
-    } else if (!subscription) {
+    if (!subscription) {
         node = await ext.rgApi.tree.showTreeItemPicker<AzExtParentTreeItem>(SubscriptionTreeItem.contextValue, context);
     } else {
         node = subscription;
@@ -31,6 +25,6 @@ export async function createFunctionApp(context: IActionContext & Partial<ICreat
     return funcAppNode.fullId;
 }
 
-export async function createFunctionAppAdvanced(context: IActionContext, subscription?: AzExtParentTreeItem | string, newResourceGroupName?: string): Promise<string> {
+export async function createFunctionAppAdvanced(context: IActionContext, subscription?: AzExtParentTreeItem, newResourceGroupName?: string): Promise<string> {
     return await createFunctionApp({ ...context, advancedCreation: true }, subscription, newResourceGroupName);
 }

--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -5,14 +5,12 @@
 
 import { Site } from '@azure/arm-appservice';
 import { tryGetWebApp } from '@microsoft/vscode-azext-azureappservice';
-import { runWithInputs, runWithTestActionContext } from '@microsoft/vscode-azext-dev';
+import { runWithTestActionContext } from '@microsoft/vscode-azext-dev';
 import * as assert from 'assert';
-import * as vscode from 'vscode';
-import { createFunctionAppAdvanced, deleteFunctionApp, DialogResponses, getRandomHexString, ProjectLanguage, registerOnActionStartHandler } from '../../extension.bundle';
+import { createFunctionAppAdvanced, deleteFunctionApp, DialogResponses, getRandomHexString } from '../../extension.bundle';
 import { cleanTestWorkspace, longRunningTestsEnabled } from '../global.test';
-import { runWithFuncSetting } from '../runWithSetting';
-import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
-import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
+import { getRotatingLocation } from './getRotatingValue';
+import { resourceGroupsToDelete, testClient } from './global.nightly.test';
 
 suite('Function App Operations', function (this: Mocha.Suite): void {
     this.timeout(7 * 60 * 1000);
@@ -61,24 +59,6 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
         });
         const createdApp: Site | undefined = await tryGetWebApp(testClient, rgName, app2Name);
         assert.ok(createdApp);
-    });
-
-    // https://github.com/Microsoft/vscode-azurefunctions/blob/main/docs/api.md#create-function-app
-    test('Create - API (deprecated)', async () => {
-        const apiRgName: string = getRandomHexString();
-        resourceGroupsToDelete.push(apiRgName);
-        const apiAppName: string = getRandomHexString();
-        const inputs = [apiAppName, getRotatingNodeVersion(), getRotatingLocation()];
-        const commandId = 'azureFunctions.createFunctionApp';
-
-        await runWithFuncSetting('projectLanguage', ProjectLanguage.JavaScript, async () => {
-            await runWithInputs(commandId, inputs, registerOnActionStartHandler, async () => {
-                const actualFuncAppId: string = <string>await vscode.commands.executeCommand(commandId, testAccount.getSubscriptionContext().subscriptionId, apiRgName);
-                const site: Site | undefined = await tryGetWebApp(testClient, apiRgName, apiAppName);
-                assert.ok(site);
-                assert.equal(actualFuncAppId, site.id);
-            });
-        });
     });
 
     test('Delete', async () => {


### PR DESCRIPTION
In an effort to remove usages of `findTreeItem`, we can remove this deprecated part of `createFunctionApp`.

We deprecated this API in 2020 https://github.com/microsoft/vscode-azurefunctions/pull/2077

