### PR TITLE
Flex fixes and includes the adding flex to function app context values

### DIFF
--- a/package.json
+++ b/package.json
@@ -415,12 +415,12 @@
                 },
                 {
                     "command": "azureFunctions.browseWebsite",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)/",
                     "group": "1@2"
                 },
                 {
                     "command": "azureFunctions.deploy",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFuncProductionSlot(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(ProductionSlot|Flex)(?!.*container)/",
                     "group": "2@1"
                 },
                 {
@@ -435,17 +435,17 @@
                 },
                 {
                     "command": "azureFunctions.startFunctionApp",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)(?!.*container)/",
                     "group": "3@1"
                 },
                 {
                     "command": "azureFunctions.stopFunctionApp",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)(?!.*container)/",
                     "group": "3@2"
                 },
                 {
                     "command": "azureFunctions.restartFunctionApp",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)(?!.*container)/",
                     "group": "3@3"
                 },
                 {
@@ -455,7 +455,7 @@
                 },
                 {
                     "command": "azureFunctions.deleteFunctionApp",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFuncProductionSlot/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(ProductionSlot|Flex)/",
                     "group": "3@5"
                 },
                 {
@@ -485,12 +485,12 @@
                 },
                 {
                     "command": "azureFunctions.viewProperties",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s).*slot/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s).*slot/",
                     "group": "6@1"
                 },
                 {
                     "command": "azureResourceGroups.refresh",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s).*slot/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s).*slot/",
                     "group": "6@2"
                 },
                 {

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -8,11 +8,11 @@ import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource"
 import { ResolvedContainerizedFunctionAppResource } from "./tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 import { createWebSiteClient } from "./utils/azureClients";
 
-// TODO: this is temporary until the new api-version is available in the SDK
-type Site2 = Site & { isFlex?: boolean };
+// TODO: this is temporary until the new SDK with api-version=2023-12-01 is available
+type Site20231201 = Site & { isFlex?: boolean };
 export class FunctionAppResolver implements AppResourceResolver {
     private siteCacheLastUpdated = 0;
-    private siteCache: Map<string, Site2> = new Map<string, Site2>();
+    private siteCache: Map<string, Site20231201> = new Map<string, Site20231201>();
 
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | ResolvedContainerizedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -1,14 +1,18 @@
 import { type Site } from "@azure/arm-appservice";
-import { uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { createGenericClient, uiUtils, type AzExtPipelineResponse, type AzExtRequestPrepareOptions } from "@microsoft/vscode-azext-azureutils";
 import { callWithTelemetryAndErrorHandling, nonNullProp, nonNullValue, nonNullValueAndProp, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { type AppResource, type AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
+import { type FunctionAppConfig } from "./commands/createFunctionApp/FunctionAppCreateStep";
 import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource";
 import { ResolvedContainerizedFunctionAppResource } from "./tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 import { createWebSiteClient } from "./utils/azureClients";
 
+// TODO: this is temporary until the new api-version is available in the SDK
+type Site2 = Site & { isFlex?: boolean };
 export class FunctionAppResolver implements AppResourceResolver {
     private siteCacheLastUpdated = 0;
-    private siteCache: Map<string, Site> = new Map<string, Site>();
+    private siteCache: Map<string, Site2> = new Map<string, Site2>();
 
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | ResolvedContainerizedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
@@ -17,7 +21,11 @@ export class FunctionAppResolver implements AppResourceResolver {
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
                 this.siteCache.clear();
                 const sites = await uiUtils.listAllIterator(client.webApps.list());
-                sites.forEach(site => this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), site));
+                const sites20231201 = await getSites20231201(context, subContext);
+                sites.forEach((site) => {
+                    const s = sites20231201.find(s => s.id?.toLowerCase() === site.id?.toLowerCase());
+                    this.siteCache.set(nonNullProp(site, 'id').toLowerCase(), Object.assign(site, { isFlex: !!s?.properties?.functionAppConfig }));
+                });
                 this.siteCacheLastUpdated = Date.now();
             }
 
@@ -28,7 +36,7 @@ export class FunctionAppResolver implements AppResourceResolver {
                 return ResolvedContainerizedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, fullSite);
             }
 
-            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site));
+            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site), site?.isFlex);
         });
     }
 
@@ -37,5 +45,22 @@ export class FunctionAppResolver implements AppResourceResolver {
             && !!resource.kind?.includes('functionapp')
             && !resource.kind?.includes('workflowapp'); // exclude logic apps
     }
+}
+
+async function getSites20231201(context: IActionContext, subContext: ISubscriptionContext): Promise<(Site & { properties?: { functionAppConfig: FunctionAppConfig } })[]> {
+    const headers = createHttpHeaders({
+        'Content-Type': 'application/json',
+    });
+
+    // we need the new api-version to get the functionAppConfig
+    const options: AzExtRequestPrepareOptions = {
+        url: `https://management.azure.com/subscriptions/${subContext.subscriptionId}/providers/Microsoft.Web/sites?api-version=2023-12-01`,
+        method: 'GET',
+        headers
+    };
+
+    const client = await createGenericClient(context, subContext);
+    const result = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
+    return (result.parsedBody as { value: unknown }).value as (Site & { properties?: { functionAppConfig: FunctionAppConfig } })[];
 }
 

--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -5,9 +5,9 @@
 
 import { type Location } from '@azure/arm-resources-subscriptions';
 import { createHttpHeaders, createPipelineRequest } from '@azure/core-rest-pipeline';
