### PR TITLE
Add Dotnet Isolated runtime specific dependencies and cleanup `durableUtils`

### DIFF
--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -19,11 +19,11 @@ import { venvUtils } from "./venvUtils";
 import { findFiles } from "./workspace";
 
 export namespace durableUtils {
-    const dotnetLtsDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
+    const dotnetInProcDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
     const dotnetIsolatedDfSqlPackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer';
-    const dotnetLtsDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
+    const dotnetInProcDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
     const dotnetIsolatedDfNetheritePackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite';
-    const dotnetLtsDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
+    const dotnetInProcDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
     const nodeDfPackage: string = 'durable-functions';
     const pythonDfPackage: string = 'azure-functions-durable';
 
@@ -161,12 +161,12 @@ export namespace durableUtils {
             case DurableBackend.Netherite:
                 isDotnetIsolated ?
                     packageNames.push(dotnetIsolatedDfNetheritePackage) :
-                    packageNames.push(dotnetLtsDfNetheritePackage);
+                    packageNames.push(dotnetInProcDfNetheritePackage);
                 break;
             case DurableBackend.SQL:
                 isDotnetIsolated ?
                     packageNames.push(dotnetIsolatedDfSqlPackage) :
-                    packageNames.push(dotnetLtsDfSqlPackage);
+                    packageNames.push(dotnetInProcDfSqlPackage);
                 break;
             case DurableBackend.Storage:
             default:
@@ -175,7 +175,7 @@ export namespace durableUtils {
         // Seems that the package arrives out-dated and needs to be updated to at least 2.9.1;
         // otherwise, error appears when running with sql backend
         if (!isDotnetIsolated) {
-            packageNames.push(dotnetLtsDfBasePackage);
+            packageNames.push(dotnetInProcDfBasePackage);
         }
 
         const failedPackages: string[] = [];

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -20,9 +20,9 @@ import { findFiles } from "./workspace";
 
 export namespace durableUtils {
     export const dotnetLtsDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
-    export const dotnetIsolatedDfSqlPackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite';
+    export const dotnetIsolatedDfSqlPackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer';
     export const dotnetLtsDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
-    export const dotnetIsolatedDfNetheritePackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer';
+    export const dotnetIsolatedDfNetheritePackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite';
     export const dotnetLtsDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
     export const nodeDfPackage: string = 'durable-functions';
     export const pythonDfPackage: string = 'azure-functions-durable';

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -172,8 +172,11 @@ export namespace durableUtils {
             default:
         }
 
-        // Seems that the package arrives out-dated and needs to be updated to at least 2.9.1;
-        // otherwise, error appears when running with sql backend
+        /*
+         * https://github.com/microsoft/vscode-azurefunctions/issues/3599
+         * Seems that the package arrives out-dated and needs to be updated to at least 2.9.1;
+         * otherwise, error appears when running with sql backend
+         */
         if (!isDotnetIsolated) {
             packageNames.push(dotnetInProcDfBasePackage);
         }

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -144,7 +144,7 @@ export namespace durableUtils {
                 await installNodeDependencies(context);
                 break;
             case ProjectLanguage.Python:
-                await pythonUtils.addDependencyToRequirements(durableUtils.pythonDfPackage, context.projectPath);
+                await pythonUtils.addDependencyToRequirements(pythonDfPackage, context.projectPath);
                 await venvUtils.runPipInstallCommandIfPossible(context.projectPath);
                 break;
             case ProjectLanguage.PowerShell:
@@ -196,10 +196,10 @@ export namespace durableUtils {
     async function installNodeDependencies(context: IFunctionWizardContext): Promise<void> {
         try {
             const packageVersion = context.languageModel === 4 ? 'preview' : '2';
-            await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'npm', 'install', `${durableUtils.nodeDfPackage}@${packageVersion}`);
+            await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'npm', 'install', `${nodeDfPackage}@${packageVersion}`);
         } catch (error) {
             const pError: IParsedError = parseError(error);
-            const dfDepInstallFailed: string = localize('failedToAddDurableNodeDependency', 'Failed to add or install the "{0}" dependency. Please inspect and verify if it needs to be added manually.', durableUtils.nodeDfPackage);
+            const dfDepInstallFailed: string = localize('failedToAddDurableNodeDependency', 'Failed to add or install the "{0}" dependency. Please inspect and verify if it needs to be added manually.', nodeDfPackage);
             ext.outputChannel.appendLog(pError.message);
             ext.outputChannel.appendLog(dfDepInstallFailed);
         }

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -116,7 +116,6 @@ export namespace durableUtils {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
                     resolve(packageReferences.some(p => /Durable/i.test(p?.['$']?.['Include'] ?? '')));
                 }
-                resolve(false);
             });
         });
     }

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -172,8 +172,8 @@ export namespace durableUtils {
             default:
         }
 
