### PR TITLE
Streamline project creation when no active project is detected via `Create Function` 

### DIFF
--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -56,6 +56,8 @@ export async function createFunctionInternal(context: IActionContext, options: a
         workspaceFolder = getContainingWorkspace(workspacePath);
     }
 
+    addLocalFuncTelemetry(context, workspacePath);
+
     let projectPath: string | undefined = await verifyProjectPath(context, workspaceFolder || workspacePath);
     if (!projectPath) {
         // If we cannot find a valid Functions project, we need to put the user into the 'Create New Project' flow..
@@ -63,8 +65,6 @@ export async function createFunctionInternal(context: IActionContext, options: a
         await createNewProjectInternal(context, options);
         return;
     }
-
-    addLocalFuncTelemetry(context, workspacePath);
 
     const { language, languageModel, version } = await verifyInitForVSCode(context, projectPath, options.language, /* TODO: languageModel: */ undefined, options.version);
 

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -6,7 +6,6 @@
 import { AzureWizard, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { window, workspace, WorkspaceFolder } from 'vscode';
 import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
-import { NoWorkspaceError } from '../../errors';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { FuncVersion } from '../../FuncVersion';
 import { localize } from '../../localize';
@@ -62,15 +61,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
         // If we cannot find a valid Functions project, we need to put the user into the 'Create New Project' flow..
         context.telemetry.properties.noWorkspaceResult = 'createNewProject';
         await createNewProjectInternal(context, options);
-
-        if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
-            // Theoretically shouldn't trigger if 'Create New Project' was successful...
-            throw new NoWorkspaceError();
-        }
-
-        workspaceFolder = workspace.workspaceFolders[0];
-        workspacePath = workspaceFolder.uri.fsPath;
-        projectPath = workspacePath;
+        return;
     }
 
     addLocalFuncTelemetry(context, workspacePath);

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -52,7 +52,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
 
     if (workspacePath === undefined) {
         workspaceFolder = await getWorkspaceFolder();
-        workspacePath = workspaceFolder ? workspaceFolder.uri.fsPath : undefined;
+        workspacePath = workspaceFolder?.uri.fsPath;
     } else {
         workspaceFolder = getContainingWorkspace(workspacePath);
     }

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -58,7 +58,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
 
     addLocalFuncTelemetry(context, workspacePath);
 