-import { AppServicePlanListStep, setLocationsTask, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
+import { setLocationsTask, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { createGenericClient, LocationListStep, type AzExtPipelineResponse, type AzExtRequestPrepareOptions } from '@microsoft/vscode-azext-azureutils';
-import { AzureWizardPromptStep, type IAzureQuickPickItem, type IWizardOptions } from '@microsoft/vscode-azext-utils';
+import { AzureWizardPromptStep, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
 import { localize } from '../../localize';
 import { getRandomHexString } from '../../utils/fs';
 import { nonNullProp } from '../../utils/nonNull';
@@ -21,7 +21,7 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
         const picks: IAzureQuickPickItem<[boolean, RegExp | undefined]>[] = [
             { label: localize('consumption', 'Consumption'), data: [true, undefined] },
             { label: localize('premium', 'Premium'), data: [false, /^EP$/i] },
-            { label: localize('dedicated', 'App Service Plan'), data: [false, /^((?!EP|Y).)*$/i] }
+            { label: localize('dedicated', 'App Service Plan'), data: [false, /^((?!EP|Y|FC).)*$/i] }
         ];
 
         if (enableFlexSetting) {
@@ -42,12 +42,7 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
         return context.useConsumptionPlan === undefined && context.dockerfilePath === undefined;
     }
 
-    public async getSubWizard(_context: IFunctionAppWizardContext): Promise<IWizardOptions<IFunctionAppWizardContext> | undefined> {
-        if (_context.dockerfilePath) {
-            return undefined;
-        }
-        return { promptSteps: [new AppServicePlanListStep()] };
-    }
+
 }
 
 export function setConsumptionPlanProperties(context: IFunctionAppWizardContext): void {

--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -41,8 +41,6 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
     public shouldPrompt(context: IFunctionAppWizardContext): boolean {
         return context.useConsumptionPlan === undefined && context.dockerfilePath === undefined;
     }
-
-
 }
 
 export function setConsumptionPlanProperties(context: IFunctionAppWizardContext): void {

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -56,6 +56,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     public static productionContextValue: string = 'azFuncProductionSlot';
     public static slotContextValue: string = 'azFuncSlot';
 
+    private _isFlex: boolean;
+
     commandId?: string | undefined;
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;
@@ -64,9 +66,14 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         super(new ParsedSite(site, subscription))
         this.data = this.site.rawSite;
         this._subscription = subscription;
-        this.contextValuesToAdd = [this.site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue];
-        if (isFlex) {
+        this.contextValuesToAdd = [];
+        this._isFlex = !!isFlex;
+        if (this._isFlex) {
             this.contextValuesToAdd.push('azFuncFlex');
+        } else if (this.site.isSlot) {
+            this.contextValuesToAdd.push(ResolvedFunctionAppResource.slotContextValue);
+        } else {
+            this.contextValuesToAdd.push(ResolvedFunctionAppResource.productionContextValue);
         }
 
         const valuesToMask = [
@@ -221,7 +228,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
 
         const children: AzExtTreeItem[] = [this._functionsTreeItem, this.appSettingsTreeItem, this._siteFilesTreeItem, this._logFilesTreeItem, this.deploymentsNode];
-        if (!this.site.isSlot) {
+        if (!this.site.isSlot && !this._isFlex) {
             this._slotsTreeItem = new SlotsTreeItem(proxyTree);
             children.push(this._slotsTreeItem);
         }

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -60,11 +60,14 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;
 
-    public constructor(subscription: ISubscriptionContext, site: Site) {
+    public constructor(subscription: ISubscriptionContext, site: Site, isFlex?: boolean) {
         super(new ParsedSite(site, subscription))
         this.data = this.site.rawSite;
         this._subscription = subscription;
         this.contextValuesToAdd = [this.site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue];
+        if (isFlex) {
+            this.contextValuesToAdd.push('azFuncFlex');
+        }
 
         const valuesToMask = [
             this.site.siteName, this.site.slotName, this.site.defaultHostName, this.site.resourceGroup,
@@ -80,8 +83,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
     }
 
-    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site): ResolvedFunctionAppResource {
-        const resource = new ResolvedFunctionAppResource(subscription, site);
+    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site, isFlex?: boolean): ResolvedFunctionAppResource {
+        const resource = new ResolvedFunctionAppResource(subscription, site, isFlex);
         void resource.site.createClient(context).then(async (client) => resource.data.siteConfig = await client.getSiteConfig())
         return resource;
     }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type Site, type WebSiteManagementClient } from '@azure/arm-appservice';
-import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
+import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, AppServicePlanListStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, SubscriptionTreeItemBase, uiUtils, type INewStorageAccountDefaults } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizard, parseError, type AzExtTreeItem, type AzureWizardExecuteStep, type AzureWizardPromptStep, type IActionContext, type ICreateChildImplContext } from '@microsoft/vscode-azext-utils';
 import { type WorkspaceFolder } from 'vscode';
@@ -240,6 +240,10 @@ async function createFunctionAppWizard(wizardContext: IFunctionAppWizardContext)
     }
 
     promptSteps.push(new FunctionAppStackStep());
+
+    if (wizardContext.advancedCreation) {
+        promptSteps.push(new AppServicePlanListStep())
+    }
 
     if (wizardContext.version === FuncVersion.v1) { // v1 doesn't support linux
         wizardContext.newSiteOS = WebsiteOS.windows;


### PR DESCRIPTION
Includes this https://github.com/microsoft/vscode-azurefunctions/pull/4072 PR but I ended up changing the context value portion of it slightly since a flex app is different from `productionSlot` or `slot`.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4070 (by removing the deployment configuration command)
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4068 (by removing the sub-wizard that asks for a plan immediately after picking the host service type. We need to let users select a runtime _first_ because which OS it can run on is stack dependent)