### PR TITLE
Fix "Start Remote Debugging" action for Node Linux function apps

### DIFF
--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -14,7 +14,7 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfig, appServicePlan?: 
     //      or it will contain language information, e.g. "Node|14"
     const isNotConsumption: boolean = appServicePlan?.toLowerCase() !== 'y';
     if (isNotConsumption) {
-        if (siteConfig.linuxFxVersion && (/^(DOCKER\|(mcr\.microsoft\.com)\/(azure-functions)\/(node)|Node\|)/i).test(siteConfig.linuxFxVersion)) {
+        if (siteConfig.linuxFxVersion && (/(DOCKER\|mcr\.microsoft\.com\/azure-functions\/node)|(Node\|)/i).test(siteConfig.linuxFxVersion)) {
             return RemoteDebugLanguage.Node;
         }
     }

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -12,11 +12,10 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfig, appServicePlan?: 
     //   If the Function App is running on Linux consumption plan remote debugging is not supported
     //   If the Function App is running on a Linux App Service plan, it will contain Docker registry information, e.g. "DOCKER|repo.azurecr.io/image:tag"
     //      or it will contain language information, e.g. "Node|14"
-    if (appServicePlan) {
-        if (/^[^yY]$/.test(appServicePlan)) {
-            if (siteConfig.linuxFxVersion && (siteConfig.linuxFxVersion.startsWith('DOCKER|mcr.microsoft.com/azure-functions/node') || siteConfig.linuxFxVersion.toLowerCase().startsWith('node|'))) {
-                return RemoteDebugLanguage.Node;
-            }
+    const isNotConsumption: boolean = appServicePlan?.toLowerCase() !== 'y';
+    if (isNotConsumption) {
+        if (siteConfig.linuxFxVersion && (/^(DOCKER\|(mcr\.microsoft\.com)\/(azure-functions)\/(node)|Node\|)/i).test(siteConfig.linuxFxVersion)) {
+            return RemoteDebugLanguage.Node;
         }
     }
 

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -6,14 +6,17 @@
 import { SiteConfig } from '@azure/arm-appservice';
 import { RemoteDebugLanguage } from '@microsoft/vscode-azext-azureappservice';
 
-export function getRemoteDebugLanguage(siteConfig: SiteConfig): RemoteDebugLanguage {
+export function getRemoteDebugLanguage(siteConfig: SiteConfig, appServicePlan?: string): RemoteDebugLanguage {
     // Read siteConfig.linuxFxVersion to determine debugging support
     //   If the Function App is running on Windows, it will be empty
-    //   If the Function App is running on Linux consumption, it will be empty
+    //   If the Function App is running on Linux consumption plan remote debugging is not supported
     //   If the Function App is running on a Linux App Service plan, it will contain Docker registry information, e.g. "DOCKER|repo.azurecr.io/image:tag"
-    //      The blessed Node.js Docker image will be something like "DOCKER|mcr.microsoft.com/azure-functions/node:2.0-node8-appservice"
-    if (siteConfig.linuxFxVersion && siteConfig.linuxFxVersion.startsWith('DOCKER|mcr.microsoft.com/azure-functions/node')) {
-        return RemoteDebugLanguage.Node;
+    //      or it will contain language information, e.g. "Node|14"
+    const isNotConsumption: boolean = appServicePlan?.toLowerCase() !== 'y';
+    if (isNotConsumption) {
+        if (siteConfig.linuxFxVersion && (siteConfig.linuxFxVersion.startsWith('DOCKER|mcr.microsoft.com/azure-functions/node') || siteConfig.linuxFxVersion.toLowerCase().startsWith('node|'))) {
+            return RemoteDebugLanguage.Node;
+        }
     }
 
     throw new Error('Azure Remote Debugging is currently only supported for Node.js Function Apps running on Linux App Service plans. Consumption plans are not supported.');

--- a/src/commands/remoteDebug/getRemoteDebugLanguage.ts
+++ b/src/commands/remoteDebug/getRemoteDebugLanguage.ts
@@ -12,12 +12,14 @@ export function getRemoteDebugLanguage(siteConfig: SiteConfig, appServicePlan?: 
     //   If the Function App is running on Linux consumption plan remote debugging is not supported
     //   If the Function App is running on a Linux App Service plan, it will contain Docker registry information, e.g. "DOCKER|repo.azurecr.io/image:tag"
     //      or it will contain language information, e.g. "Node|14"
-    const isNotConsumption: boolean = appServicePlan?.toLowerCase() !== 'y';
-    if (isNotConsumption) {
-        if (siteConfig.linuxFxVersion && (siteConfig.linuxFxVersion.startsWith('DOCKER|mcr.microsoft.com/azure-functions/node') || siteConfig.linuxFxVersion.toLowerCase().startsWith('node|'))) {
-            return RemoteDebugLanguage.Node;
+    if (appServicePlan) {
+        if (/^[^yY]$/.test(appServicePlan)) {
+            if (siteConfig.linuxFxVersion && (siteConfig.linuxFxVersion.startsWith('DOCKER|mcr.microsoft.com/azure-functions/node') || siteConfig.linuxFxVersion.toLowerCase().startsWith('node|'))) {
+                return RemoteDebugLanguage.Node;
+            }
         }
     }
+
 
     throw new Error('Azure Remote Debugging is currently only supported for Node.js Function Apps running on Linux App Service plans. Consumption plans are not supported.');
 }

--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -27,7 +27,8 @@ export async function startRemoteDebug(context: IActionContext, node?: SlotTreeI
         return await siteClient.getSiteConfig();
     });
 
-    const language: appservice.RemoteDebugLanguage = getRemoteDebugLanguage(siteConfig);
+    const appServicePlan = await siteClient.getAppServicePlan();
+    const language: appservice.RemoteDebugLanguage = getRemoteDebugLanguage(siteConfig, appServicePlan?.sku?.family);
 
     await appservice.startRemoteDebug(context, node.site, siteConfig, language);
 }


### PR DESCRIPTION
Fixes #3417.

A couple of notes:

Consumption apps are still not supported but the `linuxFxVersion` value is no longer empty in this case, so I added a check for that. I also found that if changes are made to the function apps configuration settings the `linuxFxVersion` value will be 'NODE|...' instead of the expected 'Node|...' so that's why I lowercased the value 😄.
