### PR TITLE
Enable long running tests

### DIFF
--- a/test/nightly/functionAppOperations.test.ts
+++ b/test/nightly/functionAppOperations.test.ts
@@ -12,7 +12,7 @@ import { DialogResponses, ProjectLanguage, createFunctionAppAdvanced, deleteFunc
 import { cleanTestWorkspace, longRunningTestsEnabled } from '../global.test';
 import { runWithFuncSetting } from '../runWithSetting';
 import { getRotatingLocation, getRotatingNodeVersion } from './getRotatingValue';
-import { resourceGroupsToDelete, testAccount, testClient } from './global.nightly.test';
+import { resourceGroupsToDelete, subscriptionContext, testClient } from './global.nightly.test';
 
 suite('Function App Operations', function (this: Mocha.Suite): void {
     this.timeout(7 * 60 * 1000);
@@ -73,7 +73,7 @@ suite('Function App Operations', function (this: Mocha.Suite): void {
 
         await runWithFuncSetting('projectLanguage', ProjectLanguage.JavaScript, async () => {
             await runWithInputs(commandId, inputs, registerOnActionStartHandler, async () => {
-                const actualFuncAppId: string = <string>await vscode.commands.executeCommand(commandId, testAccount.getSubscriptionContext().subscriptionId, apiRgName);
+                const actualFuncAppId: string = <string>await vscode.commands.executeCommand(commandId, subscriptionContext.subscriptionId, apiRgName);
                 const site: Site | undefined = await tryGetWebApp(testClient, apiRgName, apiAppName);
                 assert.ok(site);
                 assert.equal(actualFuncAppId, site.id);

--- a/test/nightly/global.nightly.test.ts
+++ b/test/nightly/global.nightly.test.ts
@@ -14,7 +14,7 @@ import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import * as vscode from 'vscode';
 
 export let testClient: WebSiteManagementClient;
-export let context: TestActionContext;
+let testContext: TestActionContext;
 export let subscriptionContext: ISubscriptionContext;
 export const resourceGroupsToDelete: string[] = [];
 
@@ -23,13 +23,12 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
     if (longRunningTestsEnabled) {
         this.timeout(2 * 60 * 1000);
 
-        // testAccount = new TestAzureAccount(vscode);
         await vscode.commands.executeCommand('azureResourceGroups.logIn');
         ext.azureAccountTreeItem = new AzureAccountTreeItemWithProjects();
-        context = await createTestActionContext();
-        const subscription: AzureSubscription = await subscriptionExperience(context, ext.rgApi.appResourceTree);
+        testContext = await createTestActionContext();
+        const subscription: AzureSubscription = await subscriptionExperience(testContext, ext.rgApi.appResourceTree);
         subscriptionContext = createSubscriptionContext(subscription);
-        testClient = createAzureClient([context, subscriptionContext], WebSiteManagementClient);
+        testClient = createAzureClient([testContext, subscriptionContext], WebSiteManagementClient);
     }
 });
 
@@ -43,7 +42,7 @@ suiteTeardown(async function (this: Mocha.Context): Promise<void> {
 });
 
 async function deleteResourceGroups(): Promise<void> {
-    const rgClient: ResourceManagementClient = createAzureClient([context, subscriptionContext], ResourceManagementClient);
+    const rgClient: ResourceManagementClient = createAzureClient([testContext, subscriptionContext], ResourceManagementClient);
     await Promise.all(resourceGroupsToDelete.map(async resourceGroup => {
         if ((await rgClient.resourceGroups.checkExistence(resourceGroup)).body) {
             console.log(`Started delete of resource group "${resourceGroup}"...`);


### PR DESCRIPTION
Modify the nightly tests to leverage the new resource groups extension release and use federated credentials for long-running tests