### PR TITLE
Fix attaching to C# func process

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -97,6 +97,8 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
                     const statusRequest: AzExtRequestPrepareOptions = { url: `${scheme}://localhost:${funcPort}/admin/host/status`, method: 'GET' };
                     if (scheme === 'https') {
                         statusRequest.rejectUnauthorized = false;
+                    } else {
+                        statusRequest.allowInsecureConnection = true;
                     }
 
                     try {


### PR DESCRIPTION
Fix #3748 

The doc string on this property states: 
<img width="526" alt="image" src="https://github.com/microsoft/vscode-azurefunctions/assets/12476526/38016974-d22e-4f56-a364-60d09a971201">

Which is sorta confusing because it makes it sound like *they* set it to true when http is used. But turns out it just defaults to false.

It would help me a lot if you could reproing #3748 and then make sure this fixes it for you. It does for me 😄 