### PR TITLE
1.10.0 Release Prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support new Durable Functions backend options for the following languages: C#, JavaScript, TypeScript, Python [#3273](https://github.com/microsoft/vscode-azurefunctions/issues/3272)
 - Support new Node.js Programming Model (v4) [#3285](https://github.com/microsoft/vscode-azurefunctions/issues/3285)
 - Declared limited support for virtual workspaces [#2793](https://github.com/microsoft/vscode-azurefunctions/issues/2793)
+- Added Azurite generated emulator files to .funcignore [#3371](https://github.com/microsoft/vscode-azurefunctions/issues/3371)
 ### Changed
 
 - Removed deprecated .NET runtime stacks for creating new projects and Function Apps [#3474](https://github.com/microsoft/vscode-azurefunctions/issues/3474)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## 1.10.0 - 2023-02-02
+
+### Added
+
+- Enable support for Python 3.10 when creating projects [#3486](https://github.com/microsoft/vscode-azurefunctions/issues/3486)
+- Support new Durable Functions backend options for the following languages: C#, JavaScript, TypeScript, Python [#3273](https://github.com/microsoft/vscode-azurefunctions/issues/3272)
+- Support new Node.js Programming Model (v4) [#3285](https://github.com/microsoft/vscode-azurefunctions/issues/3285)
+- Declared limited support for virtual workspaces [#2793](https://github.com/microsoft/vscode-azurefunctions/issues/2793)
+### Changed
+
+- Removed deprecated .NET runtime stacks for creating new projects and Function Apps [#3474](https://github.com/microsoft/vscode-azurefunctions/issues/3474)
+- Remove Python 3.6 due to EOL [#3526](https://github.com/microsoft/vscode-azurefunctions/issues/3526)
+- Add warning messages for Azure Functions Core Tools EOL and mismatched versions [#3346](https://github.com/microsoft/vscode-azurefunctions/issues/3346) [#2985](https://github.com/microsoft/vscode-azurefunctions/issues/2985)
+- Improve Core Tools install experience for Linux [#2745](https://github.com/microsoft/vscode-azurefunctions/issues/2745)
+
+### Fixed
+
+- [Bugs Fixed](https://github.com/microsoft/vscode-azurefunctions/milestone/60?closed=1)
+
 ## 1.9.0 - 2022-11-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.9.1-alpha.0",
+    "version": "1.10.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.9.1-alpha.0",
+            "version": "1.10.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.9.1-alpha.0",
+    "version": "1.10.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
Here's the release prep for v1.10.0.

Note: The component governance `notice.html` was not generating properly even though the builds are passing, so it has not been updated yet.