### PR TITLE
Add `listLocalProjects` function

### DIFF
--- a/src/LocalResourceProvider.ts
+++ b/src/LocalResourceProvider.ts
@@ -2,99 +2,45 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { AzExtParentTreeItem, AzExtTreeItem, callWithTelemetryAndErrorHandling, IActionContext } from "@microsoft/vscode-azext-utils";
+import { AzExtParentTreeItem, AzExtTreeItem } from "@microsoft/vscode-azext-utils";
 import { WorkspaceResourceProvider } from "@microsoft/vscode-azext-utils/hostapi";
-import * as path from 'path';
-import { Disposable, workspace, WorkspaceFolder } from "vscode";
-import { tryGetFunctionProjectRoot } from "./commands/createNewProject/verifyIsProject";
-import { getFunctionAppName, getJavaDebugSubpath } from "./commands/initProjectForVSCode/InitVSCodeStep/JavaInitVSCodeStep";
-import { funcVersionSetting, JavaBuildTool, javaBuildTool, ProjectLanguage, projectLanguageModelSetting, projectLanguageSetting } from "./constants";
-import { FuncVersion, tryParseFuncVersion } from "./FuncVersion";
-import { localize } from "./localize";
+import { Disposable } from "vscode";
 import { InitLocalProjectTreeItem } from "./tree/localProject/InitLocalProjectTreeItem";
 import { InvalidLocalProjectTreeItem } from "./tree/localProject/InvalidLocalProjectTreeItem";
 import { LocalProjectTreeItem } from "./tree/localProject/LocalProjectTreeItem";
-import { dotnetUtils } from "./utils/dotnetUtils";
-import { getWorkspaceSetting } from "./vsCodeConfig/settings";
+import { listLocalProjects } from "./workspace/listLocalProjects";
 
 export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider {
 
     public disposables: Disposable[] = [];
 
     public async provideResources(parent: AzExtParentTreeItem): Promise<AzExtTreeItem[] | null | undefined> {
+        const children: AzExtTreeItem[] = [];
 
-        return await callWithTelemetryAndErrorHandling('AzureAccountTreeItemWithProjects.provideResources', async (context: IActionContext) => {
-            const children: AzExtTreeItem[] = [];
+        Disposable.from(...this._projectDisposables).dispose();
+        this._projectDisposables = [];
 
-            Disposable.from(...this._projectDisposables).dispose();
-            this._projectDisposables = [];
+        const localProjects = await listLocalProjects();
 
-            const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
-            for (const folder of folders) {
-                const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder);
-                if (projectPath) {
-                    try {
-                        const language: ProjectLanguage | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);
-                        const languageModel: number | undefined = getWorkspaceSetting(projectLanguageModelSetting, projectPath);
-                        const version: FuncVersion | undefined = tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, projectPath));
-                        if (language === undefined || version === undefined) {
-                            children.push(new InitLocalProjectTreeItem(parent, projectPath, folder));
-                        } else {
-                            let preCompiledProjectPath: string | undefined;
-                            let effectiveProjectPath: string;
-                            let isIsolated: boolean | undefined;
-                            const compiledProjectInfo: CompiledProjectInfo | undefined = await getCompiledProjectInfo(context, projectPath, language);
-                            if (compiledProjectInfo) {
-                                preCompiledProjectPath = projectPath;
-                                effectiveProjectPath = compiledProjectInfo.compiledProjectPath;
-                                isIsolated = compiledProjectInfo.isIsolated;
-                            } else {
-                                effectiveProjectPath = projectPath;
-                            }
+        for (const project of localProjects.projects) {
+            const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(parent, project);
+            this._projectDisposables.push(treeItem);
+            children.push(treeItem);
+        }
 
+        for (const unintializedProject of localProjects.unintializedProjects) {
+            children.push(new InitLocalProjectTreeItem(parent, unintializedProject.projectPath, unintializedProject.workspaceFolder));
+        }
 
-                            const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(parent, { effectiveProjectPath, folder, language, languageModel, version, preCompiledProjectPath, isIsolated });
-                            this._projectDisposables.push(treeItem);
-                            children.push(treeItem);
-                        }
-                    } catch (error) {
-                        children.push(new InvalidLocalProjectTreeItem(parent, projectPath, error, folder));
-                    }
-                }
-            }
-            return children;
-        });
+        for (const invalidProject of localProjects.invalidProjects) {
+            children.push(new InvalidLocalProjectTreeItem(parent, invalidProject.projectPath, invalidProject.error, invalidProject.workspaceFolder));
+        }
+
+        return children;
     }
     private _projectDisposables: Disposable[] = [];
 
     public dispose(): void {
         Disposable.from(...this._projectDisposables).dispose();
-    }
-}
-
-type CompiledProjectInfo = { compiledProjectPath: string; isIsolated: boolean };
-
-async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
-    if (projectLanguage === ProjectLanguage.CSharp || projectLanguage === ProjectLanguage.FSharp) {
-        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
-        if (projFiles.length === 1) {
-            const targetFramework: string = await dotnetUtils.getTargetFramework(projFiles[0]);
-            const isIsolated = await dotnetUtils.getIsIsolated(projFiles[0]);
-            return { compiledProjectPath: path.join(projectPath, dotnetUtils.getDotnetDebugSubpath(targetFramework)), isIsolated };
-        } else {
-            throw new Error(localize('unableToFindProj', 'Unable to detect project file.'));
-        }
-    } else if (projectLanguage === ProjectLanguage.Java) {
-        const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, projectPath);
-        const functionAppName: string | undefined = await getFunctionAppName(projectPath, buildTool);
-        if (!functionAppName) {
-            throw new Error(localize('unableToGetFunctionAppName', 'Unable to detect property "functionAppName" in pom.xml.'));
-        } else {
-            return { compiledProjectPath: path.join(projectPath, getJavaDebugSubpath(functionAppName, buildTool)), isIsolated: false };
-        }
-    } else if (projectLanguage === ProjectLanguage.Ballerina) {
-        return { compiledProjectPath: path.join(projectPath, "target", "azure_functions"), isIsolated: false };
-    } else {
-        return undefined;
     }
 }

