### PR TITLE
Fix create function tests for durable Python templates

### DIFF
--- a/test/createFunction/createFunction.Script.v2.test.ts
+++ b/test/createFunction/createFunction.Script.v2.test.ts
@@ -130,18 +130,6 @@ function addSuite(tester: FunctionTesterBase): void {
             ]
         },
         {
-            functionName: 'Durable Functions activity',
-            inputs: [],
-            skip: tester.language === ProjectLanguage.Custom
-        },
-        {
-            functionName: 'Durable Functions HTTP starter',
-            inputs: [
-                getRotatingAuthLevel()
-            ],
-            skip: tester.language === ProjectLanguage.Custom
-        },
-        {
             functionName: 'Durable Functions orchestrator',
             inputs: [],
             skip: tester.language === ProjectLanguage.Custom

--- a/test/createFunction/createFunction.Script.v2.test.ts
+++ b/test/createFunction/createFunction.Script.v2.test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { FuncVersion, funcVersionSetting, ProjectLanguage, projectLanguageSetting } from '../../extension.bundle';
@@ -41,6 +42,13 @@ class PythonFunctionTester extends FunctionTesterBase {
             path.join(functionName, 'function.json'),
             path.join(functionName, '__init__.py')
         ];
+    }
+
+    protected override async initializeTestFolder(testFolder: string): Promise<void> {
+        await super.initializeTestFolder(testFolder);
+        await Promise.all([
+            AzExtFsExtra.writeFile(path.join(testFolder, 'requirements.txt'), '')
+        ]);
     }
 }
 

--- a/test/createFunction/createFunction.Script.v2.test.ts
+++ b/test/createFunction/createFunction.Script.v2.test.ts
@@ -138,19 +138,31 @@ function addSuite(tester: FunctionTesterBase): void {
             ]
         },
         {
+            functionName: 'Durable Functions activity',
+            inputs: [],
+            skip: tester.language === ProjectLanguage.Custom
+        },
+        {
+            functionName: 'Durable Functions HTTP starter',
+            inputs: [
+                getRotatingAuthLevel()
+            ],
+            skip: tester.language === ProjectLanguage.Custom
+        },
+        {
             functionName: 'Durable Functions orchestrator',
-            inputs: ['Azure Storage'],
+            inputs: [],
             skip: tester.language === ProjectLanguage.Custom
         },
         {
             functionName: 'Durable Functions entity',
-            inputs: ['Azure Storage'],
+            inputs: [],
             skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java
         },
         {
             functionName: 'Durable Functions Entity HTTP starter',
             inputs: tester.language === ProjectLanguage.JavaScript ? [] : [getRotatingAuthLevel()],
-            skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java || tester.language === ProjectLanguage.Python || tester.language === ProjectLanguage.Custom
+            skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java || tester.language === ProjectLanguage.Python
         },
         {
             functionName: 'IoT Hub (Event Hub)',

--- a/test/createFunction/createFunction.Script.v2.test.ts
+++ b/test/createFunction/createFunction.Script.v2.test.ts
@@ -131,18 +131,18 @@ function addSuite(tester: FunctionTesterBase): void {
         },
         {
             functionName: 'Durable Functions orchestrator',
-            inputs: [],
+            inputs: ['Azure Storage'],
             skip: tester.language === ProjectLanguage.Custom
         },
         {
             functionName: 'Durable Functions entity',
-            inputs: [],
+            inputs: ['Azure Storage'],
             skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java
         },
         {
             functionName: 'Durable Functions Entity HTTP starter',
             inputs: tester.language === ProjectLanguage.JavaScript ? [] : [getRotatingAuthLevel()],
-            skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java || tester.language === ProjectLanguage.Python
+            skip: tester.language === ProjectLanguage.PowerShell || tester.language === ProjectLanguage.Java || tester.language === ProjectLanguage.Python || tester.language === ProjectLanguage.Custom
         },
         {
             functionName: 'IoT Hub (Event Hub)',

--- a/test/index.ts
+++ b/test/index.ts
@@ -31,33 +31,26 @@ export async function run(): Promise<void> {
         files = ['updateBackupTemplates.js'];
     } else {
         files = await globby('**/**.test.js', { cwd: __dirname })
-        const hardcodedTests = await globby('**/**.run.only.js', { cwd: __dirname });
-        if (hardcodedTests.length > 0) {
-            files = hardcodedTests;
-        }
-
-        console.log(`Running tests from ${files.length} files.`);
-
-        files.forEach(f => mocha.addFile(path.resolve(__dirname, f)));
-
-        const failures = await new Promise<number>(resolve => mocha.run(resolve));
-        if (failures > 0) {
-            throw new Error(`${failures} tests failed.`);
-        }
     }
 
+    files.forEach(f => mocha.addFile(path.resolve(__dirname, f)));
 
-    function addEnvVarsToMochaOptions(options: Mocha.MochaOptions): void {
-        for (const envVar of Object.keys(process.env)) {
-            const match: RegExpMatchArray | null = envVar.match(/^mocha_(.+)/i);
-            if (match) {
-                const [, option] = match;
-                let value: string | number = process.env[envVar] || '';
-                if (typeof value === 'string' && !isNaN(parseInt(value))) {
-                    value = parseInt(value);
-                }
-                (<any>options)[option] = value;
+    const failures = await new Promise<number>(resolve => mocha.run(resolve));
+    if (failures > 0) {
+        throw new Error(`${failures} tests failed.`);
+    }
+}
+
+function addEnvVarsToMochaOptions(options: Mocha.MochaOptions): void {
+    for (const envVar of Object.keys(process.env)) {
+        const match: RegExpMatchArray | null = envVar.match(/^mocha_(.+)/i);
+        if (match) {
+            const [, option] = match;
+            let value: string | number = process.env[envVar] || '';
+            if (typeof value === 'string' && !isNaN(parseInt(value))) {
+                value = parseInt(value);
             }
+            (<any>options)[option] = value;
         }
     }
 }


### PR DESCRIPTION
Fixes 22 tests that used the durable templates for Python. These were failing because they expect a requirements.txt file to be present.