### PR TITLE
Remove 'Create Function' from + button

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,13 +356,6 @@
             }
         ],
         "menus": {
-            "azureWorkspaceCreate": [
-                {
-                    "command": "azureFunctions.createFunction",
-                    "when": "view == azureWorkspace",
-                    "group": "navigation@1"
-                }
-            ],
             "azureWorkspaceDeploy": [
                 {
                     "command": "azureFunctions.deploy",
@@ -371,6 +364,11 @@
                 }
             ],
             "view/title": [
+                {
+                    "command": "azureFunctions.createFunction",
+                    "when": "view == azureWorkspace",
+                    "group": "navigation@1"
+                },
                 {
                     "submenu": "azureWorkspaceDeploy",
                     "when": "view == azureWorkspace",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3350

Nice to have you back, lighting bolt button. Since it's also doing double duty for `Create New Project...` and `Create Function...`, I think it makes sense to just extract back to its own button.

Should be a temporary measure until we get an actions menu implemented.

![image](https://user-images.githubusercontent.com/5290572/201424944-908dc19f-253b-4c1a-a27f-3b5968457a37.png)