--- a/src/LocalResourceProvider.ts
+++ b/src/LocalResourceProvider.ts
@@ -22,7 +22,7 @@ export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider
 
         const localProjects = await listLocalProjects();
 
-        for (const project of localProjects.projects) {
+        for (const project of localProjects.initializedProjects) {
             const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(parent, project);
             this._projectDisposables.push(treeItem);
             children.push(treeItem);

--- a/src/commands/updateDisabledState.ts
+++ b/src/commands/updateDisabledState.ts
@@ -5,9 +5,9 @@
 
 import { IActionContext } from '@microsoft/vscode-azext-utils';
 import { window } from 'vscode';
+import { FuncVersion } from '../FuncVersion';
 import { functionFilter } from '../constants';
 import { ext } from '../extensionVariables';
-import { FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
 import { FunctionTreeItemBase } from '../tree/FunctionTreeItemBase';
 

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -62,7 +62,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
 
         const workspaceProjects = await listLocalProjects();
 
-        for (const project of workspaceProjects.projects) {
+        for (const project of workspaceProjects.initializedProjects) {
             hasLocalProject = true;
             const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, project);
             this._projectDisposables.push(treeItem);

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -6,16 +6,12 @@
 import { AzureAccountTreeItemBase } from '@microsoft/vscode-azext-azureutils';
 import { AzExtTreeItem, callWithTelemetryAndErrorHandling, GenericTreeItem, IActionContext, ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { Disposable, workspace, WorkspaceFolder } from 'vscode';
-import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIsProject';
-import { getFunctionAppName, getJavaDebugSubpath } from '../commands/initProjectForVSCode/InitVSCodeStep/JavaInitVSCodeStep';
-import { funcVersionSetting, hostFileName, javaBuildTool, JavaBuildTool, ProjectLanguage, projectLanguageModelSetting, projectLanguageSetting, projectSubpathSetting } from '../constants';
+import { Disposable, workspace } from 'vscode';
+import { funcVersionSetting, hostFileName, projectLanguageSetting, projectSubpathSetting } from '../constants';
 import { ext } from '../extensionVariables';
-import { FuncVersion, tryParseFuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
-import { dotnetUtils } from '../utils/dotnetUtils';
 import { treeUtils } from '../utils/treeUtils';
-import { getWorkspaceSetting } from '../vsCodeConfig/settings';
+import { listLocalProjects } from '../workspace/listLocalProjects';
 import { createRefreshFileWatcher } from './localProject/createRefreshFileWatcher';
 import { InitLocalProjectTreeItem } from './localProject/InitLocalProjectTreeItem';
 import { InvalidLocalProjectTreeItem } from './localProject/InvalidLocalProjectTreeItem';
@@ -64,43 +60,25 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
         Disposable.from(...this._projectDisposables).dispose();
         this._projectDisposables = [];
 
-        const folders: readonly WorkspaceFolder[] = workspace.workspaceFolders || [];
-        for (const folder of folders) {
-            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, folder);
-            if (projectPath) {
-                try {
-                    hasLocalProject = true;
+        const workspaceProjects = await listLocalProjects();
 
-                    const language: ProjectLanguage | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);
-                    const languageModel: number | undefined = getWorkspaceSetting(projectLanguageModelSetting, projectPath);
-                    const version: FuncVersion | undefined = tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, projectPath));
-                    if (language === undefined || version === undefined) {
-                        children.push(new InitLocalProjectTreeItem(this, projectPath, folder));
-                    } else {
-                        let preCompiledProjectPath: string | undefined;
-                        let effectiveProjectPath: string;
-                        let isIsolated: boolean | undefined;
-                        const compiledProjectInfo: CompiledProjectInfo | undefined = await getCompiledProjectInfo(context, projectPath, language);
-                        if (compiledProjectInfo) {
-                            preCompiledProjectPath = projectPath;
-                            effectiveProjectPath = compiledProjectInfo.compiledProjectPath;
-                            isIsolated = compiledProjectInfo.isIsolated;
-                        } else {
-                            effectiveProjectPath = projectPath;
-                        }
+        for (const project of workspaceProjects.projects) {
+            hasLocalProject = true;
+            const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, project);
+            this._projectDisposables.push(treeItem);
+            children.push(treeItem);
+            this._projectDisposables.push(createRefreshFileWatcher(this, path.join(project.options.folder.uri.fsPath, hostFileName)));
+            this._projectDisposables.push(createRefreshFileWatcher(this, path.join(project.options.folder.uri.fsPath, '*', hostFileName)));
+        }
 
+        for (const unintializedProject of workspaceProjects.unintializedProjects) {
+            hasLocalProject = true;
+            children.push(new InitLocalProjectTreeItem(this, unintializedProject.projectPath, unintializedProject.workspaceFolder));
+        }
 
-                        const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(this, { effectiveProjectPath, folder, language, languageModel, version, preCompiledProjectPath, isIsolated });
-                        this._projectDisposables.push(treeItem);
-                        children.push(treeItem);
-                    }
-                } catch (error) {
-                    children.push(new InvalidLocalProjectTreeItem(this, projectPath, error, folder));
-                }
-            }
-
-            this._projectDisposables.push(createRefreshFileWatcher(this, path.join(folder.uri.fsPath, hostFileName)));
-            this._projectDisposables.push(createRefreshFileWatcher(this, path.join(folder.uri.fsPath, '*', hostFileName)));
+        for (const invalidProject of workspaceProjects.invalidProjects) {
+            hasLocalProject = true;
+            children.push(new InvalidLocalProjectTreeItem(this, invalidProject.projectPath, invalidProject.error, invalidProject.workspaceFolder));
         }
 
         if (!hasLocalProject && children.length > 0 && children[0] instanceof GenericTreeItem) {
@@ -143,32 +121,5 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
         }
 
         return super.pickTreeItemImpl(expectedContextValues);
-    }
-}
-
-type CompiledProjectInfo = { compiledProjectPath: string; isIsolated: boolean };
-
-async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
-    if (projectLanguage === ProjectLanguage.CSharp || projectLanguage === ProjectLanguage.FSharp) {
-        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
-        if (projFiles.length === 1) {
-            const targetFramework: string = await dotnetUtils.getTargetFramework(projFiles[0]);
-            const isIsolated = await dotnetUtils.getIsIsolated(projFiles[0]);
-            return { compiledProjectPath: path.join(projectPath, dotnetUtils.getDotnetDebugSubpath(targetFramework)), isIsolated };
-        } else {
-            throw new Error(localize('unableToFindProj', 'Unable to detect project file.'));
-        }
-    } else if (projectLanguage === ProjectLanguage.Java) {
-        const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, projectPath);
-        const functionAppName: string | undefined = await getFunctionAppName(projectPath, buildTool);
-        if (!functionAppName) {
-            throw new Error(localize('unableToGetFunctionAppName', 'Unable to detect property "functionAppName" in pom.xml.'));
-        } else {
-            return { compiledProjectPath: path.join(projectPath, getJavaDebugSubpath(functionAppName, buildTool)), isIsolated: false };
-        }
-    } else if (projectLanguage === ProjectLanguage.Ballerina) {
-        return { compiledProjectPath: projectPath, isIsolated: false };
-    } else {
-        return undefined;
     }
 }

