### PR TITLE
Display a warning after deploying a blob trigger to a flex consumption app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1088,6 +1088,11 @@
                         "type": "boolean",
                         "description": "%azureFunctions.enableFlexConsumption%",
                         "default": false
+                    },
+                    "azureFunctions.showFlexEventGridWarning": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.showFlexEventGridWarning%",
+                        "default": true
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -80,6 +80,7 @@
     "azureFunctions.showDeprecatedStacks": "Show deprecated runtime stacks when creating a Function App in Azure. WARNING: These stacks may be removed at any time and may not be available in all regions.",
     "azureFunctions.showExplorer": "Show or hide the Azure Functions Explorer",
     "azureFunctions.showExtensionsCsprojWarning": "Show a warning when an Azure Functions project was detected that has mismatched \"extensions.csproj\" configuration.",
+    "%azureFunctions.showFlexEventGridWarning%": "Show a warning when deploying a Azure Blob Storage Trigger (using Event Grid) to a Flex Consumption Function App.",
     "azureFunctions.showHiddenStacks": "Show hidden runtime stacks when creating a Function App in Azure. WARNING: These stacks may be in preview or may not be available in all regions.",
     "azureFunctions.showMultiCoreToolsWarning": "Show a warning if multiple installs of Azure Functions Core Tools are detected.",
     "azureFunctions.showProjectWarning": "Show a warning when an Azure Functions project was detected that has not been initialized for use in VS Code.",

--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -133,7 +133,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStep<IFunctionAppWi
                 version: sku.functionAppConfigProperties.runtime.version
             },
             scaleAndConcurrency: {
-                maximumInstanceCount: context.newFlexInstanceMemoryMB ?? sku.maximumInstanceCount.defaultValue,
+                maximumInstanceCount: context.newFlexMaximumInstanceCount ?? sku.maximumInstanceCount.defaultValue,
                 instanceMemoryMB: context.newFlexInstanceMemoryMB ?? sku.instanceMemoryMB.find(im => im.isDefault)?.size ?? 2048,
                 alwaysReady: [],
                 triggers: null

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -128,8 +128,6 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         await validateSqlDbConnection(context, context.projectPath);
     }
 
