### PR TITLE
Remove '-alpha.7' from v4 node projects

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/JavaScriptProjectCreateStep.ts
@@ -17,7 +17,7 @@ import { IProjectWizardContext } from '../IProjectWizardContext';
 import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
 export const azureFunctionsDependency: string = '@azure/functions';
-export const azureFunctionsDependencyVersion: string = '^4.0.0-alpha.7';
+export const azureFunctionsDependencyVersion: string = '^4.0.0';
 
 export class JavaScriptProjectCreateStep extends ScriptProjectCreateStep {
     protected gitignore: string = nodeGitignore;


### PR DESCRIPTION
I just released 4.0.0 - this change isn't strictly necessary, but it makes the package.json a little cleaner and can reduce confusion for some users