### PR TITLE
Support create java 21 functions project 

### DIFF
--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -12,6 +12,7 @@ import { getJavaVersion } from "./JavaVersions";
 export const java8: string = '8';
 export const java11: string = '11';
 export const java17: string = '17';
+export const java21: string = '21';
 
 type javaVersionInfo = {
     label: string,
@@ -23,7 +24,8 @@ type javaVersionInfo = {
 const versionInfo: javaVersionInfo[] = [
     { label: 'Java 8', data: java8, miniFunc: '1.0.0' },
     { label: 'Java 11', data: java11, miniFunc: '3.0.2630' },
-    { label: 'Java 17', data: java17, miniFunc: '4.0.0' }
+    { label: 'Java 17', data: java17, miniFunc: '4.0.0' },
+    { label: 'Java 21', data: java21, miniFunc: '4.0.0' }
 ];
 
 export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardContext> {


### PR DESCRIPTION
Add `Java 21` option in java version step of java function creation wizard, fixes #4159 