### PR TITLE
Add an error when deploying a containerized function app instead of filtering out containerized function apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -445,7 +445,7 @@
                 },
                 {
                     "command": "azureFunctions.deploy",
-                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(ProductionSlot|Flex)(?!.*container)/",
+                    "when": "view =~ /(azureResourceGroups|azureFocusView)/ && viewItem =~ /azFunc(ProductionSlot|Flex)/",
                     "group": "2@1"
                 },
                 {

--- a/src/commands/deploy/FunctionAppListStep.ts
+++ b/src/commands/deploy/FunctionAppListStep.ts
@@ -26,7 +26,7 @@ export class FunctionAppListStep extends AzureWizardPromptStep<IFuncDeployContex
     private async getPicks(context: IFuncDeployContext): Promise<IAzureQuickPickItem<Site | undefined>[]> {
         const client = await createWebSiteClient([context, createSubscriptionContext(nonNullProp(context, 'subscription'))]);
         const sites = (await uiUtils.listAllIterator(client.webApps.list()));
-        const qp: IAzureQuickPickItem<Site | undefined>[] = sites.filter(s => !s.kind?.includes('container') && !!s.kind?.includes('functionapp')).map(fa => {
+        const qp: IAzureQuickPickItem<Site | undefined>[] = sites.filter(s => !!s.kind?.includes('functionapp')).map(fa => {
             return {
                 label: nonNullProp(fa, 'name'),
                 description: parseAzureResourceGroupId(nonNullProp(fa, 'id')).resourceGroup,

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -84,6 +84,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     if (node.contextValue.includes('container')) {
         const learnMoreLink: string = 'https://aka.ms/deployContainerApps'
         await context.ui.showWarningMessage(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure Functions extension. Please use the Azure Container Apps extension to deploy your project.'), { learnMoreLink });
+        //suppress display of error message
         context.errorHandling.suppressDisplay = true;
         throw new Error(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure functions extension. Please use the Azure Container Apps extension to deploy your project. For more information go to aka.ms/deployContainerApps.'));
     }

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -81,6 +81,13 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         return await getOrCreateFunctionApp(context)
     });
 
+    if (node.contextValue.includes('container')) {
+        const learnMoreLink: string = 'https://aka.ms/deployContainerApps'
+        await context.ui.showWarningMessage(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure Functions extension. Please use the Azure Container Apps extension to deploy your project.'), { learnMoreLink });
+        context.errorHandling.suppressDisplay = true;
+        throw new Error(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure functions extension. Please use the Azure Container Apps extension to deploy your project. For more information go to aka.ms/deployContainerApps.'));
+    }
+
     const { language, languageModel, version } = await verifyInitForVSCode(context, context.effectiveDeployFsPath);
 
     context.telemetry.properties.projectLanguage = language;

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -86,7 +86,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         await context.ui.showWarningMessage(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure Functions extension. Please use the Azure Container Apps extension to deploy your project.'), { learnMoreLink });
         //suppress display of error message
         context.errorHandling.suppressDisplay = true;
-        throw new Error(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure functions extension. Please use the Azure Container Apps extension to deploy your project. For more information go to aka.ms/deployContainerApps.'));
+        throw new Error();
     }
 
     const { language, languageModel, version } = await verifyInitForVSCode(context, context.effectiveDeployFsPath);

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -86,6 +86,7 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         await context.ui.showWarningMessage(localize('containerFunctionAppError', 'Deploy is not supported for containerized function apps within the Azure Functions extension. Please use the Azure Container Apps extension to deploy your project.'), { learnMoreLink });
         //suppress display of error message
         context.errorHandling.suppressDisplay = true;
+        context.telemetry.properties.error = 'Deploy not supported for containerized function apps';
         throw new Error();
     }
 


### PR DESCRIPTION
Here is what the warning looks like: 
![image](https://github.com/microsoft/vscode-azurefunctions/assets/59709511/187ccb33-414d-4f95-80df-96c5919cc90e)

It will point to a new github wiki page with instructions on how to deploy.

Todo: 
Add a button to install ACA