### PR TITLE
Resolve using list instead of get

### DIFF
--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -15,6 +15,7 @@ export class FunctionAppResolver implements AppResourceResolver {
             const client = await createWebSiteClient({ ...context, ...subContext });
 
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
+                this.siteCache.clear();
                 const sites = await uiUtils.listAllIterator(client.webApps.list());
                 sites.forEach(site => this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), site));
                 this.siteCacheLastUpdated = Date.now();

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -1,18 +1,27 @@
-import { getResourceGroupFromId } from "@microsoft/vscode-azext-azureutils";
-import { callWithTelemetryAndErrorHandling, IActionContext, ISubscriptionContext, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { Site } from "@azure/arm-appservice";
+import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { IActionContext, ISubscriptionContext, callWithTelemetryAndErrorHandling, nonNullProp, nonNullValue } from "@microsoft/vscode-azext-utils";
 import { AppResource, AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
 import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource";
 import { createWebSiteClient } from "./utils/azureClients";
 
 export class FunctionAppResolver implements AppResourceResolver {
+
+    private siteCacheLastUpdated = 0;
+    private siteCache: Map<string, Site> = new Map<string, Site>();
+
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
             const client = await createWebSiteClient({ ...context, ...subContext });
-            const rg = getResourceGroupFromId(nonNullProp(resource, 'id'));
-            const name = nonNullProp(resource, 'name');
 
-            const site = await client.webApps.get(rg, name);
-            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, site);
+            if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
+                const sites = await uiUtils.listAllIterator(client.webApps.list());
+                sites.forEach(site => this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), site));
+                this.siteCacheLastUpdated = Date.now();
+            }
+
+            const site = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
+            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site));
         });
     }
 


### PR DESCRIPTION
Fixes #3723 

Making a HTTP request for each resource is really hurting performance. Ideally we can delay these requests until the user expands the resource or invokes a command on it, but for now I think this is the best solution.

The cache only valid for 3 seconds, long enough to make sure the entire batch of resolve calls can hit the cache. I didn't do anything fancy since I want to validate with the customer that this speeds things up. I figure we can make a util and share this across extensions later.