### PR TITLE
Allow AzureWebJobsStorage__accountName to pass debug validation

### DIFF
--- a/src/commands/appSettings/connectionSettings/azureWebJobsStorage/validateStorageConnection.ts
+++ b/src/commands/appSettings/connectionSettings/azureWebJobsStorage/validateStorageConnection.ts
@@ -19,7 +19,8 @@ export async function validateStorageConnection(context: Omit<ISetConnectionSett
     }
 
     const currentStorageConnection: string | undefined = await getLocalSettingsConnectionString(context, ConnectionKey.Storage, projectPath);
-    if (currentStorageConnection) {
+    const currentStorageIdentityConnection: string | undefined = await getLocalSettingsConnectionString(context, ConnectionKey.StorageIdentity, projectPath);
+    if (currentStorageConnection || currentStorageIdentityConnection) {
         // Found a valid connection in debug mode.  Skip the wizard.
         return;
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -97,6 +97,7 @@ export enum CodeAction {
 
 export enum ConnectionKey {
     Storage = 'AzureWebJobsStorage',
+    StorageIdentity = 'AzureWebJobsStorage__accountName',
     EventHubs = 'EventHubsConnection',
     SQL = 'SQLDB_Connection'
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3987

I don't think that this should cause any problems since it's only for debug. 

This issue https://github.com/microsoft/vscode-azurefunctions/issues/3657 on the other hand requires deploying to a storage account, so can't allow the same check to pass here.