--- a/src/workspace/LocalProject.ts
+++ b/src/workspace/LocalProject.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { AzExtFsExtra, IActionContext } from "@microsoft/vscode-azext-utils";
+import { Task, tasks } from "vscode";
+import { FuncVersion } from "../FuncVersion";
+import { hostFileName, localSettingsFileName } from "../constants";
+import { IParsedHostJson, parseHostJson } from "../funcConfig/host";
+import { ILocalSettingsJson, MismatchBehavior, getLocalSettingsJson, setLocalAppSetting } from "../funcConfig/local.settings";
+import { getFuncPortFromTaskOrProject, isFuncHostTask, runningFuncPortMap } from "../funcCoreTools/funcHostTask";
+import { ApplicationSettings, FuncHostRequest, IProjectTreeItem } from "../tree/IProjectTreeItem";
+import { LocalProjectOptions } from "../tree/localProject/LocalProjectTreeItem";
+import { ProjectSource } from "../tree/projectContextValues";
+import { requestUtils } from "../utils/requestUtils";
+import path = require("path");
+
+export type WorkspaceProject = { options: LocalProjectOptions } & IProjectTreeItem;
+
+export class LocalProject implements WorkspaceProject {
+    source: ProjectSource = ProjectSource.Local;
+
+    constructor(public readonly options: LocalProjectOptions) { }
+
+    public async getHostJson(): Promise<IParsedHostJson> {
+        const version: FuncVersion = await this.getVersion();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+        const data = await AzExtFsExtra.readJSON<any>(path.join(this.options.effectiveProjectPath, hostFileName));
+        return parseHostJson(data, version);
+    }
+
+    public async getVersion(): Promise<FuncVersion> {
+        return this.options.version;
+    }
+
+    public async getApplicationSettings(context: IActionContext): Promise<ApplicationSettings> {
+        const localSettings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(this.options.effectiveProjectPath, localSettingsFileName));
+        return localSettings.Values || {};
+    }
+
+    public async setApplicationSetting(context: IActionContext, key: string, value: string): Promise<void> {
+        await setLocalAppSetting(context, this.options.effectiveProjectPath, key, value, MismatchBehavior.Overwrite);
+    }
+
+    public async getHostRequest(context: IActionContext): Promise<FuncHostRequest> {
+        let port = runningFuncPortMap.get(this.options.folder);
+        if (!port) {
+            const funcTask: Task | undefined = (await tasks.fetchTasks()).find(t => t.scope === this.options.folder && isFuncHostTask(t));
+            port = await getFuncPortFromTaskOrProject(context, funcTask, this.options.effectiveProjectPath);
+        }
+
+        const url = `http://localhost:${port}`;
+        try {
+            await requestUtils.sendRequestWithExtTimeout(context, { url: url, method: 'GET' });
+        } catch {
+            try {
+                const httpsUrl = url.replace('http', 'https');
+                await requestUtils.sendRequestWithExtTimeout(context, { url: httpsUrl, method: 'GET', rejectUnauthorized: false });
+                return { url: httpsUrl, rejectUnauthorized: false };
+            } catch {
+                // ignore
+            }
+        }
+
+        return { url };
+    }
+}

