### PR TITLE
Fix creating a function app with no workspace open

### DIFF
--- a/src/commands/createFunctionApp/containerImage/detectDockerfile.ts
+++ b/src/commands/createFunctionApp/containerImage/detectDockerfile.ts
@@ -20,7 +20,7 @@ export async function detectDockerfile(context: ICreateFunctionAppContext): Prom
         context.rootPath = workspacePath;
 
         //check for host.json location
-        if (!(await isFunctionProject(workspacePath))) {
+        if (await isFunctionProject(workspacePath)) {
             const files = (await findFiles(context.workspaceFolder, `*/${hostFileName}`));
             if (files.length === 0) {
                 throw new Error(localize('noHostJson', 'No host.json file found in the current workspace.'));

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -7,7 +7,7 @@ import { type Site, type WebSiteManagementClient } from '@azure/arm-appservice';
 import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, uiUtils, type INewStorageAccountDefaults } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizard, parseError, type AzExtTreeItem, type AzureWizardExecuteStep, type AzureWizardPromptStep, type IActionContext, type ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
-import { workspace, type WorkspaceFolder } from 'vscode';
+import { type WorkspaceFolder } from 'vscode';
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersion';
 import { FunctionAppCreateStep } from '../commands/createFunctionApp/FunctionAppCreateStep';
 import { FunctionAppHostingPlanStep, setConsumptionPlanProperties } from '../commands/createFunctionApp/FunctionAppHostingPlanStep';
@@ -114,9 +114,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             replication: StorageAccountReplication.LRS
         };
 
-        if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-            await detectDockerfile(context);
-        }
+        await detectDockerfile(context);
 
         promptSteps.push(new SiteNameStep(context.dockerfilePath ? "containerizedFunctionApp" : "functionApp"));
 

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -7,7 +7,7 @@ import { type Site, type WebSiteManagementClient } from '@azure/arm-appservice';
 import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, uiUtils, type INewStorageAccountDefaults } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizard, parseError, type AzExtTreeItem, type AzureWizardExecuteStep, type AzureWizardPromptStep, type IActionContext, type ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
-import { type WorkspaceFolder } from 'vscode';
+import { workspace, type WorkspaceFolder } from 'vscode';
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from '../FuncVersion';
 import { FunctionAppCreateStep } from '../commands/createFunctionApp/FunctionAppCreateStep';
 import { FunctionAppHostingPlanStep, setConsumptionPlanProperties } from '../commands/createFunctionApp/FunctionAppHostingPlanStep';
@@ -114,7 +114,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             replication: StorageAccountReplication.LRS
         };
 
-        await detectDockerfile(context);
+        if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
+            await detectDockerfile(context);
+        }
 
         promptSteps.push(new SiteNameStep(context.dockerfilePath ? "containerizedFunctionApp" : "functionApp"));
 


### PR DESCRIPTION
I was checking telemetry today and noticed the error count was a little high for the create function app telemetry event. Looking further into we were blocking users from creating a function app when no workspace was open. This happened due to the containerized function app flow checking for a dockerfile in the workspace. I added a check to see if a workspace was open before running this step which should fix that issue. 