### PR TITLE
UX: Change command labels, remove entry point for `Create new project...`, add entry points for `Create Function...`

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,10 +175,6 @@
                 "command": "azureFunctions.createNewProject",
                 "title": "%azureFunctions.createNewProject%",
                 "category": "Azure Functions",
-                "icon": {
-                    "light": "resources/light/CreateNewProject.svg",
-                    "dark": "resources/dark/CreateNewProject.svg"
-                },
                 "enablement": "!virtualWorkspace"
             },
             {
@@ -369,10 +365,6 @@
                     "group": "1_projects@1"
                 },
                 {
-                    "command": "azureFunctions.createNewProject",
-                    "group": "1_projects@2"
-                },
-                {
                     "command": "azureFunctions.createNewProjectWithDockerfile",
                     "group": "1_projects@3"
                 },
@@ -397,6 +389,16 @@
                 }
             ],
             "view/item/context": [
+                {
+                    "command": "azureFunctions.createFunction",
+                    "when": "view == azureWorkspace && viewItem =~ /azFunc.*ReadWrite;Functions;/i",
+                    "group": "inline"
+                },
+                {
+                    "command": "azureFunctions.createFunction",
+                    "when": "view == azureWorkspace && viewItem =~ /azFunc.*ReadWrite;Functions;/i",
+                    "group": "1@1"
+                },
                 {
                     "command": "azureFunctions.createFunctionApp",
                     "when": "view == azureResourceGroups && viewItem =~ /functionapp/i && viewItem =~ /azureResourceTypeGroup/i",
@@ -1078,7 +1080,7 @@
                         "id": "create",
                         "title": "%azureFunctions.walkthrough.functionsStart.create.title%",
                         "completionEvents": [
-                            "onCommand:azureFunctions.createNewProject"
+                            "onCommand:azureFunctions.createFunction"
                         ],
                         "description": "%azureFunctions.walkthrough.functionsStart.create.description%",
                         "media": {

--- a/package.json
+++ b/package.json
@@ -204,6 +204,13 @@
                 "category": "Azure Functions"
             },
             {
+                "command": "azureFunctions.deployProject",
+                "title": "%azureFunctions.deployProject%",
+                "category": "Azure Functions",
+                "icon": "$(cloud-upload)",
+                "enablement": "!virtualWorkspace"
+            },
+            {
                 "command": "azureFunctions.deploy",
                 "title": "%azureFunctions.deploy%",
                 "category": "Azure Functions",
@@ -369,7 +376,7 @@
                     "group": "1_projects@3"
                 },
                 {
-                    "command": "azureFunctions.deploy",
+                    "command": "azureFunctions.deployProject",
                     "group": "2_deploy@1"
                 },
                 {

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,7 +13,7 @@
     "azureFunctions.configureDeploymentSource": "Configure Deployment Source...",
     "azureFunctions.connectToGitHub": "Connect to GitHub Repository...",
     "azureFunctions.copyFunctionUrl": "Copy Function Url",
-    "azureFunctions.createFunction": "Create Function...",
+    "azureFunctions.createFunction": "Create function locally...",
     "azureFunctions.createFunctionApp": "Create Function App in Azure...",
     "azureFunctions.createFunctionAppAdvanced": "Create Function App in Azure... (Advanced)",
     "azureFunctions.createFunctionAppDetail": "For serverless, event driven apps and automation.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -24,6 +24,7 @@
     "azureFunctions.deleteFunction": "Delete Function...",
     "azureFunctions.deleteFunctionApp": "Delete Function App...",
     "azureFunctions.deleteSlot": "Delete Slot...",
+    "azureFunctions.deployProject": "Deploy function to Azure...",
     "azureFunctions.deploy": "Deploy to Function App...",
     "azureFunctions.deploySlot": "Deploy to Slot...",
     "azureFunctions.deploySubpath": "The default subpath of a workspace folder to use when deploying. If set, you will not be prompted for the folder path when deploying.",

--- a/src/LocalResourceProvider.ts
+++ b/src/LocalResourceProvider.ts
@@ -41,15 +41,15 @@ export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider
             children.push(new InvalidLocalProjectTreeItem(parent, invalidProject.projectPath, invalidProject.error, invalidProject.workspaceFolder));
         }
 
-        if (!hasLocalProject && children.length > 0 && children[0] instanceof GenericTreeItem) {
+        if (!hasLocalProject && children.length === 0) {
             const ti: GenericTreeItem = new GenericTreeItem(parent, {
-                label: localize('createFunctionLocally', 'Create function locally...'),
-                commandId: 'azureFunctions.createFunction',
-                contextValue: 'createFunction',
+                label: localize('createFunctionLocally', 'Create New Project...'),
+                commandId: 'azureFunctions.createNewProject',
+                contextValue: 'createNewProject',
                 iconPath: treeUtils.getThemedIconPath('CreateNewProject')
             });
             ti.commandArgs = [];
-            children.unshift(ti);
+            children.push(ti);
         }
 
         return children;

--- a/src/LocalResourceProvider.ts
+++ b/src/LocalResourceProvider.ts
@@ -2,12 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { type AzExtParentTreeItem, type AzExtTreeItem } from "@microsoft/vscode-azext-utils";
+import { GenericTreeItem, type AzExtParentTreeItem, type AzExtTreeItem } from "@microsoft/vscode-azext-utils";
 import { type WorkspaceResourceProvider } from "@microsoft/vscode-azext-utils/hostapi";
 import { Disposable } from "vscode";
+import { localize } from "./localize";
 import { InitLocalProjectTreeItem } from "./tree/localProject/InitLocalProjectTreeItem";
 import { InvalidLocalProjectTreeItem } from "./tree/localProject/InvalidLocalProjectTreeItem";
 import { LocalProjectTreeItem } from "./tree/localProject/LocalProjectTreeItem";
+import { treeUtils } from "./utils/treeUtils";
 import { listLocalProjects, type LocalProjectInternal } from "./workspace/listLocalProjects";
 
 export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider {
@@ -21,6 +23,7 @@ export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider
         this._projectDisposables = [];
 
         const localProjects = await listLocalProjects();
+        let hasLocalProject = false;
 
         for (const project of localProjects.initializedProjects) {
             const treeItem: LocalProjectTreeItem = new LocalProjectTreeItem(parent, project as LocalProjectInternal);
@@ -29,11 +32,24 @@ export class FunctionsLocalResourceProvider implements WorkspaceResourceProvider
         }
 
         for (const unintializedProject of localProjects.unintializedProjects) {
+            hasLocalProject = true;
             children.push(new InitLocalProjectTreeItem(parent, unintializedProject.projectPath, unintializedProject.workspaceFolder));
         }
 
         for (const invalidProject of localProjects.invalidProjects) {
+            hasLocalProject = true;
             children.push(new InvalidLocalProjectTreeItem(parent, invalidProject.projectPath, invalidProject.error, invalidProject.workspaceFolder));
+        }
+
+        if (!hasLocalProject && children.length > 0 && children[0] instanceof GenericTreeItem) {
+            const ti: GenericTreeItem = new GenericTreeItem(parent, {
+                label: localize('createFunctionLocally', 'Create function locally...'),
+                commandId: 'azureFunctions.createFunction',
+                contextValue: 'createFunction',
+                iconPath: treeUtils.getThemedIconPath('CreateNewProject')
+            });
+            ti.commandArgs = [];
+            children.unshift(ti);
         }
 
         return children;

--- a/src/agent/agentIntegration.ts
+++ b/src/agent/agentIntegration.ts
@@ -23,8 +23,8 @@ export async function getCommands(): Promise<(WizardCommandConfig | SimpleComman
         {
             type: "simple",
             name: createFunctionProjectCommandName,
-            commandId: "azureFunctions.createNewProject",
-            displayName: "Create Function Project",
+            commandId: "azureFunctions.createFunction",
+            displayName: "Create Function Locally",
             intentDescription: "This is best when users ask to create a new function project in VS Code. They may also refer to creating a function project by asking to create a project based upon a function project template.",
             requiresAzureLogin: true,
         },

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -87,6 +87,7 @@ export function registerCommands(): void {
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deleteSlot', async (context: IActionContext, node?: AzExtTreeItem) => await deleteNode(context, ResolvedFunctionAppResource.pickSlotContextValue, node));
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disableFunction', disableFunction);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploy', deployProductionSlot);
+    registerCommandWithTreeNodeUnwrapping('azureFunctions.deployProject', deployProductionSlot);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploySlot', deploySlot);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disconnectRepo', disconnectRepo);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.enableFunction', enableFunction);

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -85,7 +85,7 @@ export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
         if (!hasLocalProject && children.length > 0 && children[0] instanceof GenericTreeItem) {
             const ti: GenericTreeItem = new GenericTreeItem(this, {
                 label: localize('createNewProject', 'Create New Project...'),
-                commandId: 'azureFunctions.createNewProject',
+                commandId: 'azureFunctions.createFunction',
                 contextValue: 'createNewProject',
                 iconPath: treeUtils.getThemedIconPath('CreateNewProject')
             });

--- a/src/tree/AzureAccountTreeItemWithProjects.ts
+++ b/src/tree/AzureAccountTreeItemWithProjects.ts
@@ -20,6 +20,7 @@ import { LocalProjectTreeItemBase } from './localProject/LocalProjectTreeItemBas
 import { createRefreshFileWatcher } from './localProject/createRefreshFileWatcher';
 import { isLocalProjectCV, isProjectCV, isRemoteProjectCV } from './projectContextValues';
 
+// TODO: Remove this file. Only the long running tests rely on it (which we need to redo)
 export class AzureAccountTreeItemWithProjects extends AzureAccountTreeItemBase {
     private _projectDisposables: Disposable[] = [];
 

--- a/src/tree/localProject/InitLocalProjectTreeItem.ts
+++ b/src/tree/localProject/InitLocalProjectTreeItem.ts
@@ -27,7 +27,7 @@ export class InitLocalProjectTreeItem extends LocalProjectTreeItemBase {
     public async loadMoreChildrenImpl(_clearCache: boolean): Promise<AzExtTreeItem[]> {
         const ti: GenericTreeItem = new GenericTreeItem(this, {
             contextValue: 'initProject',
-            label: localize('initProject', 'Initialize Project for Use with VS Code...'),
+            label: localize('initProject', 'Initialize project for use with VS Code...'),
             commandId: 'azureFunctions.initProjectForVSCode',
             iconPath: new ThemeIcon('warning')
         });


### PR DESCRIPTION
This changes the Functions UI a bit to match what we discussed offline and insights from user studies.

- Go back to removing `Create New Project...`. Replace `Create Function...` with `Create function locally...` (Not sure what looks best in terms of casing)
If you're unfamiliar, `Create Function...` handles the following scenarios:
1. Local project exists? Add a new function template.
2. Local project exists but it's not initialized for VS Code? Prompts user to initialize for VS Code.
3. Local project doesn't exist? Create a new project _and_ ask what function template user wants (option to skip)

- Added two entry points to `Create function locally...`. One on the `Functions` node indicated by the Function + button. Another as a context menu action. I'm debating moving it to the local project node.
![image](https://github.com/microsoft/vscode-azurefunctions/assets/5290572/1499ab74-591e-4460-8579-02fe9cde1c2f)

- Mentioned renaming `Create Function...` but also renamed `Deploy to Function App in Azure...` to `Deploy function to Azure...`. It makes more intuitive sense because your local project is being deployed to Azure, and we have to prompt for which app is being deployed to.
![image](https://github.com/microsoft/vscode-azurefunctions/assets/5290572/e4e963f0-cca3-489c-9537-e7c632a8d07f)

By that logic, I've kept `Deploy to Function App...` the same  in the `Resources` view though.
![image](https://github.com/microsoft/vscode-azurefunctions/assets/5290572/02a3defd-869c-4567-bd2f-d4c50e595df3)

- Added `Create New Project...` to workspace view if there's no project in the workspace. It actually does call `azureFunctions.createNewProject` because we know that we need to start from scratch. `createFunction` has to do some checks before it ultimately cancels and calls `createNewProject` so performance is slightly better to just call it directly.
![image](https://github.com/microsoft/vscode-azurefunctions/assets/5290572/8bdf1138-700a-4c99-942d-2d8847d101a8)


Still to do:
- Remove `Create Function App...` option in the local workspace view
  - This will be replaced with just `Deploy function to Azure...`. My plan is to include a `+ Create new function app` option as a quickpick when we prompt for the app
- Merge `Create New Containerized Project...` into `Create function locally...` and add it as a prompt at the beginning. It's annoying, but also a one-time cost to the user that can be easily entered through.



