### PR TITLE
Update `MSSQL` task config

### DIFF
--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -240,7 +240,6 @@ export namespace durableUtils {
                 connectionStringName: ConnectionKey.SQL,
                 taskEventLockTimeout: "00:02:00",
                 createDatabaseIfNotExists: true,
-                schemaName: null
             }
         };
     }


### PR DESCRIPTION
The latest version of `DurableTask.SqlServer` doesn't like it when `schemaName` is set to `null` in the `host.json`, so I'm removing it from the default SQL task config.