### PR TITLE
Keep ordering of child nodes the same for containerized function apps

### DIFF
--- a/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
+++ b/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
@@ -137,7 +137,7 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
             contextValuesToAdd: ['azFunc', 'container'],
         });
 
-        const children: AzExtTreeItem[] = [this._functionsTreeItem, this._imageTreeItem, this.appSettingsTreeItem]
+        const children: AzExtTreeItem[] = [this._functionsTreeItem, this.appSettingsTreeItem, this._imageTreeItem,]
 
         return children;
     }
@@ -179,5 +179,9 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
         }
 
         return undefined
+    }
+
+    public compareChildrenImpl(): number {
+        return 0; // already sorted
     }
 }


### PR DESCRIPTION
Fixes #4166 

The order is now like this which matches normal functions apps: 
![image](https://github.com/microsoft/vscode-azurefunctions/assets/59709511/0cdf8ea9-53bc-4df9-99fc-36fe7f2170a0)
