### PR TITLE
Update initial launch.json for Python to use debugpy

### DIFF
--- a/src/debug/PythonDebugProvider.ts
+++ b/src/debug/PythonDebugProvider.ts
@@ -8,13 +8,17 @@ import { hostStartTaskName, localhost } from '../constants';
 import { localize } from '../localize';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 
+export const defaultPythonDebugHost: string = 'localhost';
 export const defaultPythonDebugPort: number = 9091;
 
 export const pythonDebugConfig: DebugConfiguration = {
     name: localize('attachPython', 'Attach to Python Functions'),
-    type: 'python',
+    type: 'debugpy',
     request: 'attach',
-    port: defaultPythonDebugPort,
+    connect: {
+        host: defaultPythonDebugHost,
+        port: defaultPythonDebugPort
+    },
     preLaunchTask: hostStartTaskName
 };
 


### PR DESCRIPTION
The type "python" is being deprecated for the "attach" request in the launch.json and is being replaced with "debugpy" instead. This pull requests updates the debug config for Python to use this new "debugpy".