### PR TITLE
Configure pipeline to build JsonCli tool 🤠

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -15,15 +15,35 @@ schedules:
       include:
         - main
 
-# `resources` specifies the location of templates to pick up, use it to get AzExt templates
+# under here is from https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml
+# `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
+  # get 1es template from here
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+  # get AzExt stages template from here
     - repository: azExtTemplates
       type: github
       name: microsoft/vscode-azuretools
       ref: main
       endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
 
-# Use those templates
 extends:
-  template: azure-pipelines/1esmain.yml@azExtTemplates
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
+      # codeql:
+      #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
+      image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
+      os: windows # OS of the image. Allowed values: windows, linux, macOS
+    stages:
+      # Execute stages from the AzExt stages template
+      - template: azure-pipelines/1esstages.yml@azExtTemplates
+      - template: tools/JsonCli/.azurepipelines/main.yml@self

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -1,138 +1,131 @@
-jobs:
-  - job: Windows
-    pool:
-      name: VSEngSS-MicroBuild2019-1ES
-    variables:
-      SrcPath: 'tools/JsonCli/src'
-      ProjectPath: '$(SrcPath)/Microsoft.TemplateEngine.JsonCli.csproj'
-      SigningProjectPath: '$(SrcPath)/Signing.csproj'
-      NugetConfigPath: '$(SrcPath)/nuget.config'
-      DropPath: '$(build.artifactstagingdirectory)/drop'
-    steps:
-      - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
-        displayName: 'Install Signing Plugin'
-        inputs:
-          signType: '$(SignType)'
-        env:
-          TeamName: 'AzureTools'
-          
-      - task: UseDotNet@2
-        displayName: 'Use .NET sdk 6.0.x'
-        inputs:
-          version: 6.0.x
+variables:
+  SrcPath: 'tools/JsonCli/src'
+  ProjectPath: '$(SrcPath)/Microsoft.TemplateEngine.JsonCli.csproj'
+  SigningProjectPath: '$(SrcPath)/Signing.csproj'
+  NugetConfigPath: '$(SrcPath)/nuget.config'
+  DropPath: '$(build.artifactstagingdirectory)/drop'
+  SignType: 'Test'
+steps:
+  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
+    displayName: 'Install Signing Plugin'
+    inputs:
+      signType: '$(SignType)'
+    env:
+      TeamName: 'AzureTools'
 
-      - task: UseDotNet@2
-        displayName: 'Use .NET sdk 7.0.x'
-        inputs:
-          version: 7.0.x
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 6.0.x'
+    inputs:
+      version: 6.0.x
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet restore'
-        inputs:
-          command: restore
-          projects: '$(ProjectPath)'
-          feedsToUse: config
-          nugetConfigPath: '$(NugetConfigPath)'
+  - task: UseDotNet@2
+    displayName: 'Use .NET sdk 7.0.x'
+    inputs:
+      version: 7.0.x
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet build'
-        inputs:
-          projects: '$(ProjectPath)'
-          arguments: '--configuration $(BuildConfiguration)'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore'
+    inputs:
+      command: restore
+      projects: '$(ProjectPath)'
+      feedsToUse: config
+      nugetConfigPath: '$(NugetConfigPath)'
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet publish 6.0'
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: '$(ProjectPath)'
-          arguments: '--configuration $(BuildConfiguration) --framework net6.0 --no-build'
-          zipAfterPublish: false
-          modifyOutputPath: false
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build'
+    inputs:
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration)'
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet publish 7.0'
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: '$(ProjectPath)'
-          arguments: '--configuration $(BuildConfiguration) --framework net7.0 --no-build'
-          zipAfterPublish: false
-          modifyOutputPath: false
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 6.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework net6.0 --no-build'
+      zipAfterPublish: false
+      modifyOutputPath: false
 
-      - task: DeleteFiles@1
-        displayName: 'Delete unneeded publish files'
-        inputs:
-          SourceFolder: '$(SrcPath)'
-          Contents: |
-            bin/**/publish/**/*.exe
-            bin/**/publish/**/*.pdb
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet publish 7.0'
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: '$(ProjectPath)'
+      arguments: '--configuration $(BuildConfiguration) --framework net7.0 --no-build'
+      zipAfterPublish: false
+      modifyOutputPath: false
 
