### PR TITLE
Stop passing expected child context value

### DIFF
--- a/src/commands/configureDeploymentSource.ts
+++ b/src/commands/configureDeploymentSource.ts
@@ -7,14 +7,12 @@ import { editScmType } from '@microsoft/vscode-azext-azureappservice';
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { functionFilter } from '../constants';
 import { ext } from '../extensionVariables';
-import { ResolvedFunctionAppResource } from '../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../tree/SlotTreeItem';
 
 export async function configureDeploymentSource(context: IActionContext, node?: SlotTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
 

--- a/src/commands/deleteFunctionApp.ts
+++ b/src/commands/deleteFunctionApp.ts
@@ -6,14 +6,12 @@
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { functionFilter } from '../constants';
 import { ext } from '../extensionVariables';
-import { ResolvedFunctionAppResource } from '../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../tree/SlotTreeItem';
 
 export async function deleteFunctionApp(context: IActionContext, node?: SlotTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>({ ...context, suppressCreatePick: true }, {
             filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
         });
     }
 

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -12,7 +12,6 @@ import { functionFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionTreeItem';
-import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResource';
 import { isSlotTreeItem, SlotTreeItem } from '../../tree/SlotTreeItem';
 import { createAppInsightsClient } from '../../utils/azureClients';
 import { nonNullProp } from '../../utils/nonNull';
@@ -22,8 +21,7 @@ import { enableFileLogging } from './enableFileLogging';
 export async function startStreamingLogs(context: IActionContext, treeItem?: SlotTreeItem | RemoteFunctionTreeItem): Promise<void> {
     if (!treeItem) {
         treeItem = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
 

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -9,14 +9,12 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { functionFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionTreeItem';
-import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResource';
 import { isSlotTreeItem, SlotTreeItem } from '../../tree/SlotTreeItem';
 
 export async function stopStreamingLogs(context: IActionContext, node?: SlotTreeItem | RemoteFunctionTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>({ ...context, suppressCreatePick: true }, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
 

--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -9,15 +9,13 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { functionFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
-import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../../tree/SlotTreeItem';
 import { getRemoteDebugLanguage } from './getRemoteDebugLanguage';
 
 export async function startRemoteDebug(context: IActionContext, node?: SlotTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
 

--- a/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
+++ b/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
@@ -10,7 +10,6 @@ import * as vscode from 'vscode';
 import { functionFilter } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
-import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../../tree/SlotTreeItem';
 import { openUrl } from '../../utils/openUrl';
 import { DebugProxy } from './DebugProxy';
@@ -21,8 +20,7 @@ const JAVA_OPTS: string = `-Djava.net.preferIPv4Stack=true -Xdebug -Xrunjdwp:tra
 export async function remoteDebugJavaFunctionApp(context: IActionContext, node?: SlotTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
     const client: SiteClient = await node.site.createClient(context);

--- a/src/commands/startFunctionApp.ts
+++ b/src/commands/startFunctionApp.ts
@@ -8,14 +8,12 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { functionFilter } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { ResolvedFunctionAppResource } from '../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../tree/SlotTreeItem';
 
 export async function startFunctionApp(context: IActionContext, node?: SlotTreeItem): Promise<void> {
     if (!node) {
         node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
+            filter: functionFilter
         });
     }
 

--- a/src/commands/stopFunctionApp.ts
+++ b/src/commands/stopFunctionApp.ts
@@ -8,15 +8,11 @@ import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { functionFilter } from '../constants';
 import { ext } from '../extensionVariables';
 import { localize } from '../localize';
-import { ResolvedFunctionAppResource } from '../tree/ResolvedFunctionAppResource';
 import { SlotTreeItem } from '../tree/SlotTreeItem';
 
 export async function stopFunctionApp(context: IActionContext, node?: SlotTreeItem): Promise<SlotTreeItem> {
     if (!node) {
-        node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, {
-            filter: functionFilter,
-            expectedChildContextValue: new RegExp(ResolvedFunctionAppResource.productionContextValue)
-        });
+        node = await ext.rgApi.pickAppResource<SlotTreeItem>(context, { filter: functionFilter });
     }
 
     const client: SiteClient = await node.site.createClient(context);


### PR DESCRIPTION
Fixes #3497 

In v1 we are mistakenly passing an expected child context value when we are picking a Function App. This was fine in v1 since the pickAppResource implementation allowed this, however the new implementation does not. 

These changes should not change any behavior regardless of which resources API is being used.