### PR TITLE
Fix SWA create function for node model v4

### DIFF
--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -5,15 +5,15 @@
 
 import { AzureWizard, IActionContext } from '@microsoft/vscode-azext-utils';
 import { WorkspaceFolder } from 'vscode';
+import { FuncVersion } from '../../FuncVersion';
 import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
-import { FuncVersion } from '../../FuncVersion';
 import { LocalProjectTreeItem } from '../../tree/localProject/LocalProjectTreeItem';
 import { durableUtils } from '../../utils/durableUtils';
 import { getContainingWorkspace, getRootWorkspaceFolder } from '../../utils/workspace';
-import * as api from '../../vscode-azurefunctions.api';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { verifyInitForVSCode } from '../../vsCodeConfig/verifyInitForVSCode';
+import * as api from '../../vscode-azurefunctions.api';
 import { createNewProjectInternal } from '../createNewProject/createNewProject';
 import { verifyProjectPath } from '../createNewProject/verifyIsProject';
 import { FunctionListStep } from './FunctionListStep';
@@ -72,7 +72,7 @@ export async function createFunctionInternal(context: IActionContext, options: a
     const projectTemplateKey: string | undefined = getWorkspaceSetting(projectTemplateKeySetting, projectPath);
     const wizardContext: IFunctionWizardContext = Object.assign(context, options, { projectPath, workspacePath, workspaceFolder, version, language, languageModel, projectTemplateKey, hasDurableStorage });
     const wizard: AzureWizard<IFunctionWizardContext> = new AzureWizard(wizardContext, {
-        promptSteps: [await FunctionListStep.create(wizardContext, { templateId: options.templateId, functionSettings: options.functionSettings, isProjectWizard: false })]
+        promptSteps: [new FunctionListStep({ templateId: options.templateId, functionSettings: options.functionSettings, isProjectWizard: false })]
     });
     await wizard.prompt();
     await wizard.execute();

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -5,7 +5,7 @@
 
 import { AzureWizardExecuteStep, AzureWizardPromptStep, IAzureQuickPickItem, IWizardOptions, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { QuickPickOptions } from 'vscode';
-import { nodeLearnMoreLink, nodeModels, previewPythonModel, ProjectLanguage } from '../../constants';
+import { ProjectLanguage, nodeLearnMoreLink, nodeModels, previewPythonModel } from '../../constants';
 import { pythonNewModelPreview } from '../../constants-nls';
 import { localize } from '../../localize';
 import { nonNullProp } from '../../utils/nonNull';
@@ -13,9 +13,7 @@ import { openUrl } from '../../utils/openUrl';
 import { isPythonV2Plus } from '../../utils/programmingModelUtils';
 import { FunctionListStep } from '../createFunction/FunctionListStep';
 import { addInitVSCodeSteps } from '../initProjectForVSCode/InitVSCodeLanguageStep';
-import { DotnetRuntimeStep } from './dotnetSteps/DotnetRuntimeStep';
 import { IProjectWizardContext } from './IProjectWizardContext';
-import { addJavaCreateProjectSteps } from './javaSteps/addJavaCreateProjectSteps';
 import { ProgrammingModelStep } from './ProgrammingModelStep';
 import { CustomProjectCreateStep } from './ProjectCreateStep/CustomProjectCreateStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
@@ -25,6 +23,8 @@ import { PysteinProjectCreateStep } from './ProjectCreateStep/PysteinProjectCrea
 import { PythonProjectCreateStep } from './ProjectCreateStep/PythonProjectCreateStep';
 import { ScriptProjectCreateStep } from './ProjectCreateStep/ScriptProjectCreateStep';
 import { TypeScriptProjectCreateStep } from './ProjectCreateStep/TypeScriptProjectCreateStep';
+import { DotnetRuntimeStep } from './dotnetSteps/DotnetRuntimeStep';
+import { addJavaCreateProjectSteps } from './javaSteps/addJavaCreateProjectSteps';
 
 export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizardContext> {
     public hideStepCount: boolean = true;
@@ -125,7 +125,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
 
         // All languages except Java support creating a function after creating a project
         // Java needs to fix this issue first: https://github.com/Microsoft/vscode-azurefunctions/issues/81
-        promptSteps.push(await FunctionListStep.create(context, {
+        promptSteps.push(new FunctionListStep({
             isProjectWizard: true,
             templateId: this._templateId,
             functionSettings: this._functionSettings

--- a/src/templates/script/getScriptVerifiedTemplateIds.ts
+++ b/src/templates/script/getScriptVerifiedTemplateIds.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FuncVersion } from '../../FuncVersion';
+import { nodeV4Suffix } from '../../utils/programmingModelUtils';
 
 export function getScriptVerifiedTemplateIds(version: string): (string | RegExp)[] {
     let verifiedTemplateIds: string[] = [
@@ -39,11 +40,11 @@ export function getScriptVerifiedTemplateIds(version: string): (string | RegExp)
         // These languages are only supported in v2+ - same functions as JavaScript, with a few minor exceptions that aren't worth distinguishing here
         // NOTE: The Python Preview IDs are only temporary.
         // NOTE: The Node Programming Model IDs include -4.x as a suffix
-        const regExps = verifiedTemplateIds.map(t => new RegExp(`^${t}-(JavaScript(-4.x)?|TypeScript(-4.x)?|Python|PowerShell|Custom|Python-Preview|Python-Preview-Append)$`, 'i'));
+        const regExps = verifiedTemplateIds.map(t => new RegExp(`^${t}-(JavaScript(${nodeV4Suffix})?|TypeScript(${nodeV4Suffix})?|Python|PowerShell|Custom|Python-Preview|Python-Preview-Append)$`, 'i'));
 
         // The Entity templates aren't supported in PowerShell at all, and the DurableFunctionsEntityHttpStart template is not yet supported in Python.
         // As a result, we need to manually create their respective regular expressions to account for these edge cases
-        const entityRegExps = [new RegExp(`^DurableFunctionsEntity-(JavaScript(-4.x)?|TypeScript(-4.x)?|Python|Custom)$`, 'i'), new RegExp(`^DurableFunctionsEntityHttpStart-(JavaScript(-4.x)?|TypeScript(-4.x)?|Custom)$`, 'i')];
+        const entityRegExps = [new RegExp(`^DurableFunctionsEntity-(JavaScript(${nodeV4Suffix})?|TypeScript(${nodeV4Suffix})?|Python|Custom)$`, 'i'), new RegExp(`^DurableFunctionsEntityHttpStart-(JavaScript(${nodeV4Suffix})?|TypeScript(${nodeV4Suffix})?|Custom)$`, 'i')];
         return regExps.concat(entityRegExps);
     }
 }

--- a/src/utils/programmingModelUtils.ts
+++ b/src/utils/programmingModelUtils.ts
@@ -9,6 +9,8 @@ export function isPythonV2Plus(language: string | undefined, model: number | und
     return language === ProjectLanguage.Python && model !== undefined && model > 1;
 }
 
+export const nodeV4Suffix = '-4.x';
+
 export function isNodeV4Plus(context: { language?: ProjectLanguage | string, languageModel?: number }): boolean {
     const { language, languageModel } = context;
     return (language === ProjectLanguage.JavaScript || language === ProjectLanguage.TypeScript) &&


### PR DESCRIPTION
When picking the template based on a templateId (which is how SWA creates a function [here](https://github.com/microsoft/vscode-azurestaticwebapps/blob/main/src/commands/createHttpFunction.ts#L34)), the functions extension always uses the v3 template even if v4 was selected by the user. I adjusted the filtering in `FunctionListStep` but it didn't quite work because we were calling `FunctionListStep.create` _before_ the model prompt. I switched to use the fancy new `configureBeforePrompt` method which selects the template _after_ the model prompt and worked for me.

Fixes https://github.com/microsoft/vscode-azurestaticwebapps/issues/829