### PR TITLE
Fix "+ Create new function app" error while deploying 

### DIFF
--- a/src/commands/deploy/getOrCreateFunctionApp.ts
+++ b/src/commands/deploy/getOrCreateFunctionApp.ts
@@ -32,13 +32,9 @@ export async function getOrCreateFunctionApp(context: IFuncDeployContext & Parti
         context.activityTitle = localize('functionAppCreateActivityTitle', 'Create Function App "{0}"', nonNullProp(context, 'newSiteName'))
         await wizard.execute();
 
-        if (context.dockerfilePath) {
-            const resolved = new ResolvedContainerizedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'))
-            node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
-        } else {
-            const resolved = new ResolvedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'));
-            node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
-        }
+        const resolved = context.dockerfilePath ? new ResolvedContainerizedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site')) :
+            new ResolvedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'));
+        node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
 
         await ext.rgApi.tree.refresh(context);
 

--- a/src/commands/deploy/getOrCreateFunctionApp.ts
+++ b/src/commands/deploy/getOrCreateFunctionApp.ts
@@ -10,6 +10,7 @@ import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
 import { ResolvedFunctionAppResource } from "../../tree/ResolvedFunctionAppResource";
 import { type SlotTreeItem } from "../../tree/SlotTreeItem";
+import { ResolvedContainerizedFunctionAppResource } from "../../tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 import { SubscriptionListStep } from "../SubscriptionListStep";
 import { type IFunctionAppWizardContext } from "../createFunctionApp/IFunctionAppWizardContext";
 import { FunctionAppListStep } from "./FunctionAppListStep";
@@ -31,10 +32,16 @@ export async function getOrCreateFunctionApp(context: IFuncDeployContext & Parti
         context.activityTitle = localize('functionAppCreateActivityTitle', 'Create Function App "{0}"', nonNullProp(context, 'newSiteName'))
         await wizard.execute();
 
-        const resolved = new ResolvedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'));
+        if (context.dockerfilePath) {
+            const resolved = new ResolvedContainerizedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'))
+            node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
+        } else {
+            const resolved = new ResolvedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site'));
+            node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
+        }
+
         await ext.rgApi.tree.refresh(context);
 
-        node = await ext.rgApi.tree.findTreeItem(resolved.id, context);
         context.isNewApp = true;
     }
 


### PR DESCRIPTION
Fixes #4175 

Needed to add the `ResolvedContainerizedFunctionAppResource` being created when containerized function apps are being created through the deploy path. This is set up similarly to how it is done in `SubscriptionTreeItem`. 