-    let projectPath: string | undefined = await verifyProjectPath(context, workspaceFolder || workspacePath);
+    const projectPath: string | undefined = await verifyProjectPath(context, workspaceFolder || workspacePath);
     if (!projectPath) {
         // If we cannot find a valid Functions project, we need to put the user into the 'Create New Project' flow..
         context.telemetry.properties.noWorkspaceResult = 'createNewProject';

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -82,9 +82,8 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
  * Checks if the path is already a function project. If not, it will prompt to create a new project and return undefined
  */
 export async function verifyProjectPath(context: IActionContext, workspaceFolder?: WorkspaceFolder | string): Promise<string | undefined> {
-    let projectPath: string | undefined;
     if (workspaceFolder) {
-        projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt');
+        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt');
         if (projectPath) {
             return projectPath;
         }

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -79,7 +79,7 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
 }
 
 /**
- * Checks if the path is already a function project. If not, it will prompt to create a new project and return undefined
+ * Checks if the path is already a function project, if not return undefined
  */
 export async function verifyProjectPath(context: IActionContext, workspaceFolder?: WorkspaceFolder | string): Promise<string | undefined> {
     if (workspaceFolder) {

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -82,11 +82,5 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
  * Checks if the path is already a function project, if not return undefined
  */
 export async function verifyProjectPath(context: IActionContext, workspaceFolder?: WorkspaceFolder | string): Promise<string | undefined> {
-    if (workspaceFolder) {
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt');
-        if (projectPath) {
-            return projectPath;
-        }
-    }
-    return undefined;
+    return workspaceFolder ? await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt') : undefined;
 }

--- a/src/commands/createNewProject/verifyIsProject.ts
+++ b/src/commands/createNewProject/verifyIsProject.ts
@@ -10,9 +10,7 @@ import { hostFileName, projectSubpathSetting } from '../../constants';
 import { localize } from '../../localize';
 import { telemetryUtils } from '../../utils/telemetryUtils';
 import { findFiles } from '../../utils/workspace';
-import * as api from '../../vscode-azurefunctions.api';
 import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
-import { createNewProjectInternal } from './createNewProject';
 
 // Use 'host.json' as an indicator that this is a functions project
 export async function isFunctionProject(folderPath: string): Promise<boolean> {
@@ -83,15 +81,13 @@ async function promptForProjectSubpath(context: IActionContext, workspacePath: s
 /**
  * Checks if the path is already a function project. If not, it will prompt to create a new project and return undefined
  */
-export async function verifyOrCreateNewProject(context: IActionContext, workspaceFolder?: WorkspaceFolder | string, options: api.ICreateFunctionOptions = {}): Promise<string | undefined> {
+export async function verifyProjectPath(context: IActionContext, workspaceFolder?: WorkspaceFolder | string): Promise<string | undefined> {
+    let projectPath: string | undefined;
     if (workspaceFolder) {
-        const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt');
+        projectPath = await tryGetFunctionProjectRoot(context, workspaceFolder, 'modalPrompt');
         if (projectPath) {
             return projectPath;
         }
     }
-
-    context.telemetry.properties.noWorkspaceResult = 'createNewProject';
-    await createNewProjectInternal(context, options);
     return undefined;
 }

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -13,7 +13,7 @@ import { localize } from '../../localize';
 import { getContainingWorkspace } from '../../utils/workspace';
 import { getGlobalSetting } from '../../vsCodeConfig/settings';
 import { IProjectWizardContext } from '../createNewProject/IProjectWizardContext';
-import { verifyOrCreateNewProject } from '../createNewProject/verifyIsProject';
+import { verifyProjectPath } from '../createNewProject/verifyIsProject';
 import { detectProjectLanguage, detectProjectLanguageModel } from './detectProjectLanguage';
 import { InitVSCodeLanguageStep } from './InitVSCodeLanguageStep';
 
@@ -37,7 +37,7 @@ export async function initProjectForVSCode(context: IActionContext, fsPath?: str
         workspacePath = workspaceFolder ? workspaceFolder.uri.fsPath : fsPath;
     }
 
-    const projectPath: string | undefined = await verifyOrCreateNewProject(context, workspaceFolder || workspacePath);
+    const projectPath: string | undefined = await verifyProjectPath(context, workspaceFolder || workspacePath);
     if (!projectPath) {
         return;
     }

--- a/src/commands/initProjectForVSCode/initProjectForVSCode.ts
+++ b/src/commands/initProjectForVSCode/initProjectForVSCode.ts
@@ -13,7 +13,7 @@ import { localize } from '../../localize';
 import { getContainingWorkspace } from '../../utils/workspace';
 import { getGlobalSetting } from '../../vsCodeConfig/settings';
 import { IProjectWizardContext } from '../createNewProject/IProjectWizardContext';
-import { verifyAndPromptToCreateProject } from '../createNewProject/verifyIsProject';
+import { verifyOrCreateNewProject } from '../createNewProject/verifyIsProject';
 import { detectProjectLanguage, detectProjectLanguageModel } from './detectProjectLanguage';
 import { InitVSCodeLanguageStep } from './InitVSCodeLanguageStep';
 
@@ -37,7 +37,7 @@ export async function initProjectForVSCode(context: IActionContext, fsPath?: str
         workspacePath = workspaceFolder ? workspaceFolder.uri.fsPath : fsPath;
     }
 
-    const projectPath: string | undefined = await verifyAndPromptToCreateProject(context, workspaceFolder || workspacePath);
+    const projectPath: string | undefined = await verifyOrCreateNewProject(context, workspaceFolder || workspacePath);
     if (!projectPath) {
         return;
     }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -72,11 +72,6 @@ export interface ICreateFunctionOptions {
     }
 
     /**
-     * If set to true, it will automatically create a new project without prompting (if there's not already a project). Defaults to false
-     */
-    suppressCreateProjectPrompt?: boolean;
-
-    /**
      * If set to true, it will not try to open the folder after create finishes. Defaults to false
      */
     suppressOpenFolder?: boolean;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -31,7 +31,6 @@ suite(`AzureFunctionsExtensionApi`, () => {
         await runWithInputs('api.createFunction', [language, functionName], registerOnActionStartHandler, async () => {
             await api.createFunction({
                 folderPath,
-                suppressCreateProjectPrompt: true,
                 suppressOpenFolder: true,
                 templateId: 'HttpTrigger',
                 languageFilter: /Python|C\#|^(Java|Type)Script$/i,
@@ -63,7 +62,6 @@ suite(`AzureFunctionsExtensionApi`, () => {
                 templateId: 'HttpTrigger',
                 languageFilter: /^(Java|Type)Script$/i,
                 functionSettings: { authLevel: 'anonymous' },
-                suppressCreateProjectPrompt: true,
                 suppressOpenFolder: true
             });
         });


### PR DESCRIPTION
Fixes #3265 

Though we may still need to revisit this again when we address [buttons lost to time](https://github.com/microsoft/vscode-azureresourcegroups/issues/316).

Based on the recommendations in the issue, I removed the following prompts from the `Create Function` task when we don't think the user has a project ready.

![image](https://user-images.githubusercontent.com/40250218/200082347-34a2f829-8db3-4088-9c56-aa8f159641e6.png)

![image](https://user-images.githubusercontent.com/40250218/200082360-e0599aba-77fa-4e6b-8cb6-a2a7bfe68de8.png)

Instead, if the workspace is not selected or is empty, we put the user directly into the `Create New Project` flow.
