### PR TITLE
Don't search node_modules for local projects

### DIFF
--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -23,7 +23,7 @@ export async function findFiles(base: vscode.WorkspaceFolder | string, pattern: 
     const posixBase = path.posix.normalize(typeof base === 'string' ? base : base.uri.fsPath).replace(/\\/g, '/');
     const escapedBase = escapeCharacters(posixBase)
     const fullPattern = path.posix.join(escapedBase, pattern);
-    return (await globby(fullPattern)).map(s => vscode.Uri.file(s));
+    return (await globby(fullPattern, { ignore: ['**/node_modules/**'] })).map(s => vscode.Uri.file(s));
 }
 
 function escapeCharacters(nonPattern: string): string {


### PR DESCRIPTION
An edge case, but if users have the SWA CLI installed it will detect a project they use for testing in the node_modules folder. (why that's in their bundle I don't know...)

It should also speed up the search.