-      # Run before we build the signing project, because we don't want to analyze that
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
-        displayName: 'Run Roslyn Analyzers'
-        continueOnError: true
-        condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
-        inputs:
-          msBuildCommandline: '$(Agent.ToolsDirectory)\dotnet\dotnet.exe build "$(Build.SourcesDirectory)\$(ProjectPath)" --configuration $(BuildConfiguration)'
+  - task: DeleteFiles@1
+    displayName: 'Delete unneeded publish files'
+    inputs:
+      SourceFolder: '$(SrcPath)'
+      Contents: |
+        bin/**/publish/**/*.exe
+        bin/**/publish/**/*.pdb
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet restore signing'
-        inputs:
-          command: restore
-          projects: '$(SigningProjectPath)'
-          feedsToUse: config
-          nugetConfigPath: '$(NugetConfigPath)'
+  # Run before we build the signing project, because we don't want to analyze that
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
+    displayName: 'Run Roslyn Analyzers'
+    continueOnError: true
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+    inputs:
+      msBuildCommandline: '$(Agent.ToolsDirectory)\dotnet\dotnet.exe build "$(Build.SourcesDirectory)\$(ProjectPath)" --configuration $(BuildConfiguration)'
 
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet build signing'
-        inputs:
-          projects: '$(SigningProjectPath)'
-          arguments: '--configuration $(BuildConfiguration)'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet restore signing'
+    inputs:
+      command: restore
+      projects: '$(SigningProjectPath)'
+      feedsToUse: config
+      nugetConfigPath: '$(NugetConfigPath)'
 
-      - task: CopyFiles@2
-        displayName: 'Copy Files to Staging'
-        inputs:
-          SourceFolder: '$(system.defaultworkingdirectory)/tools/JsonCli/src/'
-          Contents: 'bin/**/publish/**'
-          TargetFolder: '$(DropPath)'
-        condition: succeededOrFailed()
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet build signing'
+    inputs:
+      projects: '$(SigningProjectPath)'
+      arguments: '--configuration $(BuildConfiguration)'
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: drop'
-        inputs:
-          PathtoPublish: '$(DropPath)'
-        condition: succeededOrFailed()
+  - task: CopyFiles@2
+    displayName: 'Copy Files to Staging'
+    inputs:
+      SourceFolder: '$(system.defaultworkingdirectory)/tools/JsonCli/src/'
+      Contents: 'bin/**/publish/**'
+      TargetFolder: '$(DropPath)'
+    condition: succeededOrFailed()
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-        displayName: 'Run BinSkim'
-        inputs:
-          InputType: Basic
-          AnalyzeTarget: '$(DropPath)\*.dll;$(DropPath)\*.exe'
-        continueOnError: true
-        condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    inputs:
+      PathtoPublish: '$(DropPath)'
+    condition: succeededOrFailed()
 
-      - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@2
-        displayName: 'Verify Signed Files'
-        inputs:
-          TargetFolders: '$(DropPath)'
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+    displayName: 'Run BinSkim'
+    inputs:
+      InputType: Basic
+      AnalyzeTarget: '$(DropPath)\*.dll;$(DropPath)\*.exe'
+    continueOnError: true
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-        displayName: 'Publish Security Analysis Logs'
-        condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+  - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@2
+    displayName: 'Verify Signed Files'
+    inputs:
+      TargetFolders: '$(DropPath)'
 
-      - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-        displayName: 'Post Analysis'
-        inputs:
-          AllTools: true
-        condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+    displayName: 'Publish Security Analysis Logs'
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-      - task: ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
-        condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
-        inputs:
-          sourceScanPath: tools/JsonCli # Scope only to the JSON CLI tool, since that's all this build is for
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+    displayName: 'Post Analysis'
+    inputs:
+      AllTools: true
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-trigger: none
-
-pr: none
+  - task: ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+    inputs:
+      sourceScanPath: tools/JsonCli # Scope only to the JSON CLI tool, since that's all this build is for


### PR DESCRIPTION
In order to satisfy CodeQL, we need to build the JsonCLI tool with every 1es pipeline run.

These changes convert the existing JsonCLI pipeline to be a template that we use within the 1es pipeline. In order to do this I had to copy what Brandon did here https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml so we can pass additional templates through to 1es.

This may take a few iterations to get right...