### PR TITLE
Fix advanced creation for containerized function apps

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -27,7 +27,7 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
     }
 
     public shouldPrompt(context: IFunctionAppWizardContext): boolean {
-        return context.useConsumptionPlan === undefined || context.dockerfilePath !== undefined;
+        return context.useConsumptionPlan === undefined && context.dockerfilePath === undefined;
     }
 
     public async getSubWizard(_context: IFunctionAppWizardContext): Promise<IWizardOptions<IFunctionAppWizardContext> | undefined> {

--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -31,6 +31,9 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
     }
 
     public async getSubWizard(_context: IFunctionAppWizardContext): Promise<IWizardOptions<IFunctionAppWizardContext> | undefined> {
+        if (_context.dockerfilePath) {
+            return undefined;
+        }
         return { promptSteps: [new AppServicePlanListStep()] };
     }
 }


### PR DESCRIPTION
The subwizard was running causing there still to be an error. Tested for both scenerios and they seem to work properly for me. 

Fixes #4002 