### PR TITLE
Fix multi-root support for downloading remote app settings and debugging

### DIFF
--- a/src/commands/appSettings/getLocalSettingsFile.ts
+++ b/src/commands/appSettings/getLocalSettingsFile.ts
@@ -5,9 +5,9 @@
 
 import { AzExtFsExtra, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { workspace, WorkspaceFolder } from "vscode";
+import { WorkspaceFolder } from "vscode";
 import { localSettingsFileName } from "../../constants";
-import { selectWorkspaceFile } from "../../utils/workspace";
+import { getRootWorkspaceFolder, selectWorkspaceFile } from "../../utils/workspace";
 import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
 
 /**
@@ -15,7 +15,7 @@ import { tryGetFunctionProjectRoot } from "../createNewProject/verifyIsProject";
  * Otherwise, prompt
  */
 export async function getLocalSettingsFile(context: IActionContext, message: string, workspaceFolder?: WorkspaceFolder): Promise<string> {
-    workspaceFolder ||= workspace.workspaceFolders?.[0];
+    workspaceFolder ||= await getRootWorkspaceFolder();
     if (workspaceFolder) {
         const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder);
         if (projectPath) {

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -3,14 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizard, IActionContext, UserCancelledError } from '@microsoft/vscode-azext-utils';
-import { window, workspace, WorkspaceFolder } from 'vscode';
+import { AzureWizard, IActionContext } from '@microsoft/vscode-azext-utils';
+import { WorkspaceFolder } from 'vscode';
 import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { FuncVersion } from '../../FuncVersion';
-import { localize } from '../../localize';
 import { LocalProjectTreeItem } from '../../tree/localProject/LocalProjectTreeItem';
-import { getContainingWorkspace } from '../../utils/workspace';
+import { getContainingWorkspace, getRootWorkspaceFolder } from '../../utils/workspace';
 import * as api from '../../vscode-azurefunctions.api';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
@@ -50,7 +49,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
     let workspacePath: string | undefined = options.folderPath;
 
     if (workspacePath === undefined) {
-        workspaceFolder = await getWorkspaceFolder();
+        workspaceFolder = await getRootWorkspaceFolder();
         workspacePath = workspaceFolder?.uri.fsPath;
     } else {
         workspaceFolder = getContainingWorkspace(workspacePath);
@@ -75,22 +74,4 @@ export async function createFunctionInternal(context: IActionContext, options: a
     });
     await wizard.prompt();
     await wizard.execute();
-}
-
-async function getWorkspaceFolder(): Promise<WorkspaceFolder | undefined> {
-    let folder: WorkspaceFolder | undefined;
-
-    if (!workspace.workspaceFolders || workspace.workspaceFolders.length === 0) {
-        folder = undefined;
-    } else if (workspace.workspaceFolders.length === 1) {
-        folder = workspace.workspaceFolders[0];
-    } else {
-        const placeHolder: string = localize('selectProjectFolder', 'Select the folder containing your function project');
-        folder = await window.showWorkspaceFolderPick({ placeHolder });
-        if (!folder) {
-            throw new UserCancelledError('selectProjectFolder');
-        }
-    }
-
-    return folder;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -87,6 +87,7 @@ export const extInstallTaskName: string = `${func}: ${extInstallCommand}`;
 
 export const hostStartCommand: string = 'host start';
 export const hostStartTaskName: string = `${func}: ${hostStartCommand}`;
+export const hostStartTaskNameRegExp = new RegExp(hostStartTaskName, 'i');
 
 export const packCommand: string = 'pack';
 export const buildNativeDeps: string = '--build-native-deps';

--- a/src/debug/FuncDebugProviderBase.ts
+++ b/src/debug/FuncDebugProviderBase.ts
@@ -6,7 +6,7 @@
 import { callWithTelemetryAndErrorHandling, IActionContext } from '@microsoft/vscode-azext-utils';
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, WorkspaceFolder } from 'vscode';
 import { isFunctionProject } from '../commands/createNewProject/verifyIsProject';
-import { hostStartTaskName } from '../constants';
+import { hostStartTaskNameRegExp } from '../constants';
 import { IPreDebugValidateResult, preDebugValidate } from './validatePreDebug';
 
 export abstract class FuncDebugProviderBase implements DebugConfigurationProvider {
@@ -46,7 +46,7 @@ export abstract class FuncDebugProviderBase implements DebugConfigurationProvide
             context.telemetry.suppressIfSuccessful = true;
 
             this._debugPorts.set(folder, <number | undefined>debugConfiguration.port);
-            if (debugConfiguration.preLaunchTask === hostStartTaskName) {
+            if (hostStartTaskNameRegExp.test(debugConfiguration.preLaunchTask)) {
                 context.telemetry.properties.isActivationEvent = 'false';
                 context.telemetry.suppressIfSuccessful = false;
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -16,8 +16,8 @@ export function isMultiRootWorkspace(): boolean {
 }
 
 /*
- * Use sparingly and prefer storing and passing 'projectPaths' instead. Over-reliance on this function may result
- * in excessive prompting when a user employs a multi-root workspace.
+ * Use sparingly. Prefer storing and passing 'projectPaths' instead.
+ * Over-reliance on this function may result in excessive prompting when a user employs a multi-root workspace.
  */
 export async function getRootWorkspaceFolder(): Promise<vscode.WorkspaceFolder | undefined> {
     if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IActionContext, IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
+import { IActionContext, IAzureQuickPickItem, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import * as globby from 'globby';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -13,6 +13,33 @@ import * as fsUtils from './fs';
 export function isMultiRootWorkspace(): boolean {
     return !!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
         && vscode.workspace.name !== vscode.workspace.workspaceFolders[0].name; // multi-root workspaces always have something like "(Workspace)" appended to their name
+}
+
+/*
+ * Use sparingly and prefer storing and passing 'projectPaths' instead. Over-reliance on this function may result
+ * in excessive prompting when a user employs a multi-root workspace.
+ */
+export async function getRootWorkspaceFolder(): Promise<vscode.WorkspaceFolder | undefined> {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+        return undefined;
+    } else if (vscode.workspace.workspaceFolders.length === 1) {
+        return vscode.workspace.workspaceFolders[0];
+    } else {
+        const placeHolder: string = localize('selectRootWorkspace', 'Select the folder containing your function project');
+        const folder = await vscode.window.showWorkspaceFolderPick({ placeHolder });
+        if (!folder) {
+            throw new UserCancelledError('selectRootWorkspace');
+        }
+        return folder;
+    }
+}
+
+/*
+ * Use sparingly and prefer storing and passing 'projectPaths' instead. Over-reliance on this function may result
+ * in excessive prompting when a user employs a multi-root workspace.
+ */
+export async function getRootWorkspacePath(): Promise<string | undefined> {
+    return (await getRootWorkspaceFolder())?.uri.fsPath;
 }
 
 /**

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -34,14 +34,6 @@ export async function getRootWorkspaceFolder(): Promise<vscode.WorkspaceFolder |
     }
 }
 
-/*
- * Use sparingly and prefer storing and passing 'projectPaths' instead. Over-reliance on this function may result
- * in excessive prompting when a user employs a multi-root workspace.
- */
-export async function getRootWorkspacePath(): Promise<string | undefined> {
-    return (await getRootWorkspaceFolder())?.uri.fsPath;
-}
-
 /**
  * Alternative to `vscode.workspace.findFiles` which always returns an empty array if no workspace is open
  */


### PR DESCRIPTION
Fixes #3452 

This fixes both the downloading of remote app settings and local debugging for multi-root projects.

For the debug configuration fix, I changed this:

![image](https://user-images.githubusercontent.com/40250218/209719316-4670e84e-4778-457f-943a-11a4233e0c22.png)
 to instead be tested with a RegExp.

Reason being, with multi-root, since the `preLaunchTask` config for projects that aren't the first one usually have a port assignment as part of the string, they will not match exactly the string `func: host start`.  Because of this, the local projects that come later were skipping `preDebugValidate`.  This should prevent them from being skipped now.

As per the wiki:
![image](https://user-images.githubusercontent.com/40250218/209720355-edac827b-53d4-4e7e-850a-56e3af8f2417.png)
