### PR TITLE
Fix TypeScript project language detection

### DIFF
--- a/src/commands/initProjectForVSCode/detectProjectLanguage.ts
+++ b/src/commands/initProjectForVSCode/detectProjectLanguage.ts
@@ -24,7 +24,10 @@ export async function detectProjectLanguage(context: IActionContext, projectPath
             if (await isTypeScriptProject(projectPath)) {
                 detectedLangs.push(ProjectLanguage.TypeScript);
             } else {
-                detectedLangs.push(ProjectLanguage.JavaScript);
+                // don't add JavaScript if TypeScript is already detected
+                if (!detectedLangs.includes(ProjectLanguage.TypeScript)) {
+                    detectedLangs.push(ProjectLanguage.JavaScript);
+                }
             }
         }
 


### PR DESCRIPTION
Changes in https://github.com/microsoft/vscode-azurefunctions/pull/3586 changed TypeScript language detection in that JavaScript would also be detected, which results in prompting the user to choose a language in cases that didn't before #3586 was merged. I found this while fixing the unit tests.

These changes fix the unit tests so that if TypeScript is detected (tsconfig found, etc.), then JavaScript won't also be detected.