### PR TITLE
Stupid method to find flex function apps

### DIFF
--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -1,14 +1,18 @@
 import { type Site } from "@azure/arm-appservice";
-import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { createGenericClient, uiUtils, type AzExtPipelineResponse, type AzExtRequestPrepareOptions } from "@microsoft/vscode-azext-azureutils";
 import { callWithTelemetryAndErrorHandling, nonNullProp, nonNullValue, nonNullValueAndProp, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { type AppResource, type AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
+import { type FunctionAppConfig } from "./commands/createFunctionApp/FunctionAppCreateStep";
 import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource";
 import { ResolvedContainerizedFunctionAppResource } from "./tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 import { createWebSiteClient } from "./utils/azureClients";
 
+// TODO: this is temporary until the new api-version is available in the SDK
+type Site2 = Site & { isFlex?: boolean };
 export class FunctionAppResolver implements AppResourceResolver {
     private siteCacheLastUpdated = 0;
-    private siteCache: Map<string, Site> = new Map<string, Site>();
+    private siteCache: Map<string, Site2> = new Map<string, Site2>();
 
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | ResolvedContainerizedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
@@ -17,7 +21,11 @@ export class FunctionAppResolver implements AppResourceResolver {
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
                 this.siteCache.clear();
                 const sites = await uiUtils.listAllIterator(client.webApps.list());
-                sites.forEach(site => this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), site));
+                const sites20231201 = await getSites20231201(context, subContext);
+                sites.forEach((site) => {
+                    const s = sites20231201.find(s => s.id?.toLowerCase() === site.id?.toLowerCase());
+                    this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), Object.assign(site, { isFlex: !!s?.properties?.functionAppConfig }));
+                });
                 this.siteCacheLastUpdated = Date.now();
             }
 
@@ -28,7 +36,7 @@ export class FunctionAppResolver implements AppResourceResolver {
                 return ResolvedContainerizedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, fullSite);
             }
 
-            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site));
+            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site), site?.isFlex);
         });
     }
 
@@ -37,5 +45,22 @@ export class FunctionAppResolver implements AppResourceResolver {
             && !!resource.kind?.includes('functionapp')
             && !resource.kind?.includes('workflowapp'); // exclude logic apps
     }
+}
+
+async function getSites20231201(context: IActionContext, subContext: ISubscriptionContext): Promise<(Site & { properties?: { functionAppConfig: FunctionAppConfig } })[]> {
+    const headers = createHttpHeaders({
+        'Content-Type': 'application/json',
+    });
+
+    // we need the new api-version to get the functionAppConfig
+    const options: AzExtRequestPrepareOptions = {
+        url: `https://management.azure.com/subscriptions/${subContext.subscriptionId}/providers/Microsoft.Web/sites?api-version=2023-12-01`,
+        method: 'GET',
+        headers
+    };
+
+    const client = await createGenericClient(context, subContext);
+    const result = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
+    return (result.parsedBody as { value: unknown }).value as (Site & { properties?: { functionAppConfig: FunctionAppConfig } })[];
 }
 

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -60,11 +60,14 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;
 
-    public constructor(subscription: ISubscriptionContext, site: Site) {
+    public constructor(subscription: ISubscriptionContext, site: Site, isFlex?: boolean) {
         super(new ParsedSite(site, subscription))
         this.data = this.site.rawSite;
         this._subscription = subscription;
         this.contextValuesToAdd = [this.site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue];
+        if (isFlex) {
+            this.contextValuesToAdd.push('azFuncFlex');
+        }
 
         const valuesToMask = [
             this.site.siteName, this.site.slotName, this.site.defaultHostName, this.site.resourceGroup,
@@ -80,8 +83,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
     }
 
-    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site): ResolvedFunctionAppResource {
-        const resource = new ResolvedFunctionAppResource(subscription, site);
+    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site, isFlex?: boolean): ResolvedFunctionAppResource {
+        const resource = new ResolvedFunctionAppResource(subscription, site, isFlex);
         void resource.site.createClient(context).then(async (client) => resource.data.siteConfig = await client.getSiteConfig())
         return resource;
     }


### PR DESCRIPTION
I wish this were a April Fool's joke, but here we are:

A lot of the issues CTI came back with have to do with the fact that there's no good way for me to determine which apps are and aren't flex. You have to tell by looking at their ASP to know that.

Temporarily, the only apps that are using the `functionAppConfig` property are flex apps (because they are being created on the new api-version). I doubt that this is going to remain that way forever, but this is a temporary solution for us to add a flex context value.

I'll remove all of this garbo code once the new SDK drops with the required api-version and typing.