--- a/src/workspace/listLocalProjects.ts
+++ b/src/workspace/listLocalProjects.ts
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, callWithTelemetryAndErrorHandling } from "@microsoft/vscode-azext-utils";
+import * as vscode from "vscode";
+import { FuncVersion, tryParseFuncVersion } from "../FuncVersion";
+import { tryGetFunctionProjectRoot } from "../commands/createNewProject/verifyIsProject";
+import { getFunctionAppName, getJavaDebugSubpath } from "../commands/initProjectForVSCode/InitVSCodeStep/JavaInitVSCodeStep";
+import { JavaBuildTool, ProjectLanguage, funcVersionSetting, javaBuildTool, projectLanguageModelSetting, projectLanguageSetting } from "../constants";
+import { localize } from "../localize";
+import { dotnetUtils } from "../utils/dotnetUtils";
+import { getWorkspaceSetting } from "../vsCodeConfig/settings";
+import { LocalProject, WorkspaceProject } from "./LocalProject";
+import path = require("path");
+
+interface UnitializedLocalProject {
+    workspaceFolder: vscode.WorkspaceFolder;
+    projectPath: string;
+}
+
+interface InvalidLocalProject extends UnitializedLocalProject {
+    error: unknown;
+}
+
+interface ListWorkspaceProjectsResult {
+    projects: WorkspaceProject[];
+    unintializedProjects: UnitializedLocalProject[];
+    invalidProjects: InvalidLocalProject[];
+}
+
+export async function listLocalProjects(): Promise<ListWorkspaceProjectsResult> {
+    const result = await callWithTelemetryAndErrorHandling('listLocalProjects', async (context) => {
+        context.errorHandling.rethrow = true;
+        const result: ListWorkspaceProjectsResult = {
+            projects: [],
+            unintializedProjects: [],
+            invalidProjects: [],
+        };
+        const workspaceFolders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders || [];
+        for (const workspaceFolder of workspaceFolders) {
+            const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder);
+            if (projectPath) {
+                try {
+                    const language: ProjectLanguage | undefined = getWorkspaceSetting(projectLanguageSetting, projectPath);
+                    const languageModel: number | undefined = getWorkspaceSetting(projectLanguageModelSetting, projectPath);
+                    const version: FuncVersion | undefined = tryParseFuncVersion(getWorkspaceSetting(funcVersionSetting, projectPath));
+                    if (language === undefined || version === undefined) {
+                        result.unintializedProjects.push({
+                            workspaceFolder,
+                            projectPath,
+                        });
+                    } else {
+                        let preCompiledProjectPath: string | undefined;
+                        let effectiveProjectPath: string;
+                        let isIsolated: boolean | undefined;
+                        const compiledProjectInfo: CompiledProjectInfo | undefined = await getCompiledProjectInfo(context, projectPath, language);
+                        if (compiledProjectInfo) {
+                            preCompiledProjectPath = projectPath;
+                            effectiveProjectPath = compiledProjectInfo.compiledProjectPath;
+                            isIsolated = compiledProjectInfo.isIsolated;
+                        } else {
+                            effectiveProjectPath = projectPath;
+                        }
+                        result.projects.push(new LocalProject({
+                            effectiveProjectPath,
+                            folder: workspaceFolder,
+                            language,
+                            languageModel,
+                            version,
+                            preCompiledProjectPath,
+                            isIsolated,
+                        }));
+                    }
+                } catch (error: unknown) {
+                    result.invalidProjects.push({
+                        error,
+                        projectPath,
+                        workspaceFolder
+                    })
+                }
+            }
+        }
+
+        return result;
+    });
+
+    // Result is non-null because we are rethrowing errors above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return result!
+}
+
+type CompiledProjectInfo = { compiledProjectPath: string; isIsolated: boolean };
+
+async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
+    if (projectLanguage === ProjectLanguage.CSharp || projectLanguage === ProjectLanguage.FSharp) {
+        const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
+        if (projFiles.length === 1) {
+            const targetFramework: string = await dotnetUtils.getTargetFramework(projFiles[0]);
+            const isIsolated = await dotnetUtils.getIsIsolated(projFiles[0]);
+            return { compiledProjectPath: path.join(projectPath, dotnetUtils.getDotnetDebugSubpath(targetFramework)), isIsolated };
+        } else {
+            throw new Error(localize('unableToFindProj', 'Unable to detect project file.'));
+        }
+    } else if (projectLanguage === ProjectLanguage.Java) {
+        const buildTool: JavaBuildTool | undefined = getWorkspaceSetting(javaBuildTool, projectPath);
+        const functionAppName: string | undefined = await getFunctionAppName(projectPath, buildTool);
+        if (!functionAppName) {
+            throw new Error(localize('unableToGetFunctionAppName', 'Unable to detect property "functionAppName" in pom.xml.'));
+        } else {
+            return { compiledProjectPath: path.join(projectPath, getJavaDebugSubpath(functionAppName, buildTool)), isIsolated: false };
+        }
+    } else if (projectLanguage === ProjectLanguage.Ballerina) {
+        return { compiledProjectPath: path.join(projectPath, "target", "azure_functions"), isIsolated: false };
+    } else {
+        return undefined;
+    }
+}

