### PR TITLE
Add progress message to deploy after function app is picked

### DIFF
--- a/src/commands/deploy/getOrCreateFunctionApp.ts
+++ b/src/commands/deploy/getOrCreateFunctionApp.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice";
-import { AzureWizard, nonNullProp, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
-import { l10n } from "vscode";
+import { AzureWizard, nonNullProp, nonNullValueAndProp, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { ProgressLocation, l10n, window } from "vscode";
 import { ext } from "../../extensionVariables";
 import { localize } from "../../localize";
 import { ResolvedFunctionAppResource } from "../../tree/ResolvedFunctionAppResource";
@@ -25,7 +25,14 @@ export async function getOrCreateFunctionApp(context: IFuncDeployContext & Parti
 
     await wizard.prompt();
 
-    node = context.site ? await ext.rgApi.tree.findTreeItem(nonNullProp(context.site, 'id'), context) : undefined;
+    if (context.site) {
+        await window.withProgress({ location: ProgressLocation.Notification, cancellable: false, title: localize('deploySetUp', 'Loading deployment configurations...') },
+            async () => {
+                node = await ext.rgApi.tree.findTreeItem(nonNullValueAndProp(context.site, 'id'), context)
+            });
+    } else {
+        node = undefined
+    }
 
     // if there was no node, then the user is creating a new function app
     if (!node) {


### PR DESCRIPTION
Fixes #4189.

findTreeItem takes around 10-15 seconds to finish so it can be a little confusing to users why nothing is happening after they pick a function app. This occurs with both regular and containerized apps. 

On another note, currently `getOrCreateFunctionApp` is only being used in deploy so this shouldn't be shown anywhere else. Not sure if we want to make a note that this function should only be used with deploy due to the message or do something else? 