### PR TITLE
Remove .NET 5 create function tests

### DIFF
--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -44,8 +44,8 @@ class CSharpFunctionTester extends FunctionTesterBase {
 for (const source of allTemplateSources) {
     addSuite(FuncVersion.v2, 'netcoreapp2.1', source);
     addSuite(FuncVersion.v3, 'netcoreapp3.1', source);
-    addSuite(FuncVersion.v3, 'net5.0', source, true);
-    addSuite(FuncVersion.v4, 'net5.0', source, true);
+    // addSuite(FuncVersion.v3, 'net5.0', source, true);
+    // addSuite(FuncVersion.v4, 'net5.0', source, true);
     addSuite(FuncVersion.v4, 'net6.0', source, true);
     addSuite(FuncVersion.v4, 'net6.0', source, false);
     addSuite(FuncVersion.v4, 'net7.0', source, true);


### PR DESCRIPTION
.NET 5.0 is no longer officially supported by any of the Functions runtime versions.

https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp