### PR TITLE
Fix containerized project creation for .NET projects

### DIFF
--- a/src/commands/createNewProject/IProjectWizardContext.ts
+++ b/src/commands/createNewProject/IProjectWizardContext.ts
@@ -29,6 +29,8 @@ export interface IProjectWizardContext extends IActionContext {
     openApiSpecificationFile?: Uri[];
 
     targetFramework?: string | string[];
+
+    containerizedProject?: boolean;
 }
 
 export type OpenBehavior = 'AddToWorkspace' | 'OpenInNewWindow' | 'OpenInCurrentWindow' | 'AlreadyOpen' | 'DontOpen';

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -37,10 +37,7 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         // For containerized function apps we need to call func init before intialization as we want the .csproj file to be overwritten with the correct version
         // currentely the version created by func init is behind the template version
         if (context.containerizedProject) {
-            let runtime = 'dotnet-isolated';
-            if (workerRuntime.displayInfo.description === 'LTS') {
-                runtime = 'dotnet'
-            }
+            const runtime = context.workerRuntime?.capabilities.includes('isolated') ? 'dotnet-isolated' : 'dotnet';
             await cpUtils.executeCommand(ext.outputChannel, context.projectPath, "func", "init", "--worker-runtime", runtime, "--docker");
         } else {
             await this.confirmOverwriteExisting(context, projName);

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -7,6 +7,7 @@ import { AzExtFsExtra, DialogResponses, type IActionContext } from '@microsoft/v
 import * as path from 'path';
 import { getMajorVersion, type FuncVersion } from '../../../FuncVersion';
 import { ConnectionKey, ProjectLanguage, gitignoreFileName, hostFileName, localSettingsFileName } from '../../../constants';
+import { ext } from '../../../extensionVariables';
 import { MismatchBehavior, setLocalAppSetting } from '../../../funcConfig/local.settings';
 import { localize } from "../../../localize";
 import { executeDotnetTemplateCommand, validateDotnetInstalled } from '../../../templates/dotnet/executeDotnetTemplateCommand';
@@ -31,7 +32,12 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
 
         const projectName: string = path.basename(context.projectPath);
         const projName: string = projectName + language === ProjectLanguage.FSharp ? '.fsproj' : '.csproj';
-        await this.confirmOverwriteExisting(context, projName);
+
+        if (context.containerizedProject) {
+            await cpUtils.executeCommand(ext.outputChannel, context.projectPath, "func", "init", "--worker-runtime", "dotnet-isolated", "--docker");
+        } else {
+            await this.confirmOverwriteExisting(context, projName);
+        }
 
         const majorVersion: string = getMajorVersion(version);
         const workerRuntime = nonNullProp(context, 'workerRuntime');

--- a/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/DotnetProjectCreateStep.ts
@@ -33,6 +33,8 @@ export class DotnetProjectCreateStep extends ProjectCreateStepBase {
         const projectName: string = path.basename(context.projectPath);
         const projName: string = projectName + language === ProjectLanguage.FSharp ? '.fsproj' : '.csproj';
 
+        // For containerized function apps we need to call func init before intialization as we want the .csproj file to be overwritten with the correct version
+        // currentely the version created by func init is behind the template version
         if (context.containerizedProject) {
             await cpUtils.executeCommand(ext.outputChannel, context.projectPath, "func", "init", "--worker-runtime", "dotnet-isolated", "--docker");
         } else {

--- a/src/commands/createNewProject/createNewProject.ts
+++ b/src/commands/createNewProject/createNewProject.ts
@@ -61,6 +61,7 @@ export async function createNewProjectInternal(context: IActionContext, options:
         if (!await validateFuncCoreToolsInstalled(context, message)) {
             throw new UserCancelledError('validateFuncCoreToolsInstalled');
         }
+        wizardContext.containerizedProject = true;
     }
 
     if (options.folderPath) {

--- a/src/commands/createNewProject/dockerfileSteps/CreateDockerfileProjectStep.ts
+++ b/src/commands/createNewProject/dockerfileSteps/CreateDockerfileProjectStep.ts
@@ -12,12 +12,10 @@ export class CreateDockerfileProjectStep extends AzureWizardExecuteStep<IFunctio
     public priority: number = 100;
 
     public async execute(context: IFunctionWizardContext): Promise<void> {
-        let language = nonNullValueAndProp(context, 'language').toLowerCase();
-        if (language === 'c#') {
-            language = 'csharp';
+        const language = nonNullValueAndProp(context, 'language').toLowerCase();
+        if (language !== 'c#') {
+            await cpUtils.executeCommand(ext.outputChannel, nonNullValueAndProp(context, 'projectPath'), "func", "init", "--worker-runtime", language, "--docker");
         }
-
-        await cpUtils.executeCommand(ext.outputChannel, nonNullValueAndProp(context, 'projectPath'), "func", "init", "--worker-runtime", language, "--docker");
     }
 
     public shouldExecute(): boolean {

--- a/src/commands/createNewProject/dockerfileSteps/CreateDockerfileProjectStep.ts
+++ b/src/commands/createNewProject/dockerfileSteps/CreateDockerfileProjectStep.ts
@@ -13,6 +13,7 @@ export class CreateDockerfileProjectStep extends AzureWizardExecuteStep<IFunctio
 
     public async execute(context: IFunctionWizardContext): Promise<void> {
         const language = nonNullValueAndProp(context, 'language').toLowerCase();
+        // If the language is C# this command needs to be called earlier as the versioning in the .csproj file is different from the one in the template
         if (language !== 'c#') {
             await cpUtils.executeCommand(ext.outputChannel, nonNullValueAndProp(context, 'projectPath'), "func", "init", "--worker-runtime", language, "--docker");
         }

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -53,9 +53,6 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
         const runtimes = await getRuntimes(context);
         const picks: IAzureQuickPickItem<cliFeedUtils.IWorkerRuntime | undefined>[] = [];
         for (const runtime of runtimes) {
-            if (context.containerizedProject && runtime.displayInfo.description === 'LTS') {
-                continue;
-            }
             picks.push({
                 label: runtime.displayInfo.displayName,
                 description: runtime.displayInfo.description,

--- a/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
+++ b/src/commands/createNewProject/dotnetSteps/DotnetRuntimeStep.ts
@@ -53,6 +53,9 @@ export class DotnetRuntimeStep extends AzureWizardPromptStep<IProjectWizardConte
         const runtimes = await getRuntimes(context);
         const picks: IAzureQuickPickItem<cliFeedUtils.IWorkerRuntime | undefined>[] = [];
         for (const runtime of runtimes) {
+            if (context.containerizedProject && runtime.displayInfo.description === 'LTS') {
+                continue;
+            }
             picks.push({
                 label: runtime.displayInfo.displayName,
                 description: runtime.displayInfo.description,

--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -49,7 +49,8 @@ export namespace cliFeedUtils {
         projectTemplates: string;
         projectTemplateId: {
             csharp: string;
-        }
+        },
+        capabilities: string;
     }
 
     export async function getLatestVersion(context: IActionContext, version: FuncVersion): Promise<string> {


### PR DESCRIPTION
For some reason the func cli created .csproj and the .csproj we create don't have the same versions so we need to initialize the project for vscode after calling the func cli command instead of the other way around. This is only the case for .NET projects. We also are skipping the overwrite confirm as we always want the files to be overwritten in this case.

.NET 6.0 LTS also need to use the dotnet --worker-runtime instead of dotnet-isolated. 