### PR TITLE
Remove "Attach Debugger" from containerized function apps context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,7 +505,7 @@
                 },
                 {
                     "command": "azureFunctions.startJavaRemoteDebug",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot/ && config.azureFunctions.enableJavaRemoteDebugging == true",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(Production|)Slot(?!.*container)/ && config.azureFunctions.enableJavaRemoteDebugging == true",
                     "group": "5@2"
                 },
                 {


### PR DESCRIPTION
This is only happening when setting "Enable Java Remote Debugging" is enabled. 

Fixes #4124.