### PR TITLE
Remove old workaround for `netFrameworkVersion` that has been fixed

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -9,9 +9,9 @@ import { LocationListStep } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizardExecuteStep, parseError } from '@microsoft/vscode-azext-utils';
 import { AppResource } from '@microsoft/vscode-azext-utils/hostapi';
 import { Progress } from 'vscode';
-import { ConnectionKey, contentConnectionStringKey, contentShareKey, extensionVersionKey, ProjectLanguage, runFromPackageKey, webProvider } from '../../constants';
-import { ext } from '../../extensionVariables';
 import { FuncVersion, getMajorVersion } from '../../FuncVersion';
+import { ConnectionKey, ProjectLanguage, contentConnectionStringKey, contentShareKey, extensionVersionKey, runFromPackageKey, webProvider } from '../../constants';
+import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { createWebSiteClient } from '../../utils/azureClients';
 import { getRandomHexString } from '../../utils/fs';
@@ -99,11 +99,6 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
 
     private async getNewSiteConfig(context: IFunctionAppWizardContext, stack: FullFunctionAppStack): Promise<SiteConfig> {
         const stackSettings: FunctionAppRuntimeSettings = nonNullProp(stack.minorVersion.stackSettings, context.newSiteOS === WebsiteOS.linux ? 'linuxRuntimeSettings' : 'windowsRuntimeSettings');
-        // https://github.com/microsoft/vscode-azurefunctions/issues/2990
-        if (context.newSiteOS === 'windows' && context.version === FuncVersion.v4) {
-            stackSettings.siteConfigPropertiesDictionary.netFrameworkVersion = 'v6.0'
-        }
-
         const newSiteConfig: SiteConfig = stackSettings.siteConfigPropertiesDictionary;
         const storageConnectionString: string = (await getStorageConnectionString(context)).connectionString;
 

--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -7,7 +7,7 @@ import { ServiceClient } from '@azure/core-client';
 import { createPipelineRequest } from '@azure/core-rest-pipeline';
 import { AzExtPipelineResponse, createGenericClient } from '@microsoft/vscode-azext-azureutils';
 import { IAzureQuickPickItem, openUrl, parseError } from '@microsoft/vscode-azext-utils';
-import { FuncVersion, funcVersionLink } from '../../../FuncVersion';
+import { funcVersionLink } from '../../../FuncVersion';
 import { hiddenStacksSetting, noRuntimeStacksAvailableLabel } from '../../../constants';
 import { previewDescription } from '../../../constants-nls';
 import { localize } from '../../../localize';
@@ -213,14 +213,6 @@ function removeHiddenStacksAndProperties(stacks: FunctionAppStack[]): void {
                     if (minor.stackSettings.windowsRuntimeSettings?.isHidden) {
                         delete minor.stackSettings.windowsRuntimeSettings;
                     }
-                }
-
-                if (minor.stackSettings.windowsRuntimeSettings?.supportedFunctionsExtensionVersions.includes(FuncVersion.v3) &&
-                    minor.stackSettings.windowsRuntimeSettings?.supportedFunctionsExtensionVersions.includes(FuncVersion.v4)) {
-                    // Temporary workaround becausecurrently there are stacks that support both v3 and v4, but if netFrameworkVersion v6.0
-                    // is set for ~3 app, it will break so delete the netFrameworkVersion and only set to v6.0 for ~4
-                    // https://github.com/microsoft/vscode-azurefunctions/issues/2990
-                    delete minor.stackSettings.windowsRuntimeSettings.siteConfigPropertiesDictionary.netFrameworkVersion;
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3825
May fix https://github.com/microsoft/vscode-azurefunctions/issues/3836

We had to do a workaround for this [issue](https://github.com/microsoft/vscode-azurefunctions/issues/2990). The conditionals were breaking .NET 7 and .NET 8 apps though because it was deleting and/or overwriting the framework settings.