### PR TITLE
Add clean script to TypeScript projects

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/TypeScriptProjectCreateStep.ts
@@ -6,8 +6,8 @@
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
 import { Progress } from 'vscode';
-import { functionSubpathSetting, tsConfigFileName, tsDefaultOutDir } from '../../../constants';
 import { FuncVersion } from '../../../FuncVersion';
+import { functionSubpathSetting, tsConfigFileName, tsDefaultOutDir } from '../../../constants';
 import { localize } from '../../../localize';
 import { confirmOverwriteFile } from '../../../utils/fs';
 import { isNodeV4Plus } from '../../../utils/programmingModelUtils';
@@ -52,7 +52,8 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
         const typeScriptPackageJsonScripts: { [key: string]: string } = {
             build: 'tsc',
             watch: 'tsc -w',
-            prestart: 'npm run build',
+            clean: `rimraf ${tsDefaultOutDir}`,
+            prestart: 'npm run clean && npm run build',
             start: 'func start',
             test: 'echo \"No tests yet...\"'
         };
@@ -92,6 +93,7 @@ export class TypeScriptProjectCreateStep extends JavaScriptProjectCreateStep {
 
         devDeps['@types/node'] = `^${nodeTypesVersion}.x`;
         devDeps['typescript'] = '^4.0.0';
+        devDeps['rimraf'] = '^5.0.0';
         return devDeps;
     }
 }

--- a/test/project/createNewProject.test.ts
+++ b/test/project/createNewProject.test.ts
@@ -30,8 +30,8 @@ const testCases: CreateProjectTestCase[] = [
 // Test cases that are the same for both v2 and v3
 for (const version of [FuncVersion.v2, FuncVersion.v3, FuncVersion.v4]) {
     testCases.push(
-        { ...getJavaScriptValidateOptions(true /* hasPackageJson */, version) },
-        { ...getTypeScriptValidateOptions(version) },
+        { ...getJavaScriptValidateOptions(true /* hasPackageJson */, version), inputs: ['Model V3'] },
+        { ...getTypeScriptValidateOptions({ version }), inputs: ['Model V3'] },
         { ...getPowerShellValidateOptions(version) },
         { ...getDotnetScriptValidateOptions(ProjectLanguage.CSharpScript, version), isHiddenLanguage: true },
         { ...getDotnetScriptValidateOptions(ProjectLanguage.FSharpScript, version), isHiddenLanguage: true },

--- a/test/project/initProjectForVSCode.test.ts
+++ b/test/project/initProjectForVSCode.test.ts
@@ -32,11 +32,11 @@ suite('Init Project For VS Code', function (this: Mocha.Suite): void {
     });
 
     test('TypeScript', async () => {
-        await initAndValidateProject({ ...getTypeScriptValidateOptions(), mockFiles: [['HttpTrigger', 'index.ts'], 'tsconfig.json', 'package.json'] });
+        await initAndValidateProject({ ...getTypeScriptValidateOptions({ missingCleanScript: true }), mockFiles: [['HttpTrigger', 'index.ts'], 'tsconfig.json', 'package.json'] });
     });
 
     test('TypeScript with extensions.csproj', async () => {
-        const options: IValidateProjectOptions = getTypeScriptValidateOptions();
+        const options: IValidateProjectOptions = getTypeScriptValidateOptions({ missingCleanScript: true });
         options.expectedSettings['files.exclude'] = { obj: true, bin: true };
         await initAndValidateProject({ ...options, mockFiles: [['HttpTrigger', 'index.ts'], 'tsconfig.json', 'package.json', 'extensions.csproj'] });
     });

--- a/test/project/validateProject.ts
+++ b/test/project/validateProject.ts
@@ -45,8 +45,9 @@ export function getJavaScriptValidateOptions(hasPackageJson: boolean = false, ve
     };
 }
 
-export function getTypeScriptValidateOptions(version: FuncVersion = defaultTestFuncVersion): IValidateProjectOptions {
-    return {
+export function getTypeScriptValidateOptions(options?: { version?: FuncVersion, missingCleanScript?: boolean }): IValidateProjectOptions {
+    const version = options?.version || defaultTestFuncVersion;
+    const result = {
         language: ProjectLanguage.TypeScript,
         version,
         expectedSettings: {
@@ -73,6 +74,10 @@ export function getTypeScriptValidateOptions(version: FuncVersion = defaultTestF
             'host start'
         ]
     };
+    if (!options?.missingCleanScript) {
+        result.expectedTasks.push('npm clean (functions)');
+    }
+    return result;
 }
 
 export function getCSharpValidateOptions(targetFramework: string, version: FuncVersion = defaultTestFuncVersion, numCsproj: number = 1): IValidateProjectOptions {


### PR DESCRIPTION
In model v4, the entrypoint is a glob (`dist/src/functions/*.js`) meaning if you delete a ts file in `src`, you also need to delete the js file in `dist` otherwise the function will still show up. This can be confusing, so probably worth adding a clean script.

A few notes:
- rimraf v5 works in [Node.js v14+](https://github.com/isaacs/rimraf/blob/main/package.json#L79), but I feel like that's fine since Node 12 was EOL Oct 2020
- There's not as much value when adding this to the old model, but I thought it was easier to keep them consistent
- I'm _pretty sure_ my test changes work, but obviously I wasn't able to do a full test run given the state of the tests