### PR TITLE
Add new command `deployByFunctionAppId`

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,6 +215,12 @@
                 "enablement": "!virtualWorkspace"
             },
             {
+                "command": "azureFunctions.deployByFunctionAppId",
+                "title": "%azureFunctions.deployByFunctionAppId%",
+                "category": "Azure Functions",
+                "enablement": "!virtualWorkspace"
+            },
+            {
                 "command": "azureFunctions.deploySlot",
                 "title": "%azureFunctions.deploySlot%",
                 "category": "Azure Functions",
@@ -662,6 +668,10 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "azureFunctions.deployByFunctionAppId",
+                    "when": "never"
+                },
                 {
                     "command": "azureFunctions.openInPortal",
                     "when": "never"

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,6 +25,7 @@
     "azureFunctions.deleteFunctionApp": "Delete Function App...",
     "azureFunctions.deleteSlot": "Delete Slot...",
     "azureFunctions.deploy": "Deploy to Function App...",
+    "azureFunctions.deployByFunctionAppId": "Deploy to Function App by ID...",
     "azureFunctions.deploySlot": "Deploy to Slot...",
     "azureFunctions.deploySubpath": "The default subpath of a workspace folder to use when deploying. If set, you will not be prompted for the folder path when deploying.",
     "azureFunctions.description": "An Azure Functions extension for Visual Studio Code.",

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -37,9 +37,6 @@ export async function deployProductionSlot(context: IActionContext, target?: vsc
     await deploy(context, target, undefined);
 }
 
-/**
- *
- */
 export async function deployProductionSlotByFunctionAppId(context: IActionContext, functionAppId?: string | {}): Promise<void> {
     await deploy(context, undefined, functionAppId);
 }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -33,8 +33,15 @@ import { verifyAppSettings } from './verifyAppSettings';
 
 export type IFuncDeployContext = IDeployContext & ISetConnectionSettingContext & ExecuteActivityContext;
 
-export async function deployProductionSlot(context: IActionContext, target?: vscode.Uri | string | SlotTreeItem, functionAppId?: string | {}): Promise<void> {
-    await deploy(context, target, functionAppId);
+export async function deployProductionSlot(context: IActionContext, target?: vscode.Uri | string | SlotTreeItem): Promise<void> {
+    await deploy(context, target, undefined);
+}
+
+/**
+ *
+ */
+export async function deployProductionSlotByFunctionAppId(context: IActionContext, functionAppId?: string | {}): Promise<void> {
+    await deploy(context, undefined, functionAppId);
 }
 
 export async function deploySlot(context: IActionContext, target?: vscode.Uri | string | SlotTreeItem, functionAppId?: string | {}): Promise<void> {

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -38,7 +38,7 @@ import { createSlot } from './createSlot';
 import { deleteFunction } from './deleteFunction';
 import { deleteFunctionApp } from './deleteFunctionApp';
 import { deleteNode } from './deleteNode';
-import { deployProductionSlot, deploySlot } from './deploy/deploy';
+import { deployProductionSlot, deployProductionSlotByFunctionAppId, deploySlot } from './deploy/deploy';
 import { connectToGitHub } from './deployments/connectToGitHub';
 import { disconnectRepo } from './deployments/disconnectRepo';
 import { redeployDeployment } from './deployments/redeployDeployment';
@@ -112,6 +112,7 @@ export function registerCommands(): void {
     );
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disableFunction', disableFunction);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploy', deployProductionSlot);
+    registerCommand('azureFunctions.deployByFunctionAppId', deployProductionSlotByFunctionAppId);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploySlot', deploySlot);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disconnectRepo', disconnectRepo);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.enableFunction', enableFunction);

--- a/src/commands/registerCommands.ts
+++ b/src/commands/registerCommands.ts
@@ -112,7 +112,10 @@ export function registerCommands(): void {
     );
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disableFunction', disableFunction);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploy', deployProductionSlot);
+
+    // See: https://github.com/microsoft/vscode-azurefunctions/pull/4125
     registerCommand('azureFunctions.deployByFunctionAppId', deployProductionSlotByFunctionAppId);
+
     registerCommandWithTreeNodeUnwrapping('azureFunctions.deploySlot', deploySlot);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.disconnectRepo', disconnectRepo);
     registerCommandWithTreeNodeUnwrapping('azureFunctions.enableFunction', enableFunction);


### PR DESCRIPTION
One or more teams currently leverage our deploy command directly using `commands.executeCommand`.  We previously allowed the `functionAppId` target to be passed as a third argument into `deployProductionSlot`.  Upon investigation, I noticed that only the first arg was being passed down when wrapped with `registerCommandWithTreeNodeUnwrapping`.  

Calling with `registerCommand` instead seems to preserve all args.  As a workaround, I have created a command for these teams to utilize directly where the only thing you need to pass it is the `functionAppId`.  This is probably better also because they are not really ever passing a tree item anyway, so we don't ever need to unwrap for their use-case.