### PR TITLE
Use ~ for version instead of ^

### DIFF
--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -26,7 +26,7 @@ export async function getAzureContainerAppsApi(context: IActionContext, installM
     const acaExtension: apiUtils.AzureExtensionApiProvider | undefined = await apiUtils.getExtensionExports(acaExtensionId);
 
     if (acaExtension) {
-        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('^0.0.1');
+        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('~0.0.1');
     }
 
     await context.ui.showWarningMessage(installMessage ??

--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -26,7 +26,7 @@ export async function getAzureContainerAppsApi(context: IActionContext, installM
     const acaExtension: apiUtils.AzureExtensionApiProvider | undefined = await apiUtils.getExtensionExports(acaExtensionId);
 
     if (acaExtension) {
-        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('~0.0.1');
+        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('^1.0.0');
     }
 
     await context.ui.showWarningMessage(installMessage ??


### PR DESCRIPTION
Basically, `~` is used to only accept new patch updates whereas `^` is supposed to accept new minor and patch updates. There must be a bug in `semver` because `^0.0.1` is not accepting `v0.0.2` where as `~0.0.1` does even though both should work.

We're going to have to simship these changes (+/- a couple of days). Since we are shipping both anyway, we may want to revisit if we just want to call the ACA API version 1.0.0 and go from there since that would actually be more helpful for tracking the versioning of our API anyway.

Ref: https://stackoverflow.com/questions/22343224/whats-the-difference-between-tilde-and-caret-in-package-json