### PR TITLE
Remove .net 5 from testing

### DIFF
--- a/.azure-pipelines/common/test.yml
+++ b/.azure-pipelines/common/test.yml
@@ -48,11 +48,6 @@ steps:
     version: 6.0.x
     includePreviewVersions: true
 
-- task: UseDotNet@2
-  displayName: 'Use .NET sdk 5.0.x'
-  inputs:
-    version: 5.0.x
-
 - task: Npm@1
   displayName: 'Test'
   inputs:

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -15,11 +15,7 @@ jobs:
           signType: '$(SignType)'
         env:
           TeamName: 'AzureTools'
-      - task: UseDotNet@2
-        displayName: 'Use .NET sdk 5.0.x'
-        inputs:
-          version: 5.0.x
-
+          
       - task: UseDotNet@2
         displayName: 'Use .NET sdk 6.0.x'
         inputs:
@@ -43,16 +39,6 @@ jobs:
         inputs:
           projects: '$(ProjectPath)'
           arguments: '--configuration $(BuildConfiguration)'
-
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet publish 5.0'
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: '$(ProjectPath)'
-          arguments: '--configuration $(BuildConfiguration) --framework net5.0 --no-build'
-          zipAfterPublish: false
-          modifyOutputPath: false
 
       - task: DotNetCoreCLI@2
         displayName: 'dotnet publish 6.0'


### PR DESCRIPTION
.NET 5 is no longer supported. We shouldn't be testing against it.