### PR TITLE
Default `parameters.enableLongRunningTests` to `true`

### DIFF
--- a/.azure-pipelines/1esmain.yml
+++ b/.azure-pipelines/1esmain.yml
@@ -37,7 +37,7 @@ parameters:
   - name: enableLongRunningTests
     displayName: Enable Long Running Tests
     type: boolean
-    default: false
+    default: true
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines


### PR DESCRIPTION
Hossam had a good idea about just defaulting these to true since they only get triggered on updates to `main` or `rel/*`.

We can keep the parameter available still in case people want to opt out of the long running tests when triggering manually.