### PR TITLE
Create container on flex app creation and allow flex nodes to be passed into deploy

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -289,7 +289,6 @@ async function tryCreateStorageContainer(site: Site & { properties: FlexFunction
             await blobClient.createContainer(containerName);
         }
     }
-
 }
 
 type FlexFunctionAppProperties = {

--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -5,6 +5,7 @@
 
 import { type NameValuePair, type Site, type SiteConfig, type WebSiteManagementClient } from '@azure/arm-appservice';
 import { createHttpHeaders, createPipelineRequest, type RequestBodyType } from '@azure/core-rest-pipeline';
+import { BlobServiceClient } from '@azure/storage-blob';
 import { ParsedSite, WebsiteOS, type CustomLocation, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { LocationListStep, createGenericClient, type AzExtPipelineResponse, type AzExtRequestPrepareOptions } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizardExecuteStep, parseError, randomUtils } from '@microsoft/vscode-azext-utils';
@@ -245,6 +246,9 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         const client = await createGenericClient(context, context);
         const result = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
         if (result && result.status >= 200 && result.status < 300) {
+            const site = result.parsedBody as Site & { properties: FlexFunctionAppProperties };
+            const storageConnectionString: string = (await getStorageConnectionString(context)).connectionString;
+            await tryCreateStorageContainer(site, storageConnectionString);
             const client: WebSiteManagementClient = await createWebSiteClient(context);
             // the payload for the new API version "2023-12-01" is incompatiable with our current SiteClient so get the old payload
             try {
@@ -273,6 +277,19 @@ function getSiteKind(context: IAppServiceWizardContext): string {
         kind += ',kubernetes';
     }
     return kind;
+}
+
+// storage container is needed for flex deployment, but it is not created automatically
+async function tryCreateStorageContainer(site: Site & { properties: FlexFunctionAppProperties }, storageConnectionString: string): Promise<void> {
+    const blobClient = BlobServiceClient.fromConnectionString(storageConnectionString);
+    const containerName = site.properties?.functionAppConfig?.deployment.storage.value.split('/').pop();
+    if (containerName) {
+        const client = blobClient.getContainerClient(containerName);
+        if (!await client.exists()) {
+            await blobClient.createContainer(containerName);
+        }
+    }
+
 }
 
 type FlexFunctionAppProperties = {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -61,7 +61,8 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
 
     if (treeUtils.isAzExtTreeItem(arg1)) {
         if (!arg1.contextValue.match(ResolvedFunctionAppResource.pickSlotContextValue) &&
-            !arg1.contextValue.match(ResolvedFunctionAppResource.productionContextValue)) {
+            !arg1.contextValue.match(ResolvedFunctionAppResource.productionContextValue) &&
+            !arg1.contextValue.match(ResolvedFunctionAppResource.flexContextValue)) {
             // if the user uses the deploy button, it's possible for the local project node to be passed in, so we should reset it to undefined
             arg1 = undefined;
         }

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -55,6 +55,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     public static pickSlotContextValue: RegExp = new RegExp(/azFuncSlot(?!s)/);
     public static productionContextValue: string = 'azFuncProductionSlot';
     public static slotContextValue: string = 'azFuncSlot';
+    public static flexContextValue: string = 'azFuncFlex';
 
     private _isFlex: boolean;
 
@@ -69,7 +70,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         this.contextValuesToAdd = [];
         this._isFlex = !!isFlex;
         if (this._isFlex) {
-            this.contextValuesToAdd.push('azFuncFlex');
+            this.contextValuesToAdd.push(ResolvedFunctionAppResource.flexContextValue);
         } else if (this.site.isSlot) {
             this.contextValuesToAdd.push(ResolvedFunctionAppResource.slotContextValue);
         } else {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4083

Had a discussion with CLI tooling team. The fact that we do not create the container in the storage account on flex app creation breaks their deployment scenario. I made the design decision to create the container on deployment originally, but I do not think there is any harm in verifying the container in both scenarios.