### PR TITLE
Revert `Netherite` emulator string from `SingleHost` to `MemoryF`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,10 +140,10 @@ export const tsDefaultOutDir: string = 'dist';
 export const tsConfigFileName: string = 'tsconfig.json';
 
 export const localEventHubsEmulatorConnectionStringDefault: string = 'MemoryF';
-export const localEventHubsEmulatorConnectionStringAlternateOne: string = 'Memory';
+export const localEventHubsEmulatorConnectionStringAlternate: string = 'Memory';
 
 export const localStorageEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
-export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionStringDefault}|${localEventHubsEmulatorConnectionStringAlternateOne}`);
+export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionStringDefault}|${localEventHubsEmulatorConnectionStringAlternate}`);
 
 export const workerRuntimeKey: string = 'FUNCTIONS_WORKER_RUNTIME';
 export const workerRuntimeVersionKey: string = 'FUNCTIONS_WORKER_RUNTIME_VERSION';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -142,7 +142,6 @@ export const tsConfigFileName: string = 'tsconfig.json';
 export const localEventHubsEmulatorConnectionStringDefault: string = 'MemoryF';
 export const localEventHubsEmulatorConnectionStringAlternateOne: string = 'Memory';
 
-
 export const localStorageEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
 export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionStringDefault}|${localEventHubsEmulatorConnectionStringAlternateOne}`);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -139,12 +139,12 @@ export const localhost: string = '127.0.0.1';
 export const tsDefaultOutDir: string = 'dist';
 export const tsConfigFileName: string = 'tsconfig.json';
 
-export const localEventHubsEmulatorConnectionStringDefault: string = 'SingleHost';
-export const localEventHubsEmulatorConnectionStringAlternateOne: string = 'MemoryF';
-export const localEventHubsEmulatorConnectionStringAlternateTwo: string = 'Memory';
+export const localEventHubsEmulatorConnectionStringDefault: string = 'MemoryF';
+export const localEventHubsEmulatorConnectionStringAlternateOne: string = 'Memory';
+
 
 export const localStorageEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
-export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionStringDefault}|${localEventHubsEmulatorConnectionStringAlternateOne}|${localEventHubsEmulatorConnectionStringAlternateTwo}`);
+export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionStringDefault}|${localEventHubsEmulatorConnectionStringAlternateOne}`);
 
 export const workerRuntimeKey: string = 'FUNCTIONS_WORKER_RUNTIME';
 export const workerRuntimeVersionKey: string = 'FUNCTIONS_WORKER_RUNTIME_VERSION';


### PR DESCRIPTION
Current extension bundle brings in `Netherite` v1.1.1.  I believe `SingleHost` was introduced in v1.2, so only works with C# projects.  We should revert back and put #3534 in tracking...