### PR TITLE
Convert JSON CLI tool pipeline to 1ES PT

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -15,15 +15,32 @@ schedules:
       include:
         - main
 
-# `resources` specifies the location of templates to pick up, use it to get AzExt templates
+# Note: not using template outlined in https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/README.md
+# so that we can customize sdl parameters.
+#
+# Instead, the rest of this is based on https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml
+
+# `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
-    - repository: azExtTemplates
-      type: github
-      name: microsoft/vscode-azuretools
-      ref: main
-      endpoint: GitHub-AzureTools # The service connection to use when accessing this repository
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
 
-# Use those templates
 extends:
-  template: azure-pipelines/1esmain.yml@azExtTemplates
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    sdl:
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
+      codeql:
+        language: javascript # only build a codeql database for javascript, since the jsoncli pipeline handles csharp
+      #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool
+      image: server2022-microbuildVS2022-1es # Name of the image in your pool. If not specified, first image of the pool is used
+      os: windows # OS of the image. Allowed values: windows, linux, macOS
+    stages:
+      # Execute stages from the AzExt stages template
+      - template: ./1esstages.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
     "files.exclude": {
-        "tools/JsonCli/src/**": true
+        "tools/JsonCli/src/**": false
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
     "files.exclude": {
-        "tools/JsonCli/src/**": false
+        "tools/JsonCli/src/**": true
     },
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,

--- a/tools/JsonCli/.azure-pipelines/1esmain.yml
+++ b/tools/JsonCli/.azure-pipelines/1esmain.yml
@@ -28,9 +28,9 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    # sdl:
-      # credscan:
-        # suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
+    sdl:
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       # codeql:
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
     pool:

--- a/tools/JsonCli/.azure-pipelines/1esmain.yml
+++ b/tools/JsonCli/.azure-pipelines/1esmain.yml
@@ -15,7 +15,11 @@ schedules:
       include:
         - main
 
-# under here is from https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml
+# Note: not using template outlined in https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/README.md
+# so that we can customize sdl parameters.
+#
+# Instead, the rest of this is based on https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml
+
 # `resources` specifies the location of templates to pick up, use it to get 1ES templates
 resources:
   repositories:
@@ -27,6 +31,8 @@ resources:
 
 variables:
   Codeql.BuildIdentifier: JsonCli
+  # Local analysis is only enabled on PR branches
+  Codeql.AnalyzeInPipeline: $[startsWith(variables['Build.SourceBranch'], 'refs/pull/')]
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -35,7 +41,7 @@ extends:
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
       codeql:
-        cadence: 0
+        language: csharp # only build a codeql database for csharp, since the pipeline at the root handles javascript
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool

--- a/tools/JsonCli/.azure-pipelines/1esmain.yml
+++ b/tools/JsonCli/.azure-pipelines/1esmain.yml
@@ -25,6 +25,9 @@ resources:
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
 
+variables:
+  Codeql.BuildIdentifier: JsonCli
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:

--- a/tools/JsonCli/.azure-pipelines/1esmain.yml
+++ b/tools/JsonCli/.azure-pipelines/1esmain.yml
@@ -31,7 +31,8 @@ extends:
     sdl:
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)\.azure-pipelines\compliance\CredScanSuppressions.json
-      # codeql:
+      codeql:
+        cadence: 0
       #   enabled: true # TODO: would like to enable only on scheduled builds but CodeQL cannot currently be disabled per https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql
     pool:
       name: VSEngSS-MicroBuild2022-1ES # Name of your hosted pool

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -1,5 +1,5 @@
 stages:
-  - stage: JsonCli_stage
+  - stage: dotnet_JsonCli_stage
     jobs:
       - job: JsonCli_job
         steps:

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -103,36 +103,36 @@ stages:
           #     PathtoPublish: '$(build.artifactstagingdirectory)/drop'
           #   condition: succeededOrFailed()
 
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-            displayName: 'Run BinSkim'
-            inputs:
-              InputType: Basic
-              AnalyzeTarget: '$(build.artifactstagingdirectory)/drop\*.dll;$(build.artifactstagingdirectory)/drop\*.exe'
-            continueOnError: true
-            condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+          # - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+          #   displayName: 'Run BinSkim'
+          #   inputs:
+          #     InputType: Basic
+          #     AnalyzeTarget: '$(build.artifactstagingdirectory)/drop\*.dll;$(build.artifactstagingdirectory)/drop\*.exe'
+          #   continueOnError: true
+          #   condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-          - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@2
-            displayName: 'Verify Signed Files'
-            inputs:
-              TargetFolders: '$(build.artifactstagingdirectory)/drop'
+          # - task: ms-vseng.MicroBuildShipTasks.7c429315-71ba-4cb3-94bb-f829c95f7915.MicroBuildCodesignVerify@2
+          #   displayName: 'Verify Signed Files'
+          #   inputs:
+          #     TargetFolders: '$(build.artifactstagingdirectory)/drop'
 
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-            displayName: 'Publish Security Analysis Logs'
-            condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+        #   - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+        #     displayName: 'Publish Security Analysis Logs'
+        #     condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-          - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-            displayName: 'Post Analysis'
-            inputs:
-              AllTools: true
-            condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+        #   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+        #     displayName: 'Post Analysis'
+        #     inputs:
+        #       AllTools: true
+        #     condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
 