-    // prompt for event grid storage thing here?
-
     if (getWorkspaceSetting<boolean>('showDeployConfirmation', context.workspaceFolder.uri.fsPath) && !context.isNewApp && isZipDeploy) {
         const deployCommandId = 'azureFunctions.deploy';
         await showDeployConfirmation(context, node.site, deployCommandId);

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -46,7 +46,7 @@ export async function promptForEventGrid(context: IActionContext, workspaceFolde
 
     const eventGridWarning = localize(
         'eventGridWarning',
-        `Usage of an Event Grid based blob trigger requires an Event Grid subscription created on an Azure Storage v2 account. If you don't already, you need to create a Event Grid subscription to complete your deployment.`);
+        `Usage of an Event Grid based blob trigger requires an Event Grid subscription created on an Azure Storage v2 account. If you haven't already, you need to create a Event Grid subscription to complete your deployment.`);
     const options: IAzureMessageOptions = { learnMoreLink: 'https://aka.ms/learnMoreEventGridSubscription' };
     // need to add don't show again
     const result = await context.ui.showWarningMessage(eventGridWarning, options, { title: 'Close' }, DialogResponses.dontWarnAgain);

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -1,8 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 import { type FunctionEnvelope } from "@azure/arm-appservice";
-import { type IActionContext, type IAzureMessageOptions } from "@microsoft/vscode-azext-utils";
+import { DialogResponses, type IActionContext, type IAzureMessageOptions } from "@microsoft/vscode-azext-utils";
 import * as retry from 'p-retry';
 import { type WorkspaceFolder } from "vscode";
-import { DialogResponses } from "../../../extension.bundle";
 import { localize } from "../../localize";
 import { type IBindingTemplate } from "../../templates/IBindingTemplate";
 import { type SlotTreeItem } from "../../tree/SlotTreeItem";

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -1,7 +1,7 @@
 import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
 import { createGenericClient, type AzExtPipelineResponse } from "@microsoft/vscode-azext-azureutils";
 import { openUrl, type IActionContext } from "@microsoft/vscode-azext-utils";
-import { type MessageItem } from "vscode";
+import { commands, type MessageItem } from "vscode";
 import { localize } from "../../localize";
 import { type SlotTreeItem } from "../../tree/SlotTreeItem";
 import { listLocalFunctions } from "../../workspace/listLocalFunctions";
@@ -36,6 +36,7 @@ export async function hasLocalEventGridBlobTrigger(projectPath: string): Promise
     const deployedProject = projects.initializedProjects.find(p => p.options.effectiveProjectPath === projectPath);
     if (deployedProject) {
         const functions = await listLocalFunctions(deployedProject as LocalProjectInternal);
+        await commands.executeCommand('azureFunctions.executeFunction', functions.functions[0]);
         return functions.functions.some(f => f.triggerBindingType === 'blobTrigger');
     }
 

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -1,0 +1,53 @@
+import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { createGenericClient, type AzExtPipelineResponse } from "@microsoft/vscode-azext-azureutils";
+import { openUrl, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { type MessageItem } from "vscode";
+import { localize } from "../../localize";
+import { type SlotTreeItem } from "../../tree/SlotTreeItem";
+import { listLocalFunctions } from "../../workspace/listLocalFunctions";
+import { listLocalProjects, type LocalProjectInternal } from "../../workspace/listLocalProjects";
+
+export async function hasEventSystemTopics(context: IActionContext, node: SlotTreeItem): Promise<boolean> {
+    const client = await createGenericClient(context, node.subscription);
+    const headers = createHttpHeaders({
+        'Content-Type': 'application/json',
+    });
+    const options = createPipelineRequest({
+        url: `/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01`,
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+            query: `where type =~ 'Microsoft.EventGrid/systemTopics' | where properties.topicType =~ 'Microsoft.Web.sites' | where properties.source =~ '${node.id}' | project id`,
+            subscriptions: [node.subscription.subscriptionId]
+        })
+    });
+
+    const response = await client.sendRequest(options) as AzExtPipelineResponse;
+    const body = response.parsedBody as { count: number };
+    if (body.count >= 1) {
+        return true;
+    }
+
+    return false;
+}
+
+export async function hasLocalEventGridBlobTrigger(projectPath: string): Promise<boolean> {
+    const projects = await listLocalProjects();
+    const deployedProject = projects.initializedProjects.find(p => p.options.effectiveProjectPath === projectPath);
+    if (deployedProject) {
+        const functions = await listLocalFunctions(deployedProject as LocalProjectInternal);
+        return functions.functions.some(f => f.triggerBindingType === 'blobTrigger');
+    }
+
+    return false;
+}
+
+export async function promptForEventGrid(context: IActionContext): Promise<void> {
+    const eventGridWarning = localize('eventGridWarning', `Usage of Event Grid based blob trigger requires an Event Grid subscription created on an Azure Storage v2 account. If you don't already have a subscription created, create one before continuing with deployment.`);
+    const btns: MessageItem[] = [{ title: localize('createSub', 'Create a subscription') }, { title: localize('continue', 'Continue with deployment') }];
+    const result = await context.ui.showWarningMessage(eventGridWarning, { modal: true }, ...btns);
+
+    if (result.title === btns[0].title) {
+        await openUrl('https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger?tabs=isolated-process%2Cnodejs-v4&pivots=programming-language-csharp#create-the-event-subscription');
+    }
+}

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -48,10 +48,8 @@ export async function promptForEventGrid(context: IActionContext, workspaceFolde
         'eventGridWarning',
         `Usage of an Event Grid based blob trigger requires an Event Grid subscription created on an Azure Storage v2 account. If you haven't already, you need to create a Event Grid subscription to complete your deployment.`);
     const options: IAzureMessageOptions = { learnMoreLink: 'https://aka.ms/learnMoreEventGridSubscription' };
-    // need to add don't show again
     const result = await context.ui.showWarningMessage(eventGridWarning, options, { title: 'Close' }, DialogResponses.dontWarnAgain);
     if (result === DialogResponses.dontWarnAgain) {
         await updateWorkspaceSetting('showFlexEventGridWarning', false, workspaceFolder);
     }
-
 }


### PR DESCRIPTION
For Azure Storage Blob Triggers (Using Event Grid) to work on a live Function App, there are further steps that need to be done.

You can read about that here: https://aka.ms/learnMoreEventGridSubscription

This is just an interim solution, but basically we want to let users know about the next steps whenever they deploy a blobTrigger to a flex app.