### PR TITLE
expanding in-proc .NET support

### DIFF
--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -54,9 +54,12 @@ export namespace cliFeedUtils {
     }
 
     export async function getLatestVersion(context: IActionContext, version: FuncVersion): Promise<string> {
-        const cliFeed: ICliFeed = await getCliFeed(context);
-
         const majorVersion: string = getMajorVersion(version);
+        return await getLatestReleaseVersionForMajorVersion(context, majorVersion);
+    }
+
+    export async function getLatestReleaseVersionForMajorVersion(context: IActionContext, majorVersion: string): Promise<string> {
+        const cliFeed: ICliFeed = await getCliFeed(context);
         let tag: string = 'v' + majorVersion;
         const templateProvider = ext.templateProvider.get(context);
         if (templateProvider.templateSource === TemplateSource.Staging) {


### PR DESCRIPTION
This PR expands the lookup behavior for templating to accommodate upcoming changes to the tooling feed. These will allow us to better serve the in-process model templates.

Structurally, the behavior is to, for V4 only, we pull additional information from an additional tag surfaced by the feed.

I have validated these changes with a local version of the tooling feed using those changes.