### PR TITLE
Detect new NodeJs model during "Init for VS Code"

### DIFF
--- a/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
+++ b/src/commands/createFunction/openAPISteps/OpenAPICreateStep.ts
@@ -6,7 +6,7 @@
 import { AzureWizardExecuteStep, DialogResponses, IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { ProgressLocation, Uri, window } from "vscode";
-import { ProjectLanguage } from "../../../constants";
+import { packageJsonFileName, ProjectLanguage } from "../../../constants";
 import { ext } from "../../../extensionVariables";
 import { localize } from "../../../localize";
 import { cpUtils } from "../../../utils/cpUtils";
@@ -97,7 +97,7 @@ async function validateAutorestInstalled(context: IActionContext): Promise<void>
 async function addAutorestSpecificTypescriptDependencies(context: IFunctionWizardContext): Promise<void> {
     const coreHttp: string = '@azure/core-http';
     const coreHttpVersion: string = '^1.1.4';
-    const packagePath: string = path.join(context.projectPath, 'package.json');
+    const packagePath: string = path.join(context.projectPath, packageJsonFileName);
 
     await confirmEditJsonFile(context, packagePath, (data: { devDependencies?: { [key: string]: string } }): {} => {
         data.devDependencies = data.devDependencies || {};

--- a/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
@@ -6,7 +6,7 @@
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { Progress } from 'vscode';
-import { functionSubpathSetting } from '../../../constants';
+import { functionSubpathSetting, packageJsonFileName } from '../../../constants';
 import { ext } from '../../../extensionVariables';
 import { localize } from '../../../localize';
 import { cpUtils } from '../../../utils/cpUtils';
@@ -30,7 +30,7 @@ export class JavaScriptProjectCreateStep extends ScriptProjectCreateStep {
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         await super.executeCore(context, progress);
 
-        const packagePath: string = path.join(context.projectPath, 'package.json');
+        const packagePath: string = path.join(context.projectPath, packageJsonFileName);
         if (await confirmOverwriteFile(context, packagePath)) {
             await AzExtFsExtra.writeJSON(packagePath, this.getPackageJson(context));
         }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/JavaScriptInitVSCodeStep.ts
@@ -6,7 +6,7 @@
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { DebugConfiguration, TaskDefinition } from "vscode";
-import { extInstallTaskName, func, hostStartCommand, hostStartTaskName, ProjectLanguage } from "../../../constants";
+import { extInstallTaskName, func, hostStartCommand, hostStartTaskName, packageJsonFileName, ProjectLanguage } from "../../../constants";
 import { nodeDebugConfig } from "../../../debug/NodeDebugProvider";
 import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
 import { convertToFunctionsTaskLabel } from '../../../vsCodeConfig/tasks';
@@ -22,7 +22,7 @@ export class JavaScriptInitVSCodeStep extends ScriptInitVSCodeStep {
     protected async executeCore(context: IProjectWizardContext): Promise<void> {
         await super.executeCore(context);
 
-        this.hasPackageJson = await AzExtFsExtra.pathExists(path.join(context.projectPath, 'package.json'));
+        this.hasPackageJson = await AzExtFsExtra.pathExists(path.join(context.projectPath, packageJsonFileName));
         if (this.hasPackageJson) {
             this.preDeployTask = npmPruneTaskLabel;
             this.settings.push({ key: 'postDeployTask', value: npmInstallTaskLabel });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,7 @@ export const launchFileName: string = 'launch.json';
 export const settingsFileName: string = 'settings.json';
 export const vscodeFolderName: string = '.vscode';
 export const gitignoreFileName: string = '.gitignore';
+export const packageJsonFileName: string = 'package.json';
 export const requirementsFileName: string = 'requirements.txt';
 export const pythonFunctionAppFileName: string = 'function_app.py';
 export const extensionsCsprojFileName: string = 'extensions.csproj';

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -13,6 +13,7 @@ import { ext } from "../extensionVariables";
 import { IHostJsonV2, INetheriteTaskJson, ISqlTaskJson, IStorageTaskJson } from "../funcConfig/host";
 import { localize } from "../localize";
 import { cpUtils } from "./cpUtils";
+import { hasNodeJsDependency } from "./nodeJsUtils";
 import { pythonUtils } from "./pythonUtils";
 import { venvUtils } from "./venvUtils";
 import { findFiles } from "./workspace";
@@ -92,14 +93,7 @@ export namespace durableUtils {
     }
 
     async function nodeProjectHasDurableDependency(projectPath: string): Promise<boolean> {
-        const packagePath: string = path.join(projectPath, 'package.json');
-        if (!await AzExtFsExtra.pathExists(packagePath)) {
-            return false;
-        }
-
-        const packageJson: Record<string, unknown> = await AzExtFsExtra.readJSON(packagePath);
-        const dependencies = packageJson?.dependencies as {} || {};
-        return !!dependencies[nodeDfPackage];
+        return await hasNodeJsDependency(projectPath, nodeDfPackage);
     }
 
     async function dotnetProjectHasDurableDependency(projectPath: string): Promise<boolean> {

--- a/src/utils/nodeJsUtils.ts
+++ b/src/utils/nodeJsUtils.ts
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtFsExtra } from "@microsoft/vscode-azext-utils";
+import * as path from 'path';
+import { packageJsonFileName } from "../constants";
+
+interface PackageJson {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+}
+
+export async function tryGetPackageJson(projectPath: string): Promise<PackageJson | undefined> {
+    try {
+        return await AzExtFsExtra.readJSON(path.join(projectPath, packageJsonFileName));
+    } catch {
+        return undefined;
+    }
+}
+
+export async function hasNodeJsDependency(projectPath: string, depName: string, isDevDependency: boolean = false): Promise<boolean> {
+    try {
+        const packageJson = await tryGetPackageJson(projectPath);
+        if (isDevDependency) {
+            return !!packageJson?.devDependencies?.[depName];
+        } else {
+            return !!packageJson?.dependencies?.[depName];
+        }
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
Right now "Init for VS Code" always defaults to the v3 model. My fix uses the version of the "@azure/functions" dependency to detect the model version. Also, since the new model can put ".ts" and ".js" files anywhere, I'm checking for the "typescript" dev dependency to determine if it's a TypeScript or JavaScript project instead.

Lastly, I noticed some code in the repo that was basically doing the same thing as me so I consolidated that a bit.