### PR TITLE
Remove log streaming context menu actions on flex apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -465,12 +465,12 @@
                 },
                 {
                     "command": "azureFunctions.startStreamingLogs",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)(?!.*container)/",
                     "group": "4@1"
                 },
                 {
                     "command": "azureFunctions.stopStreamingLogs",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)(Slot|Flex)(?!s)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!s)(?!.*container)/",
                     "group": "4@2"
                 },
                 {


### PR DESCRIPTION
I was told that flex apps don't support log streaming so just remove it for now.