### PR TITLE
Delete the correct .NET project templates on reload

### DIFF
--- a/src/templates/TemplateProviderBase.ts
+++ b/src/templates/TemplateProviderBase.ts
@@ -7,6 +7,7 @@ import { AzExtFsExtra, type IActionContext } from '@microsoft/vscode-azext-utils
 import * as path from 'path';
 import { Disposable, env } from 'vscode';
 import { FuncVersion } from '../FuncVersion';
+import { type IProjectWizardContext } from '../commands/createNewProject/IProjectWizardContext';
 import { type ProjectLanguage } from '../constants';
 import { NotImplementedError } from '../errors';
 import { ext } from '../extensionVariables';
@@ -170,7 +171,12 @@ export abstract class TemplateProviderBase implements Disposable {
     /**
      * A key used to identify the templates for the current type of project
      */
-    public async getProjKey(context: IActionContext): Promise<string> {
+    public async getProjKey(context: IActionContext & Partial<IProjectWizardContext>): Promise<string> {
+        // if user has already selected template, rely on project wizard rather than project settings
+        if (context.projectTemplateKey) {
+            return context.projectTemplateKey
+        }
+
         if (!this.refreshProjKey) {
             throw new NotImplementedError('refreshProjKey', this);
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3954 (hopefully)

I think the reason that this appeared during testing is due to the templates being cached, but on first reload, the wrong cache was getting deleted. 

The dotnet template provider looked for a csproj setting or an internal `projectTemplateKey` for which .NET templates to clear. However, when creating a new project, this setting would either a.) not exist, or b.) was potentially incorrect.

For example, if you were creating a net8.0 project, but your last project was net6.0, your old settings would have picked that up and deleted the wrong cache on reloading the templates. By default, the net6.0 templates were getting deleted, so if you tried to reload net7.0-isolated without a project opened, the reload wouldn't actually do anything.

I'm able to reproduce the duplicate templates if I do some combination of the following steps:
1. Have an empty folder opened
2. Get the latest templates from the feed
3. Change my template source to "Staging"
4. Reload VS Code
5. Get the latest templates from the staging feed
6. Change my setting back to "" (which defaults to latest)
7. Reload VS Code
8. Try to create a .NET 7 Isolated project
9. It should list multiple HTTP functions

Note that my fix shouldn't prevent the duplicates from showing up, but makes the reload and `clearCachedTemplates` command work properly.  That being said, I haven't seen it reproducing anymore so maybe it also fixed it in ways I don't understand 🤷 

Edit: Confirmed that if I revert my changes, it starts reproducing again. I'm assuming the `getProjKey` is being used somewhere else that I'm not realizing and is what's causing duplicating templates.