--- a/src/workspace/listLocalProjects.ts
+++ b/src/workspace/listLocalProjects.ts
@@ -25,7 +25,7 @@ interface InvalidLocalProject extends UnitializedLocalProject {
 }
 
 interface ListWorkspaceProjectsResult {
-    projects: WorkspaceProject[];
+    initializedProjects: WorkspaceProject[];
     unintializedProjects: UnitializedLocalProject[];
     invalidProjects: InvalidLocalProject[];
 }
@@ -34,7 +34,7 @@ export async function listLocalProjects(): Promise<ListWorkspaceProjectsResult> 
     const result = await callWithTelemetryAndErrorHandling('listLocalProjects', async (context) => {
         context.errorHandling.rethrow = true;
         const result: ListWorkspaceProjectsResult = {
-            projects: [],
+            initializedProjects: [],
             unintializedProjects: [],
             invalidProjects: [],
         };
@@ -63,7 +63,7 @@ export async function listLocalProjects(): Promise<ListWorkspaceProjectsResult> 
                         } else {
                             effectiveProjectPath = projectPath;
                         }
-                        result.projects.push(new LocalProject({
+                        result.initializedProjects.push(new LocalProject({
                             effectiveProjectPath,
                             folder: workspaceFolder,
                             language,


### PR DESCRIPTION
Goals:
* Separate the local project model from the local project tree item
* Create a standalone function that lists local projects that can be used later for the Limelight API

Non goals:
* Change any behavior

Created a `LocalProject` class that can live underneath `LocalProjectTreeItem`. We can later on pass this class to the Limelight extension so they can wrap it in their own UI.

I will follow up this PR with the same code changes but for local functions.