### PR TITLE
Fix no activity log when deleting containerized function app

### DIFF
--- a/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { createWebSiteClient } from "@microsoft/vscode-azext-azureappservice";
+import { AzureWizardExecuteStep, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
+import { ProgressLocation, window } from "vscode";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../localize";
+import { type DeleteFunctionappWizardContext } from "./DeleteFunctionAppWizardContext";
+
+export class DeleteContainerizedFunctionappStep extends AzureWizardExecuteStep<DeleteFunctionappWizardContext> {
+    public priority: number = 100;
+
+    public async execute(context: DeleteFunctionappWizardContext): Promise<void> {
+        const deleting: string = localize('DeletingFunctionApp', 'Deleting function app "{0}"...', context.site.name);
+        const deleteSucceeded: string = localize('DeleteFunctionAppSucceeded', 'Successfully deleted function app "{0}".', context.site.name);
+
+        await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
+            ext.outputChannel.appendLog(deleting);
+            const client = await createWebSiteClient([context, context.proxyTree.subscription]);
+            await client.webApps.delete(nonNullValueAndProp(context.site, 'resourceGroup'), nonNullValueAndProp(context.site, 'name'));
+            void window.showInformationMessage(deleteSucceeded);
+            ext.outputChannel.appendLog(deleteSucceeded);
+        });
+    }
+
+    public shouldExecute(): boolean {
+        return true;
+    }
+}

--- a/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
@@ -5,7 +5,7 @@
 
 import { createWebSiteClient } from "@microsoft/vscode-azext-azureappservice";
 import { AzureWizardExecuteStep, nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
-import { ProgressLocation, window } from "vscode";
+import { window } from "vscode";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
 import { type DeleteFunctionappWizardContext } from "./DeleteFunctionAppWizardContext";
@@ -17,13 +17,11 @@ export class DeleteContainerizedFunctionappStep extends AzureWizardExecuteStep<D
         const deleting: string = localize('DeletingFunctionApp', 'Deleting function app "{0}"...', context.site.name);
         const deleteSucceeded: string = localize('DeleteFunctionAppSucceeded', 'Successfully deleted function app "{0}".', context.site.name);
 
-        await window.withProgress({ location: ProgressLocation.Notification, title: deleting }, async (): Promise<void> => {
-            ext.outputChannel.appendLog(deleting);
-            const client = await createWebSiteClient([context, context.proxyTree.subscription]);
-            await client.webApps.delete(nonNullValueAndProp(context.site, 'resourceGroup'), nonNullValueAndProp(context.site, 'name'));
-            void window.showInformationMessage(deleteSucceeded);
-            ext.outputChannel.appendLog(deleteSucceeded);
-        });
+        ext.outputChannel.appendLog(deleting);
+        const client = await createWebSiteClient([context, context.subscription]);
+        await client.webApps.delete(nonNullValueAndProp(context.site, 'resourceGroup'), nonNullValueAndProp(context.site, 'name'));
+        void window.showInformationMessage(deleteSucceeded);
+        ext.outputChannel.appendLog(deleteSucceeded);
     }
 
     public shouldExecute(): boolean {

--- a/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteContainerizedFunctionAppStep.ts
@@ -18,7 +18,7 @@ export class DeleteContainerizedFunctionappStep extends AzureWizardExecuteStep<D
         const deleteSucceeded: string = localize('DeleteFunctionAppSucceeded', 'Successfully deleted function app "{0}".', context.site.name);
 
         ext.outputChannel.appendLog(deleting);
-        const client = await createWebSiteClient([context, context.subscription]);
+        const client = await createWebSiteClient(context);
         await client.webApps.delete(nonNullValueAndProp(context.site, 'resourceGroup'), nonNullValueAndProp(context.site, 'name'));
         void window.showInformationMessage(deleteSucceeded);
         ext.outputChannel.appendLog(deleteSucceeded);

--- a/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
@@ -1,0 +1,13 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { type Site } from "@azure/arm-appservice";
+import { type ExecuteActivityContext, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { type ContainerTreeItem } from "../../tree/containerizedFunctionApp/ContainerTreeItem";
+
+export interface DeleteFunctionappWizardContext extends IActionContext, ExecuteActivityContext {
+    site: Site;
+    proxyTree: ContainerTreeItem;
+}

--- a/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
@@ -4,9 +4,8 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { type Site } from "@azure/arm-appservice";
-import { type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { type ExecuteActivityContext, type IActionContext, type ISubscriptionActionContext } from "@microsoft/vscode-azext-utils";
 
-export interface DeleteFunctionappWizardContext extends IActionContext, ExecuteActivityContext {
+export interface DeleteFunctionappWizardContext extends ISubscriptionActionContext, IActionContext, ExecuteActivityContext {
     site: Site;
-    subscription: ISubscriptionContext;
 }

--- a/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
+++ b/src/commands/deleteContainerizedFunctionApp/DeleteFunctionAppWizardContext.ts
@@ -4,10 +4,9 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { type Site } from "@azure/arm-appservice";
-import { type ExecuteActivityContext, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { type ContainerTreeItem } from "../../tree/containerizedFunctionApp/ContainerTreeItem";
+import { type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 
 export interface DeleteFunctionappWizardContext extends IActionContext, ExecuteActivityContext {
     site: Site;
-    proxyTree: ContainerTreeItem;
+    subscription: ISubscriptionContext;
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -195,7 +195,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
         let node: SlotTreeItem | ContainerTreeItem;
 
         if (context.dockerfilePath) {
-            const resolved = new ResolvedContainerizedFunctionAppResource(nonNullProp(wizardContext, 'site'))
+            const resolved = new ResolvedContainerizedFunctionAppResource(subscription.subscription, nonNullProp(wizardContext, 'site'))
             node = new ContainerTreeItem(subscription, resolved);
         } else {
             const resolved = new ResolvedFunctionAppResource(subscription.subscription, nonNullProp(wizardContext, 'site'));

--- a/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
+++ b/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
@@ -148,7 +148,7 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
         });
 
         const message: string = localize('ConfirmDeleteFunction', 'Are you sure you want to delete function app "{0}"?', this.site.name);
-        const title: string = localize('DeleteFunctionApp', 'Delete function app');
+        const title: string = localize('DeleteFunctionApp', 'Delete function app "{0}"...', this.site.name);
 
         const wizard = new AzureWizard(wizardContext, {
             promptSteps: [new DeleteConfirmationStep(message)],
@@ -158,7 +158,6 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
 
         await wizard.prompt();
         await wizard.execute();
-
     }
 
     public async pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined> {

--- a/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
+++ b/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
@@ -145,7 +145,7 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
         const wizardContext: DeleteFunctionappWizardContext = Object.assign(context, {
             site: this.site,
-            subscription: this._subscription,
+            ...this._subscription,
             ...(await createActivityContext()),
         });
 


### PR DESCRIPTION
Fixes #4004. 

Can't reuse the deleteSite steps within the appservice tools package since we cannot create a client the same way. 