### PR TITLE
Fix not-quite-correct CodeQL alert

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -27,7 +27,7 @@ export async function findFiles(base: vscode.WorkspaceFolder | string, pattern: 
 }
 
 function escapeCharacters(nonPattern: string): string {
-    return nonPattern.replace(/[$^*+?()[\]]/g, '\\$&')
+    return nonPattern.replace(/[$^*+?()\[\]\\]/g, '\\$&')
 }
 
 export async function selectWorkspaceFolder(context: IActionContext, placeHolder: string, getSubPath?: (f: vscode.WorkspaceFolder) => string | undefined | Promise<string | undefined>): Promise<string> {


### PR DESCRIPTION
CodeQL is upset that backslashes aren't being escaped here, not understanding that because of what's happening in the method above, it's not possible for there to be backslashes in the input.