-          - task: ComponentGovernanceComponentDetection@0
-            displayName: 'Component Detection'
-            condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
-            inputs:
-              sourceScanPath: tools/JsonCli # Scope only to the JSON CLI tool, since that's all this build is for
-        templateContext:
-          outputs:
-          - output: pipelineArtifact
-            path: $(build.artifactstagingdirectory)/drop
-            artifact: drop
+        #   - task: ComponentGovernanceComponentDetection@0
+        #     displayName: 'Component Detection'
+        #     condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
+        #     inputs:
+        #       sourceScanPath: tools/JsonCli # Scope only to the JSON CLI tool, since that's all this build is for
+        # templateContext:
+        #   outputs:
+        #   - output: pipelineArtifact
+        #     path: $(build.artifactstagingdirectory)/drop
+        #     artifact: drop

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -83,11 +83,11 @@ stages:
               feedsToUse: config
               nugetConfigPath: 'tools/JsonCli/src/nuget.config'
 
-          - task: DotNetCoreCLI@2
-            displayName: 'dotnet build signing'
-            inputs:
-              projects: 'tools/JsonCli/src/Signing.csproj'
-              arguments: '--configuration Release'
+          # - task: DotNetCoreCLI@2
+          #   displayName: 'dotnet build signing'
+          #   inputs:
+          #     projects: 'tools/JsonCli/src/Signing.csproj'
+          #     arguments: '--configuration Release'
 
           - task: CopyFiles@2
             displayName: 'Copy Files to Staging'

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -20,6 +20,11 @@ stages:
             inputs:
               version: 7.0.x
 
+          - task: UseDotNet@2
+            displayName: 'Use .NET sdk 8.0.x'
+            inputs:
+              version: 8.0.x
+
           - task: DotNetCoreCLI@2
             displayName: 'dotnet restore'
             inputs:

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -1,7 +1,7 @@
 stages:
-  - stage: dotnet_JsonCli_stage
+  - stage: DotNet_JsonCli_Stage
     jobs:
-      - job: JsonCli_job
+      - job: DotNet_JsonCli_Job
         steps:
           - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@2
             displayName: 'Install Signing Plugin'

--- a/tools/JsonCli/.azure-pipelines/main.yml
+++ b/tools/JsonCli/.azure-pipelines/main.yml
@@ -37,7 +37,7 @@ stages:
             displayName: 'dotnet build'
             inputs:
               projects: 'tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj'
-              arguments: '--configuration $(BuildConfiguration)'
+              arguments: '--configuration Release'
 
           - task: DotNetCoreCLI@2
             displayName: 'dotnet publish 6.0'
@@ -45,7 +45,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: 'tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj'
-              arguments: '--configuration $(BuildConfiguration) --framework net6.0 --no-build'
+              arguments: '--configuration Release --framework net6.0 --no-build'
               zipAfterPublish: false
               modifyOutputPath: false
 
@@ -55,7 +55,7 @@ stages:
               command: publish
               publishWebProjects: false
               projects: 'tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj'
-              arguments: '--configuration $(BuildConfiguration) --framework net7.0 --no-build'
+              arguments: '--configuration Release --framework net7.0 --no-build'
               zipAfterPublish: false
               modifyOutputPath: false
 
@@ -73,7 +73,7 @@ stages:
             continueOnError: true
             condition: eq(variables['ENABLE_COMPLIANCE'], 'true')
             inputs:
-              msBuildCommandline: '$(Agent.ToolsDirectory)\dotnet\dotnet.exe build "$(Build.SourcesDirectory)\tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj" --configuration $(BuildConfiguration)'
+              msBuildCommandline: '$(Agent.ToolsDirectory)\dotnet\dotnet.exe build "$(Build.SourcesDirectory)\tools/JsonCli/src/Microsoft.TemplateEngine.JsonCli.csproj" --configuration Release'
 
           - task: DotNetCoreCLI@2
             displayName: 'dotnet restore signing'
@@ -87,7 +87,7 @@ stages:
             displayName: 'dotnet build signing'
             inputs:
               projects: 'tools/JsonCli/src/Signing.csproj'
-              arguments: '--configuration $(BuildConfiguration)'
+              arguments: '--configuration Release'
 
           - task: CopyFiles@2
             displayName: 'Copy Files to Staging'

--- a/tools/JsonCli/src/Signing.csproj
+++ b/tools/JsonCli/src/Signing.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
         <!-- Since this project is just for signing, we don't want to actually build anything -->
         <DefaultItemExcludes>$(DefaultItemExcludes);**/*.cs</DefaultItemExcludes>
     </PropertyGroup>


### PR DESCRIPTION
I had to customize sdl parameters in each pipeline which meant instead of using the [template provided by Brandon](https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/README.md), I just used the pipeline file behind the template from [here](https://github.com/microsoft/vscode-azuretools/blob/main/azure-pipelines/1esmain.yml).

The sdl params I had to customize are the codeql language parameter so that I can force the root pipeline to only generate a database for javascript, and the json cli tool pipeline to only generate a database for csharp. Details about the language parameter are here: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/1es-codeql

The signing step for the json cli tool wasn't working so I'm commenting it out for now, and will get it working later. Currently getting codeql up and running is higher priority. We only need to sign this when making changes to the json cli tool and releasing it.