### PR TITLE
Change the name of the windows-process-tree module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
     "engines": {
-        "vscode": "^1.66.0"
+        "vscode": "^1.78.0"
     },
     "repository": {
         "type": "git",

--- a/src/utils/windowsProcessTree.ts
+++ b/src/utils/windowsProcessTree.ts
@@ -7,7 +7,7 @@ import { localize } from '../localize';
 import { getCoreNodeModule } from "./getCoreNodeModule";
 
 export function getWindowsProcessTree(): IWindowsProcessTree {
-    const moduleName: string = 'windows-process-tree';
+    const moduleName: string = '@vscode/windows-process-tree';
     const windowsProcessTree: IWindowsProcessTree | undefined = getCoreNodeModule<IWindowsProcessTree>(moduleName);
     if (!windowsProcessTree) {
         throw new Error(localize('noWindowsProcessTree', 'Failed to find dependency "{0}".', moduleName));


### PR DESCRIPTION
Fixes #3664 

From VS Code 1.77 => 1.78, the name of the dependency was changed
https://github.com/microsoft/vscode/commit/15cb6b36f8c29df77133b422d46b64e4d508488f

We could either a.) check for both, or b.) increase the minimum required version for the extension