### PR TITLE
Use Stacks API for Flex Consumption SKU

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -22,22 +22,20 @@ import { getStorageConnectionString } from '../appSettings/connectionSettings/ge
 import { enableFileLogging } from '../logstream/enableFileLogging';
 import { type FullFunctionAppStack, type IFunctionAppWizardContext } from './IFunctionAppWizardContext';
 import { showSiteCreated } from './showSiteCreated';
-import { type FunctionAppRuntimeSettings } from './stacks/models/FunctionAppStackModel';
+import { type FunctionAppRuntimeSettings, type Sku } from './stacks/models/FunctionAppStackModel';
 
 export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWizardContext> {
     public priority: number = 140;
 
     public async execute(context: IFunctionAppWizardContext, progress: Progress<{ message?: string; increment?: number }>): Promise<void> {
         const os: WebsiteOS = nonNullProp(context, 'newSiteOS');
-        const stack: FullFunctionAppStack | undefined = context.newSiteStack
+        const stack: FullFunctionAppStack = nonNullProp(context, 'newSiteStack');
 
-        if (stack) {
-            context.telemetry.properties.newSiteOS = os;
-            context.telemetry.properties.newSiteStack = stack.stack.value;
-            context.telemetry.properties.newSiteMajorVersion = stack.majorVersion.value;
-            context.telemetry.properties.newSiteMinorVersion = stack.minorVersion.value;
-            context.telemetry.properties.planSkuTier = context.plan?.sku?.tier;
-        }
+        context.telemetry.properties.newSiteOS = os;
+        context.telemetry.properties.newSiteStack = stack.stack.value;
+        context.telemetry.properties.newSiteMajorVersion = stack.majorVersion.value;
+        context.telemetry.properties.newSiteMinorVersion = stack.minorVersion.value;
+        context.telemetry.properties.planSkuTier = context.plan?.sku?.tier;
 
         const message: string = localize('creatingNewApp', 'Creating new function app "{0}"...', context.newSiteName);
         ext.outputChannel.appendLog(message);
@@ -45,9 +43,11 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
 
         const siteName: string = nonNullProp(context, 'newSiteName');
         const rgName: string = nonNullProp(nonNullProp(context, 'resourceGroup'), 'name');
+        const flexSku: Sku | null | undefined = stack.minorVersion.stackSettings.linuxRuntimeSettings?.Sku && stack.minorVersion.stackSettings.linuxRuntimeSettings?.Sku[0];
 
-        // TODO: Because we don't have the stack API, assume no stack means it's a flex app
-        context.site = stack ? await this.createFunctionApp(context, rgName, siteName, stack) : await this.createFlexFunctionApp(context, rgName, siteName);
+        context.site = !flexSku ?
+            await this.createFunctionApp(context, rgName, siteName, stack) :
+            await this.createFlexFunctionApp(context, rgName, siteName, flexSku);
         context.activityResult = context.site as AppResource;
 
         const site = new ParsedSite(context.site, context);
@@ -101,7 +101,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         site.extendedLocation = { name: customLocation.id, type: 'customLocation' };
     }
 
-    private async getNewFlexSite(context: IFunctionAppWizardContext): Promise<Site> {
+    private async getNewFlexSite(context: IFunctionAppWizardContext, sku: Sku): Promise<Site> {
         const location = await LocationListStep.getLocation(context, webProvider);
         const site: Site & { properties: FlexFunctionAppProperties } = {
             name: context.newSiteName,
@@ -129,12 +129,12 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
                 }
             },
             runtime: {
-                name: context.newSiteStackFlex?.runtime,
-                version: context.newSiteStackFlex?.version
+                name: sku.functionAppConfigProperties.runtime.name,
+                version: sku.functionAppConfigProperties.runtime.version
             },
             scaleAndConcurrency: {
-                maximumInstanceCount: 100,
-                instanceMemoryMB: 2048,
+                maximumInstanceCount: sku.maximumInstanceCount.defaultValue,
+                instanceMemoryMB: sku.instanceMemoryMB.find(im => im.isDefault)?.size || 2048,
                 alwaysReady: [],
                 triggers: null
             },
@@ -231,7 +231,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         return await client.webApps.beginCreateOrUpdateAndWait(rgName, siteName, await this.getNewSite(context, stack));
     }
 
-    async createFlexFunctionApp(context: IFunctionAppWizardContext, rgName: string, siteName: string): Promise<Site> {
+    async createFlexFunctionApp(context: IFunctionAppWizardContext, rgName: string, siteName: string, sku: Sku): Promise<Site> {
         const headers = createHttpHeaders({
             'Content-Type': 'application/json',
         });
@@ -239,7 +239,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
         const options: AzExtRequestPrepareOptions = {
             url: `https://management.azure.com/subscriptions/${context.subscriptionId}/resourceGroups/${rgName}/providers/Microsoft.Web/sites/${siteName}?api-version=2023-12-01`,
             method: 'PUT',
-            body: JSON.stringify(await this.getNewFlexSite(context)) as unknown as RequestBodyType,
+            body: JSON.stringify(await this.getNewFlexSite(context, sku)) as unknown as RequestBodyType,
             headers
         };
 

--- a/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
+++ b/src/commands/createFunctionApp/IFunctionAppWizardContext.ts
@@ -22,8 +22,6 @@ export interface IFunctionAppWizardContext extends IAppServiceWizardContext, ICr
     language: string | undefined;
     stackFilter?: string;
     newSiteStack?: FullFunctionAppStack;
-    newSiteStackFlex?: { runtime: string, version: string } /* While we're not using the stacks API for flex, it's easier to just hard-code these two values instead of the entire FullFunctionAppStack */
-
     durableStorageType?: DurableBackendValues;
 
     // Detected local connection string

--- a/src/commands/createFunctionApp/stacks/FunctionAppStackStep.ts
+++ b/src/commands/createFunctionApp/stacks/FunctionAppStackStep.ts
@@ -16,9 +16,7 @@ export class FunctionAppStackStep extends AzureWizardPromptStep<IFunctionAppWiza
     public async prompt(context: IFunctionAppWizardContext): Promise<void> {
         const placeHolder: string = localize('selectRuntimeStack', 'Select a runtime stack.');
         const isFlex: boolean = context.newPlanSku?.tier === 'FlexConsumption';
-
-        // TODO: Since we aren't able to get the stacks for flex, we're using a simple object to represent the stack but we should when available
-        let result: FullFunctionAppStack | { runtime: string, version: string } | undefined;
+        let result: FullFunctionAppStack | undefined;
         while (true) {
             const options: AgentQuickPickOptions = {
                 placeHolder,
@@ -37,23 +35,18 @@ export class FunctionAppStackStep extends AzureWizardPromptStep<IFunctionAppWiza
                 break;
             }
         }
-        if (isFlex) {
-            context.newSiteStackFlex = result as { runtime: string, version: string };
-        } else {
-            context.newSiteStack = result as FullFunctionAppStack;
-
-            if (!context.newSiteStack.minorVersion.stackSettings.linuxRuntimeSettings) {
-                context.newSiteOS = WebsiteOS.windows;
-            } else if (!context.newSiteStack.minorVersion.stackSettings.windowsRuntimeSettings) {
-                context.newSiteOS = WebsiteOS.linux;
-            } else if (!context.advancedCreation) {
-                context.newSiteOS = <WebsiteOS>context.newSiteStack.stack.preferredOs;
-            }
+        context.newSiteStack = result as FullFunctionAppStack;
+        if (!context.newSiteStack.minorVersion.stackSettings.linuxRuntimeSettings) {
+            context.newSiteOS = WebsiteOS.windows;
+        } else if (!context.newSiteStack.minorVersion.stackSettings.windowsRuntimeSettings) {
+            context.newSiteOS = WebsiteOS.linux;
+        } else if (!context.advancedCreation) {
+            context.newSiteOS = <WebsiteOS>context.newSiteStack.stack.preferredOs;
         }
     }
 
     public shouldPrompt(context: IFunctionAppWizardContext): boolean {
-        return !context.newSiteStack && !context.newSiteStackFlex;
+        return !context.newSiteStack;
     }
 
     public async getSubWizard(context: IFunctionAppWizardContext): Promise<IWizardOptions<IFunctionAppWizardContext>> {
@@ -69,76 +62,8 @@ export class FunctionAppStackStep extends AzureWizardPromptStep<IFunctionAppWiza
         return { promptSteps };
     }
 
-    private async getPicks(context: IFunctionAppWizardContext, isFlex: boolean): Promise<AgentQuickPickItem<IAzureQuickPickItem<FullFunctionAppStack | { runtime: string, version: string } | undefined>>[]> {
-        // TODO: hardcoding the runtime versions for now, but we should get this from the API when available
-        if (isFlex) {
-            return [
-                {
-                    label: '.NET 8 Isolated',
-                    data: {
-                        runtime: 'dotnet-isolated',
-                        version: '8.0'
-                    },
-                    group: '.NET',
-                    agentMetadata: {}
-                },
-                {
-                    label: 'Java 17',
-                    data: {
-                        runtime: 'java',
-                        version: '17'
-                    },
-                    group: 'Java',
-                    agentMetadata: {}
-                },
-                {
-                    label: 'Java 11',
-                    data: {
-                        runtime: 'java',
-                        version: '11'
-                    },
-                    group: 'Java',
-                    agentMetadata: {}
-                },
-                {
-                    label: "Node.js 20 LTS",
-                    data: {
-                        runtime: 'node',
-                        version: '20'
-                    },
-                    group: 'Node.js',
-                    agentMetadata: {}
-                },
-                {
-                    label: 'Python 3.11',
-                    data: {
-                        runtime: 'python',
-                        version: '3.11'
-                    },
-                    group: 'Python',
-                    agentMetadata: {}
-                },
-                {
-                    label: 'Python 3.10',
-                    data: {
-                        runtime: 'python',
-                        version: '3.10'
-                    },
-                    group: 'Python',
-                    agentMetadata: {}
-                },
-                {
-                    label: 'PowerShell',
-                    data: {
-                        runtime: 'powershell',
-                        version: '7.2'
-                    },
-                    group: 'PowerShell Core',
-                    agentMetadata: {}
-                }
-            ];
-        }
-        let picks: AgentQuickPickItem<IAzureQuickPickItem<FullFunctionAppStack | undefined>>[] = await getStackPicks(context);
+    private async getPicks(context: IFunctionAppWizardContext, isFlex: boolean): Promise<AgentQuickPickItem<IAzureQuickPickItem<FullFunctionAppStack | undefined>>[]> {
+        let picks: AgentQuickPickItem<IAzureQuickPickItem<FullFunctionAppStack | undefined>>[] = await getStackPicks(context, isFlex);
         if (picks.filter(p => p.label !== noRuntimeStacksAvailableLabel).length === 0) {
             // if every runtime only has noRuntimeStackAvailable quickpick items, reset picks to []
             picks = [];

--- a/src/commands/createFunctionApp/stacks/models/FunctionAppStackModel.ts
+++ b/src/commands/createFunctionApp/stacks/models/FunctionAppStackModel.ts
@@ -40,4 +40,27 @@ export interface FunctionAppRuntimeSettings extends CommonSettings {
     appSettingsDictionary: AppSettingsDictionary;
     siteConfigPropertiesDictionary: SiteConfigPropertiesDictionary;
     supportedFunctionsExtensionVersions: FunctionsExtensionVersion[];
+    // Sku property is only used for flex consumption plans
+    Sku: Sku[] | null;
+}
+
+export interface Sku {
+    skuCode: string;
+    instanceMemoryMB: InstanceMemoryMB[];
+    maximumInstanceCount: {
+        lowestMaximumInstanceCount: number;
+        highestMaximumInstanceCount: number;
+        defaultValue: number;
+    },
+    functionAppConfigProperties: {
+        runtime: {
+            name: string,
+            version: string
+        }
+    }
+}
+
+interface InstanceMemoryMB {
+    size: number;
+    isDefault: boolean;
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -141,7 +141,6 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             }
         } else {
             promptSteps.push(new ResourceGroupListStep());
-            CustomLocationListStep.addStep(wizardContext, promptSteps);
             promptSteps.push(new StorageAccountListStep(
                 storageAccountCreateOptions,
                 {
@@ -237,6 +236,8 @@ async function createFunctionAppWizard(wizardContext: IFunctionAppWizardContext)
 
     if (wizardContext.advancedCreation) {
         promptSteps.push(new FunctionAppHostingPlanStep());
+        // location is required to get flex runtimes, so prompt before stack step
+        CustomLocationListStep.addStep(wizardContext, promptSteps);
     }
 
     promptSteps.push(new FunctionAppStackStep());


### PR DESCRIPTION
There are some different requirements for the stack API when acquiring the runtimes
1. Location is required as part of the endpoint URL. Due to this constraint, I moved the location step to be before the stacks step
2. Stack is a required query parameter which is why I have the for loop of stacks
3. If the stack has the Sku array under its LinuxRuntimeSettings, than it is flex compatible. All other runtimes have Sku as null.
