### PR TITLE
Accommondate new .NET HTTP trigger ids

### DIFF
--- a/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
+++ b/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
@@ -34,6 +34,6 @@ export function getDotnetVerifiedTemplateIds(version: string): RegExp[] {
     }
 
     return verifiedTemplateIds.map(id => {
-        return new RegExp(`^azure\\.function\\.csharp\\.(?:isolated\\.|)${id}\\.[0-9]+\\.x$`, 'i');
+        return new RegExp(`^azure\\.function\\.csharp\\.(?:isolated\\.|)${id}\\.(?:Net(Core|Fx)\.|)[0-9]+\\.x$`, 'i');
     });
 }


### PR DESCRIPTION
HTTP triggers for .NET are going to support a newer HttpTrigger template. In order to support the old and new templates, the id was updated to `NetCore.1.x` or `NetFx.1.x`.

In order for HTTP triggers to continue to show up in the verified list, I just added a conditional capture group to the RegExp. Confirmed that it works with staging templates.