### PR TITLE
Change file structure for typescript functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1057,7 +1057,7 @@
                     "azureFunctions.functionSubpath": {
                         "scope": "resource",
                         "type": "string",
-                        "default": "src/functions",
+                        "default": "functions",
                         "description": "%azureFunctions.functionSubpath%"
                     },
                     "azureFunctions.showNodeProgrammingModel": {

--- a/src/commands/createFunction/scriptSteps/NodeV4FunctionCreateStep.ts
+++ b/src/commands/createFunction/scriptSteps/NodeV4FunctionCreateStep.ts
@@ -5,7 +5,7 @@
 
 import { AzExtFsExtra, nonNullProp } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { functionSubpathSetting } from '../../../constants';
+import { functionSubpathSetting, tsDefaultSrcDir } from '../../../constants';
 import { IScriptFunctionTemplate } from '../../../templates/script/parseScriptTemplates';
 import { getWorkspaceSetting } from '../../../vsCodeConfig/settings';
 import { FunctionCreateStepBase } from '../FunctionCreateStepBase';
@@ -14,12 +14,12 @@ import { getFileExtensionFromLanguage } from './ScriptFunctionCreateStep';
 
 export class NodeV4FunctionCreateStep extends FunctionCreateStepBase<IScriptFunctionWizardContext> {
     public async executeCore(context: IScriptFunctionWizardContext): Promise<string> {
-        const functionSubpath: string = getWorkspaceSetting(functionSubpathSetting, context.projectPath) as string;
+        const fileExt = getFileExtensionFromLanguage(context.language);
+        const functionSubpath: string = path.join(fileExt?.toLowerCase() === '.ts' ? tsDefaultSrcDir : '', getWorkspaceSetting(functionSubpathSetting, context.projectPath) as string);
         const functionPath = path.join(context.projectPath, functionSubpath);
         await AzExtFsExtra.ensureDir(functionPath);
 
         const functionName = nonNullProp(context, 'functionName');
-        const fileExt = getFileExtensionFromLanguage(context.language);
         const fileName = `${functionName}${fileExt}`;
 
         const template: IScriptFunctionTemplate = nonNullProp(context, 'functionTemplate');

--- a/src/commands/createFunction/scriptSteps/NodeV4FunctionNameStep.ts
+++ b/src/commands/createFunction/scriptSteps/NodeV4FunctionNameStep.ts
@@ -5,7 +5,7 @@
 
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { functionSubpathSetting } from '../../../constants';
+import { functionSubpathSetting, tsDefaultSrcDir } from '../../../constants';
 import { localize } from "../../../localize";
 import { IScriptFunctionTemplate } from '../../../templates/script/parseScriptTemplates';
 import { nonNullProp } from '../../../utils/nonNull';
@@ -17,18 +17,20 @@ import { getFileExtensionFromLanguage } from './ScriptFunctionCreateStep';
 export class NodeV4FunctionNameStep extends FunctionNameStepBase<IScriptFunctionWizardContext> {
     protected async getUniqueFunctionName(context: IScriptFunctionWizardContext): Promise<string | undefined> {
         const template: IScriptFunctionTemplate = nonNullProp(context, 'functionTemplate');
+        const fileExt = getFileExtensionFromLanguage(context.language);
         const functionSubpath: string = getWorkspaceSetting(functionSubpathSetting, context.projectPath) as string;
         return await this.getUniqueFsPath(
-            path.join(context.projectPath, functionSubpath),
+            path.join(context.projectPath, fileExt?.toLowerCase() === '.ts' ? tsDefaultSrcDir : '', functionSubpath),
             template.defaultFunctionName,
-            getFileExtensionFromLanguage(context.language));
+            fileExt);
     }
 
     protected async validateFunctionNameCore(context: IScriptFunctionWizardContext, name: string): Promise<string | undefined> {
         const functionSubpath: string = getWorkspaceSetting(functionSubpathSetting, context.projectPath) as string;
-        name = `${name}${getFileExtensionFromLanguage(context.language)}`;
+        const fileExt = getFileExtensionFromLanguage(context.language);
+        name = `${name}${fileExt}`;
 
-        if (await AzExtFsExtra.pathExists(path.join(context.projectPath, functionSubpath, name))) {
+        if (await AzExtFsExtra.pathExists(path.join(context.projectPath, fileExt?.toLowerCase() === '.ts' ? tsDefaultSrcDir : '', functionSubpath, name))) {
             return localize('existingFileError', 'A file with the name "{0}" already exists.', name);
         } else {
             return undefined;

--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -6,7 +6,7 @@
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { Progress } from 'vscode';
-import { functionSubpathSetting, tsConfigFileName, tsDefaultOutDir } from '../../../constants';
+import { functionSubpathSetting, tsConfigFileName, tsDefaultOutDir, tsDefaultSrcDir } from '../../../constants';
 import { FuncVersion } from '../../../FuncVersion';
 import { localize } from '../../../localize';
 import { confirmOverwriteFile } from '../../../utils/fs';
@@ -27,7 +27,7 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
                     module: 'commonjs',
                     target: 'es6',
                     outDir: tsDefaultOutDir,
-                    rootDir: '.',
+                    rootDir: tsDefaultSrcDir,
                     sourceMap: true,
                     strict: false
                 }

--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -42,7 +42,7 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
             const functionSubpath: string = getWorkspaceSetting(functionSubpathSetting) as string;
 
             // this is set in the super class, but we want to override it
-            packageJson.main = path.posix.join('dist', functionSubpath, '*.js');
+            packageJson.main = path.posix.join(tsDefaultOutDir, functionSubpath, '*.js');
         }
 
         return packageJson;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -137,6 +137,7 @@ export const packTaskName: string = `${func}: ${packCommand}`;
 export const localhost: string = '127.0.0.1';
 
 export const tsDefaultOutDir: string = 'dist';
+export const tsDefaultSrcDir: string = 'src';
 export const tsConfigFileName: string = 'tsconfig.json';
 
 export const localEventHubsEmulatorConnectionStringDefault: string = 'MemoryF';


### PR DESCRIPTION
By default, functions in TypeScript (Model V4) are created in `src/functions` directory , then transpiled function code are generated in `dist/src/functions` directory as below.

```
├── src
│   └── functions
│       └──httpTrigger1.ts
├── dist # generated by tsc
│   └── src
│       └── functions
│           ├──httpTrigger1.js
│           └──httpTrigger1.map.js
```

In the above structure, `src` in `dist` does not seem to be needed.

This PR changes default settings (including generated `package.json`, `tsconfig.json` etc) for the structure from above to below.

```
├── src
│   └── functions
│       └──httpTrigger1.ts
├── dist # generated by tsc
│   └── functions
│       ├──httpTrigger1.js
│       └──httpTrigger1.map.js
```

Additionally, structure for JavaScript functions also is changed because transpilation is not needed.
```
├── functions
│   └──httpTrigger1.js
```