-        // Seems that the package arrives out-dated and needs to be updated;
-        // otherwise, error appears when running with certain storage types
+        // Seems that the package arrives out-dated and needs to be updated to at least 2.9.1;
+        // otherwise, error appears when running with sql backend
         if (!isDotnetIsolated) {
             packageNames.push(dotnetLtsDfBasePackage);
         }

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -19,9 +19,11 @@ import { venvUtils } from "./venvUtils";
 import { findFiles } from "./workspace";
 
 export namespace durableUtils {
-    export const dotnetDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
-    export const dotnetDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
-    export const dotnetDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
+    export const dotnetLtsDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
+    export const dotnetIsolatedDfSqlPackage: string = '';
+    export const dotnetLtsDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
+    export const dotnetIsolatedDfNetheritePackage: string = '';
+    export const dotnetLtsDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
     export const nodeDfPackage: string = 'durable-functions';
     export const pythonDfPackage: string = 'azure-functions-durable';
 
@@ -111,17 +113,8 @@ export namespace durableUtils {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
                     let packageReferences = result?.['Project']?.['ItemGroup']?.[0]?.PackageReference ?? [];
                     packageReferences = (packageReferences instanceof Array) ? packageReferences : [packageReferences];
-
-                    for (const packageRef of packageReferences) {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                        if (packageRef['$'] && packageRef['$']['Include']) {
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                            if (packageRef['$']['Include'] === dotnetDfBasePackage) {
-                                resolve(true);
-                                return;
-                            }
-                        }
-                    }
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+                    resolve(packageReferences.some(p => /Durable/i.test(p?.['$']?.['Include'])));
                 }
                 resolve(false);
             });
@@ -165,17 +158,17 @@ export namespace durableUtils {
         const packageNames: string[] = [];
         switch (context.newDurableStorageType) {
             case DurableBackend.Netherite:
-                packageNames.push(durableUtils.dotnetDfNetheritePackage);
+                packageNames.push(durableUtils.dotnetLtsDfNetheritePackage);
                 break;
             case DurableBackend.SQL:
-                packageNames.push(durableUtils.dotnetDfSqlPackage);
+                packageNames.push(durableUtils.dotnetLtsDfSqlPackage);
                 break;
             case DurableBackend.Storage:
             default:
         }
 
         // Seems that the package arrives out-dated and needs to be updated
-        packageNames.push(durableUtils.dotnetDfBasePackage);
+        packageNames.push(durableUtils.dotnetLtsDfBasePackage);
 
         const failedPackages: string[] = [];
         for (const packageName of packageNames) {

--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -19,13 +19,13 @@ import { venvUtils } from "./venvUtils";
 import { findFiles } from "./workspace";
 
 export namespace durableUtils {
-    export const dotnetLtsDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
-    export const dotnetIsolatedDfSqlPackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer';
-    export const dotnetLtsDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
-    export const dotnetIsolatedDfNetheritePackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite';
-    export const dotnetLtsDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
-    export const nodeDfPackage: string = 'durable-functions';
-    export const pythonDfPackage: string = 'azure-functions-durable';
+    const dotnetLtsDfSqlPackage: string = 'Microsoft.DurableTask.SqlServer.AzureFunctions';
+    const dotnetIsolatedDfSqlPackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.SqlServer';
+    const dotnetLtsDfNetheritePackage: string = 'Microsoft.Azure.DurableTask.Netherite.AzureFunctions';
+    const dotnetIsolatedDfNetheritePackage: string = 'Microsoft.Azure.Functions.Worker.Extensions.DurableTask.Netherite';
+    const dotnetLtsDfBasePackage: string = 'Microsoft.Azure.WebJobs.Extensions.DurableTask';
+    const nodeDfPackage: string = 'durable-functions';
+    const pythonDfPackage: string = 'azure-functions-durable';
 
     export function requiresDurableStorageSetup(context: IFunctionWizardContext): boolean {
         return !!context.functionTemplate && templateRequiresDurableStorageSetup(context.functionTemplate.id, context.language) && !context.hasDurableStorage;


### PR DESCRIPTION
Add .NET Isolated runtime specific dependencies, specifically for `Netherite` and `MSSQL` storage types.

Partially addresses the error message shown in #3566.