### PR TITLE
Minor fixes for durable in new NodeJs model

### DIFF
--- a/src/templates/script/getScriptVerifiedTemplateIds.ts
+++ b/src/templates/script/getScriptVerifiedTemplateIds.ts
@@ -43,7 +43,7 @@ export function getScriptVerifiedTemplateIds(version: string): (string | RegExp)
 
         // The Entity templates aren't supported in PowerShell at all, and the DurableFunctionsEntityHttpStart template is not yet supported in Python.
         // As a result, we need to manually create their respective regular expressions to account for these edge cases
-        const entityRegExps = [new RegExp(`^DurableFunctionsEntity-(JavaScript|TypeScript|Python|Custom)$`, 'i'), new RegExp(`^DurableFunctionsEntityHttpStart-(JavaScript|TypeScript|Custom)$`, 'i')];
+        const entityRegExps = [new RegExp(`^DurableFunctionsEntity-(JavaScript(-4.x)?|TypeScript(-4.x)?|Python|Custom)$`, 'i'), new RegExp(`^DurableFunctionsEntityHttpStart-(JavaScript(-4.x)?|TypeScript(-4.x)?|Custom)$`, 'i')];
         return regExps.concat(entityRegExps);
     }
 }

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -199,7 +199,8 @@ export namespace durableUtils {
 
     async function installNodeDependencies(context: IFunctionWizardContext): Promise<void> {
         try {
-            await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'npm', 'install', durableUtils.nodeDfPackage);
+            const packageVersion = context.languageModel === 4 ? 'preview' : '2';
+            await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'npm', 'install', `${durableUtils.nodeDfPackage}@${packageVersion}`);
         } catch (error) {
             const pError: IParsedError = parseError(error);
             const dfDepInstallFailed: string = localize('failedToAddDurableNodeDependency', 'Failed to add or install the "{0}" dependency. Please inspect and verify if it needs to be added manually.', durableUtils.nodeDfPackage);


### PR DESCRIPTION
- Show entity templates as verified
- Install the preview v3 package instead of latest v2 (fyi the durable versions do _not_ match the main model versions 😅). I wish I could do `npm install durable-functions@3` but apparently that doesn't include prerelease versions :/