### PR TITLE
Remove `azureWebJobsStorage` validation on deploy

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { SiteConfigResource } from '@azure/arm-appservice';
-import { deploy as innerDeploy, getDeployFsPath, getDeployNode, IDeployContext, IDeployPaths, showDeployConfirmation } from '@microsoft/vscode-azext-azureappservice';
+import { IDeployContext, IDeployPaths, getDeployFsPath, getDeployNode, deploy as innerDeploy, showDeployConfirmation } from '@microsoft/vscode-azext-azureappservice';
 import { DialogResponses, IActionContext, nonNullValue } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
-import { CodeAction, ConnectionType, deploySubpathSetting, DurableBackend, DurableBackendValues, functionFilter, ProjectLanguage, remoteBuildSetting, ScmType } from '../../constants';
+import { CodeAction, ConnectionType, DurableBackend, DurableBackendValues, ProjectLanguage, ScmType, deploySubpathSetting, functionFilter, remoteBuildSetting } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
@@ -19,9 +19,8 @@ import { isPathEqual } from '../../utils/fs';
 import { treeUtils } from '../../utils/treeUtils';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
-import { validateStorageConnection } from '../appSettings/connectionSettings/azureWebJobsStorage/validateStorageConnection';
-import { validateEventHubsConnection } from '../appSettings/connectionSettings/eventHubs/validateEventHubsConnection';
 import { ISetConnectionSettingContext } from '../appSettings/connectionSettings/ISetConnectionSettingContext';
+import { validateEventHubsConnection } from '../appSettings/connectionSettings/eventHubs/validateEventHubsConnection';
 import { validateSqlDbConnection } from '../appSettings/connectionSettings/sqlDatabase/validateSqlDbConnection';
 import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
 import { notifyDeployComplete } from './notifyDeployComplete';
@@ -97,12 +96,9 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     const durableStorageType: DurableBackendValues | undefined = await durableUtils.getStorageTypeFromWorkspace(language, context.projectPath);
     context.telemetry.properties.projectDurableStorageType = durableStorageType;
 
-    const { shouldValidateStorage, shouldValidateEventHubs, shouldValidateSqlDb } = await shouldValidateConnections(durableStorageType, client, context.projectPath);
+    const { shouldValidateEventHubs, shouldValidateSqlDb } = await shouldValidateConnections(durableStorageType, client, context.projectPath);
 
     // Preliminary local validation done to ensure all required resources have been created and are available. Final deploy writes are made in 'verifyAppSettings'
-    if (shouldValidateStorage) {
-        await validateStorageConnection(context, context.projectPath, { preselectedConnectionType: ConnectionType.Azure });
-    }
     if (shouldValidateEventHubs) {
         await validateEventHubsConnection(context, context.projectPath, { preselectedConnectionType: ConnectionType.Azure });
     }

--- a/src/commands/deploy/shouldValidateConnection.ts
+++ b/src/commands/deploy/shouldValidateConnection.ts
@@ -4,20 +4,17 @@ import { ConnectionKey, DurableBackend, DurableBackendValues } from "../../const
 import { getEventHubName } from "../appSettings/connectionSettings/eventHubs/validateEventHubsConnection";
 
 export interface IShouldValidateConnection {
-    shouldValidateStorage: boolean;
     shouldValidateEventHubs: boolean;
     shouldValidateSqlDb: boolean;
 }
 
 export async function shouldValidateConnections(durableStorageType: DurableBackendValues | undefined, client: SiteClient, projectPath: string): Promise<IShouldValidateConnection> {
     const app: StringDictionary = await client.listApplicationSettings();
-    const remoteStorageConnection: string | undefined = app?.properties?.[ConnectionKey.Storage];
     const remoteEventHubsConnection: string | undefined = app?.properties?.[ConnectionKey.EventHubs];
     const remoteSqlDbConnection: string | undefined = app?.properties?.[ConnectionKey.SQL];
     const eventHubName: string | undefined = await getEventHubName(projectPath);
 
-    const shouldValidateStorage: boolean = !remoteStorageConnection;
     const shouldValidateEventHubs: boolean = durableStorageType === DurableBackend.Netherite && (!eventHubName || !remoteEventHubsConnection);
     const shouldValidateSqlDb: boolean = durableStorageType === DurableBackend.SQL && !remoteSqlDbConnection;
-    return { shouldValidateStorage, shouldValidateEventHubs, shouldValidateSqlDb };
+    return { shouldValidateEventHubs, shouldValidateSqlDb };
 }


### PR DESCRIPTION
Fixes #3638 

As part of the Durable work, I introduced a remote resource/connection string validation pattern on deploy because these were required for netherite and sql backends.  I went ahead and applied this pattern to storage to maintain consistency across the connection strings.  

AFAICT, this was not being done before, and in adding this, I introduced an unintended consequence - see: https://github.com/microsoft/vscode-azurefunctions/issues/3638#issuecomment-1502080143 
Basically, I was not aware of and did not take this into account: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial#edit-the-azurewebjobsstorage-configuration

Since we already connect storage accounts during Function App creation, it's probably not super necessary to do this validation anyway.  I am removing `azureWebJobsStorage` validation on deploy to be consistent with how we used to things and to fix the above issue.