### PR TITLE
Check for a `Directory.Build.props` file

### DIFF
--- a/src/utils/dotnetUtils.ts
+++ b/src/utils/dotnetUtils.ts
@@ -85,7 +85,7 @@ export namespace dotnetUtils {
             const buildPropsFile: string = 'Directory.Build.props';
             const buildPropsFiles = await workspace.findFiles(buildPropsFile, null);
             if (buildPropsFiles.length > 0) {
-                const buildPropsContents = (await AzExtFsExtra.readFile(buildPropsFiles[0])).toString();
+                const buildPropsContents = await AzExtFsExtra.readFile(buildPropsFiles[0]);
                 const buildPropsMatches = buildPropsContents.match(regExp);
                 if (buildPropsMatches) {
                     return buildPropsMatches[1];


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3940

If we can't find the property we're looking for in the csproj file, we should check the Directory.Build.props file. It's a standard file name in .NET. More about that here: https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022#directorybuildprops-and-directorybuildtargets

But basically, `dotnet` commands know to check the props file and apply that to other projects.