### PR TITLE
Make skip for now message more clear when there are no resources available

### DIFF
--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -23,7 +23,7 @@ export async function promptForResource<T extends IBaseResourceWithName>(context
             .map((r: T) => r.name ? { data: r, label: r.name, description: r._description } : undefined)
             .filter((p: IAzureQuickPickItem<T> | undefined) => p));
         picks.push({
-            label: localize('skipForNow', '$(clock) Skip for now'),
+            label: picks.length ? localize('skipForNow', '$(clock) Skip for now') : localize('skipForNow', '$(warning) Skip because no resource was found'),
             data: undefined,
             suppressPersistence: true
         });

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -23,7 +23,7 @@ export async function promptForResource<T extends IBaseResourceWithName>(context
             .map((r: T) => r.name ? { data: r, label: r.name, description: r._description } : undefined)
             .filter((p: IAzureQuickPickItem<T> | undefined) => p));
         picks.push({
-            label: picks.length ? localize('skipForNow', '$(clock) Skip for now') : localize('skipForNow', '$(warning) Skip because no resource was found'),
+            label: picks.length ? localize('skipForNow', '$(clock) Skip for now') : localize('skippedNoResources', '$(warning) Skipped because no matching resource was found'),
             data: undefined,
             suppressPersistence: true
         });


### PR DESCRIPTION
Partially fixes #3550 

This is the old skip for now. The behavior is the same as before:
![image](https://user-images.githubusercontent.com/5290572/222806422-93902709-9c00-495b-ad56-f0caeecab3b6.png)

If no picks were found, the message is edited to reflect that and hopefully makes it more clear for users. Ideally, we could create these resources for the user here later, but this is more of a gapfixer.
![image](https://user-images.githubusercontent.com/5290572/222806990-ec754481-8159-49d6-99e7-74b6ab762ced.png)
