### PR TITLE
Add retry logic to getFunctionsForHostedProject on ECONNREFUSED

### DIFF
--- a/package.json
+++ b/package.json
@@ -998,6 +998,11 @@
                         "description": "%azureFunctions.requestTimeout%",
                         "default": 15
                     },
+                    "azureFunctions.hostStartTimeout": {
+                        "type": "number",
+                        "description": "%azureFunctions.hostStartTimeout%",
+                        "default": 60
+                    },
                     "azureFunctions.defaultFunctionAppToDeploy": {
                         "scope": "resource",
                         "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -68,6 +68,7 @@
     "azureFunctions.redeploy": "Redeploy",
     "azureFunctions.reportIssue": "Report Issue...",
     "azureFunctions.requestTimeout": "The timeout (in seconds) to be used when making requests, for example getting the latest templates.",
+    "azureFunctions.hostStartTimeout": "The timeout (in seconds) to be used when starting the Azure Functions host.",
     "azureFunctions.restartFunctionApp": "Restart",
     "azureFunctions.scmDoBuildDuringDeployment": "Set to true to build your project on the server. Currently only applicable for Linux Function Apps.",
     "azureFunctions.setAzureWebJobsStorage": "Set AzureWebJobsStorage...",

--- a/src/workspace/listLocalFunctions.ts
+++ b/src/workspace/listLocalFunctions.ts
@@ -64,9 +64,9 @@ export async function listLocalFunctions(project: LocalProjectInternal): Promise
     }))!;
 }
 
-const timeoutKey: string = 'requestTimeout';
+const timeoutKey: string = 'hostStartTimeout';
 
-function getRequestTimeoutMS(): number {
+function getHostStartTimeoutMS(): number {
     // Shouldn't be null because the setting has a default value
     return nonNullValue(getWorkspaceSetting<number>(timeoutKey), timeoutKey) * 1000;
 }
@@ -77,7 +77,7 @@ function getRequestTimeoutMS(): number {
 async function getFunctionsForHostedProject(context: IActionContext, project: LocalProjectInternal): Promise<ILocalFunction[]> {
     if (runningFuncTaskMap.has(project.options.folder)) {
         const hostRequest = await project.getHostRequest(context);
-        const timeout = getRequestTimeoutMS();
+        const timeout = getHostStartTimeoutMS();
         const startTime = Date.now();
         let functions;
         let retry = true;


### PR DESCRIPTION
This adds retry logic for a configurable amount of time on encountering an ECONNREFUSED error to getFunctionsForHostedProject, as currently when the user starts debugging a hosted project, this function will get an ECONNREFUSED error from the Azure Functions host as it hasn't started up yet.