### PR TITLE
Add EventGridBlobTrigger to the verified list

### DIFF
--- a/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
+++ b/src/templates/dotnet/getDotnetVerifiedTemplateIds.ts
@@ -18,6 +18,8 @@ export function getDotnetVerifiedTemplateIds(version: string): RegExp[] {
         'CosmosDBTrigger',
         'EventGridTrigger',
         'EventGridCloudEventTrigger',
+        //TODO: Add unit test for EventGridBlobTrigger
+        'EventGridBlobTrigger,'
     ];
 
     if (version === FuncVersion.v1) {

--- a/src/templates/script/getScriptVerifiedTemplateIds.ts
+++ b/src/templates/script/getScriptVerifiedTemplateIds.ts
@@ -35,6 +35,8 @@ export function getScriptVerifiedTemplateIds(version: string): (string | RegExp)
             'ServiceBusTopicTrigger',
             'SendGrid',
             'IoTHubTrigger',
+            //TODO: Add unit test for EventGridBlobTrigger
+            'EventGridBlobTrigger'
         ]);
 
         // These languages are only supported in v2+ - same functions as JavaScript, with a few minor exceptions that aren't worth distinguishing here


### PR DESCRIPTION
It's hard to add tests for these atm since not all languages are even shipping it right now, but the Function team wants EventGridBlobTrigger in the verified list since BlobTriggers won't work for flex consumption.

EDIT: I know that these will break the tests atm, but I'll fix that post-build.