### PR TITLE
Functions node fully refreshes after deploy

### DIFF
--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -26,12 +26,16 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
     public static async createFunctionsTreeItem(context: IActionContext, parent: SlotTreeItem): Promise<RemoteFunctionsTreeItem> {
         const ti: RemoteFunctionsTreeItem = new RemoteFunctionsTreeItem(parent);
         // initialize
-        await ti.refreshImpl(context);
+        await ti.initAsync(context);
         return ti;
     }
 
-    public async refreshImpl(context: IActionContext): Promise<void> {
+    public async initAsync(context: IActionContext): Promise<void> {
         this.isReadOnly = await this.parent.isReadOnly(context);
+    }
+
+    public async refreshImpl(context: IActionContext): Promise<void> {
+        await this.initAsync(context);
         await this.loadAllChildren(context);
     }
 

--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -32,6 +32,7 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
 
     public async refreshImpl(context: IActionContext): Promise<void> {
         this.isReadOnly = await this.parent.isReadOnly(context);
+        await this.loadAllChildren(context);
     }
 
     public hasMoreChildrenImpl(): boolean {


### PR DESCRIPTION
The refresh used to only change the read-only state of the Functions node, so after deployment, it wasn't showing new nodes apparently.

There is a refresh in `notifyDeployComplete` so this will make Functions call the API to see if there are any new triggers post deployment.