### PR TITLE
Update .NET Isolated detection to check against the template ID

### DIFF
--- a/src/utils/durableUtils.ts
+++ b/src/utils/durableUtils.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import { Uri } from "vscode";
 import * as xml2js from "xml2js";
 import { IFunctionWizardContext } from "../commands/createFunction/IFunctionWizardContext";
-import { ConnectionKey, DurableBackend, DurableBackendValues, hostFileName, ProjectLanguage, requirementsFileName } from "../constants";
+import { ConnectionKey, DurableBackend, DurableBackendValues, ProjectLanguage, hostFileName, requirementsFileName } from "../constants";
 import { ext } from "../extensionVariables";
 import { IHostJsonV2, INetheriteTaskJson, ISqlTaskJson, IStorageTaskJson } from "../funcConfig/host";
 import { localize } from "../localize";
@@ -151,7 +151,7 @@ export namespace durableUtils {
 
     async function installDotnetDependencies(context: IFunctionWizardContext): Promise<void> {
         const packageNames: string[] = [];
-        const isDotnetIsolated: boolean = /Isolated/i.test(context.projectTemplateKey ?? '');
+        const isDotnetIsolated: boolean = /Isolated/i.test(context.functionTemplate?.id ?? '');
 
         switch (context.newDurableStorageType) {
             case DurableBackend.Netherite:


### PR DESCRIPTION
Closes #3642 

Changing the value we check against...  If we set up a project with another template before we add Durable Functions Orchestration, `projectTemplateKey` may equal an empty string (it wasn't obvious to me why but I didn't dig too deeply).  This causes `isDotnetIsolated` to be a false negative.  Checking the template ID seems to be a more robust fix.. though please let me know if there's a better known value we should be checking against instead.