### PR TITLE
Fix fail to add new application setting which name starts with a number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-rest-pipeline": "^1.11.0",
                 "@azure/storage-blob": "^12.5.0",
                 "@microsoft/vscode-azext-azureappservice": "^3.1.1",
-                "@microsoft/vscode-azext-azureappsettings": "^0.2.0",
+                "@microsoft/vscode-azext-azureappsettings": "^0.2.1",
                 "@microsoft/vscode-azext-azureutils": "^3.0.0",
                 "@microsoft/vscode-azext-serviceconnector": "^0.1.3",
                 "@microsoft/vscode-azext-utils": "^2.3.1",
@@ -954,9 +954,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappsettings": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.0.tgz",
-            "integrity": "sha512-fHv+m+dOluuYgPCQ7Mt8HoDgguWy8zHWofP3T6uxkuDF8VAJbjl9LFYHwV0frVcK4Qgxcj95QDjw5AMSUMHtqw==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.1.tgz",
+            "integrity": "sha512-YfYnXC/Gmx86+U+lAwui0EUlzRtOxSSrPcSmYsJHR7iVZ1Xzr7nblQveNTHKOUHaphSoNGnz9+2mzcYQwJnpNQ==",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"
             }
@@ -14052,9 +14052,9 @@
             }
         },
         "@microsoft/vscode-azext-azureappsettings": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.0.tgz",
-            "integrity": "sha512-fHv+m+dOluuYgPCQ7Mt8HoDgguWy8zHWofP3T6uxkuDF8VAJbjl9LFYHwV0frVcK4Qgxcj95QDjw5AMSUMHtqw==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.1.tgz",
+            "integrity": "sha512-YfYnXC/Gmx86+U+lAwui0EUlzRtOxSSrPcSmYsJHR7iVZ1Xzr7nblQveNTHKOUHaphSoNGnz9+2mzcYQwJnpNQ==",
             "requires": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1165,7 +1165,7 @@
         "@azure/core-rest-pipeline": "^1.11.0",
         "@azure/storage-blob": "^12.5.0",
         "@microsoft/vscode-azext-azureappservice": "^3.1.1",
-        "@microsoft/vscode-azext-azureappsettings": "^0.2.0",
+        "@microsoft/vscode-azext-azureappsettings": "^0.2.1",
         "@microsoft/vscode-azext-azureutils": "^3.0.0",
         "@microsoft/vscode-azext-serviceconnector": "^0.1.3",
         "@microsoft/vscode-azext-utils": "^2.3.1",

--- a/src/tree/containerizedFunctionApp/AppSettingsClient.ts
+++ b/src/tree/containerizedFunctionApp/AppSettingsClient.ts
@@ -25,6 +25,7 @@ export class ContainerAppSettingsClientProvider implements AppSettingsClientProv
 export class ContainerAppSettingsClient implements IAppSettingsClient {
     public fullName: string;
     public isLinux: boolean;
+    public isContainer: boolean;
 
     private _resourceGroup: string;
     private _siteName: string;
@@ -34,6 +35,7 @@ export class ContainerAppSettingsClient implements IAppSettingsClient {
         this._client = client;
         this._resourceGroup = nonNullProp(site, 'resourceGroup');
         this.isLinux = true;
+        this.isContainer = true;
         this._siteName = nonNullProp(site, 'name');
         this.fullName = this._siteName;
     }


### PR DESCRIPTION
Fixes #4000.

Need to merge and release this appsettings [PR ](https://github.com/microsoft/vscode-azuretools/pull/1699) first. 

Seems the name validaton for containerized function apps is different than regular ones. Currently the portal doesn't have any validation but since they gave us the regex it was a pretty simple fix. 

