### PR TITLE
Upgrade appservice SDK for Flex Consumption support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-alpha.20230530.1",
-                "@azure/arm-appservice": "^14.0.0",
+                "@azure/arm-appservice": "^15.0.0",
                 "@azure/arm-cosmosdb": "^15.0.0",
                 "@azure/arm-eventhub": "^5.1.0",
                 "@azure/arm-servicebus": "^5.0.0",
@@ -118,16 +118,16 @@
             }
         },
         "node_modules/@azure/arm-appservice": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.1.0.tgz",
-            "integrity": "sha512-dRhYI8HQ49DQrT91RzIjIa22bs2Pw/2mPtW+4a6ED5lzQ6IMPP0XEPXSSqqkPKedZRXRaZqazi16/QjuidJPnQ==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-15.0.0.tgz",
+            "integrity": "sha512-huJ2uFDXB7w0cYKqxhzYOHuTsuLCY1e0xmWFF8G3KpDbQGnFDM3AVNtxWPas50OxuSWClblqSaExiS/XnWhTTg==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
+                "@azure/core-auth": "^1.6.0",
                 "@azure/core-client": "^1.7.0",
                 "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.12.0",
+                "@azure/core-rest-pipeline": "^1.14.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
@@ -335,15 +335,27 @@
             }
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+            "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.1.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/core-client": {
@@ -425,21 +437,55 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.13.0.tgz",
-            "integrity": "sha512-a62aP/wppgmnfIkJLfcB4ssPBcH94WzrzPVJ3tlJt050zX4lfmtnvy95D3igDo3f31StO+9BgPrzvkj4aOxnoA==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.1.tgz",
+            "integrity": "sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==",
             "dependencies": {
-                "@azure/abort-controller": "^1.1.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.3.0",
+                "@azure/core-util": "^1.9.0",
                 "@azure/logger": "^1.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0"
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline/node_modules/https-proxy-agent": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/@azure/core-tracing": {
@@ -454,15 +500,26 @@
             }
         },
         "node_modules/@azure/core-util": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
-            "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+            "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
             "dependencies": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/logger": {
@@ -921,6 +978,23 @@
             "peerDependencies": {
                 "@azure/ms-rest-azure-env": "^2.0.0",
                 "@microsoft/vscode-azext-azureappsettings": "^0.2.0"
+            }
+        },
+        "node_modules/@microsoft/vscode-azext-azureappservice/node_modules/@azure/arm-appservice": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.0.0.tgz",
+            "integrity": "sha512-tU0ld4B230qsPrk7pmcpiQWkufB/SfON5If8sUR3nsWcEvprB6iZqr1OC4ETjgtAYabNCq22OFquuUizGCoAYQ==",
+            "dependencies": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-auth": "^1.3.0",
+                "@azure/core-client": "^1.7.0",
+                "@azure/core-lro": "^2.5.0",
+                "@azure/core-paging": "^1.2.0",
+                "@azure/core-rest-pipeline": "^1.8.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappservice/node_modules/fs-extra": {
@@ -1515,14 +1589,6 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/@tsconfig/node10": {
@@ -2347,6 +2413,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "dependencies": {
                 "debug": "4"
             },
@@ -5871,16 +5938,26 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dependencies": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
+            }
+        },
+        "node_modules/http-proxy-agent/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/http-signature": {
@@ -5908,6 +5985,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "dependencies": {
                 "agent-base": "6",
                 "debug": "4"
@@ -9702,9 +9780,9 @@
             }
         },
         "node_modules/tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -10913,16 +10991,16 @@
             }
         },
         "@azure/arm-appservice": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.1.0.tgz",
-            "integrity": "sha512-dRhYI8HQ49DQrT91RzIjIa22bs2Pw/2mPtW+4a6ED5lzQ6IMPP0XEPXSSqqkPKedZRXRaZqazi16/QjuidJPnQ==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-15.0.0.tgz",
+            "integrity": "sha512-huJ2uFDXB7w0cYKqxhzYOHuTsuLCY1e0xmWFF8G3KpDbQGnFDM3AVNtxWPas50OxuSWClblqSaExiS/XnWhTTg==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
-                "@azure/core-auth": "^1.3.0",
+                "@azure/core-auth": "^1.6.0",
                 "@azure/core-client": "^1.7.0",
                 "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.12.0",
+                "@azure/core-rest-pipeline": "^1.14.0",
                 "tslib": "^2.2.0"
             }
         },
@@ -11091,12 +11169,23 @@
             }
         },
         "@azure/core-auth": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-            "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+            "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
             "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@azure/core-client": {
@@ -11165,18 +11254,45 @@
             }
         },
         "@azure/core-rest-pipeline": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.13.0.tgz",
-            "integrity": "sha512-a62aP/wppgmnfIkJLfcB4ssPBcH94WzrzPVJ3tlJt050zX4lfmtnvy95D3igDo3f31StO+9BgPrzvkj4aOxnoA==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.1.tgz",
+            "integrity": "sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==",
             "requires": {
-                "@azure/abort-controller": "^1.1.0",
+                "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.4.0",
                 "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.3.0",
+                "@azure/core-util": "^1.9.0",
                 "@azure/logger": "^1.0.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "tslib": "^2.2.0"
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                },
+                "https-proxy-agent": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+                    "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+                    "requires": {
+                        "agent-base": "^7.0.2",
+                        "debug": "4"
+                    }
+                }
             }
         },
         "@azure/core-tracing": {
@@ -11188,12 +11304,22 @@
             }
         },
         "@azure/core-util": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.3.2.tgz",
-            "integrity": "sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+            "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
             "requires": {
-                "@azure/abort-controller": "^1.0.0",
-                "tslib": "^2.2.0"
+                "@azure/abort-controller": "^2.0.0",
+                "tslib": "^2.6.2"
+            },
+            "dependencies": {
+                "@azure/abort-controller": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+                    "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                }
             }
         },
         "@azure/logger": {
@@ -11575,6 +11701,20 @@
                 "yazl": "^2.5.1"
             },
             "dependencies": {
+                "@azure/arm-appservice": {
+                    "version": "14.0.0",
+                    "resolved": "https://registry.npmjs.org/@azure/arm-appservice/-/arm-appservice-14.0.0.tgz",
+                    "integrity": "sha512-tU0ld4B230qsPrk7pmcpiQWkufB/SfON5If8sUR3nsWcEvprB6iZqr1OC4ETjgtAYabNCq22OFquuUizGCoAYQ==",
+                    "requires": {
+                        "@azure/abort-controller": "^1.0.0",
+                        "@azure/core-auth": "^1.3.0",
+                        "@azure/core-client": "^1.7.0",
+                        "@azure/core-lro": "^2.5.0",
+                        "@azure/core-paging": "^1.2.0",
+                        "@azure/core-rest-pipeline": "^1.8.0",
+                        "tslib": "^2.2.0"
+                    }
+                },
                 "fs-extra": {
                     "version": "10.1.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -12057,11 +12197,6 @@
                     }
                 }
             }
-        },
-        "@tootallnate/once": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-            "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
         },
         "@tsconfig/node10": {
             "version": "1.0.9",
@@ -12749,6 +12884,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "requires": {
                 "debug": "4"
             }
@@ -15430,13 +15566,22 @@
             }
         },
         "http-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "requires": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "dependencies": {
+                "agent-base": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+                    "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+                    "requires": {
+                        "debug": "^4.3.4"
+                    }
+                }
             }
         },
         "http-signature": {
@@ -15460,6 +15605,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
@@ -18290,9 +18436,9 @@
             }
         },
         "tslib": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "tsutils": {
             "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -1210,7 +1210,7 @@
     },
     "dependencies": {
         "@azure/arm-appinsights": "^5.0.0-alpha.20230530.1",
-        "@azure/arm-appservice": "^14.0.0",
+        "@azure/arm-appservice": "^15.0.0",
         "@azure/arm-cosmosdb": "^15.0.0",
         "@azure/arm-eventhub": "^5.1.0",
         "@azure/arm-servicebus": "^5.0.0",

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -1,9 +1,7 @@
 import { type Site } from "@azure/arm-appservice";
-import { createHttpHeaders, createPipelineRequest } from "@azure/core-rest-pipeline";
-import { createGenericClient, uiUtils, type AzExtPipelineResponse, type AzExtRequestPrepareOptions } from "@microsoft/vscode-azext-azureutils";
+import { getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { callWithTelemetryAndErrorHandling, nonNullProp, nonNullValue, nonNullValueAndProp, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { type AppResource, type AppResourceResolver } from "@microsoft/vscode-azext-utils/hostapi";
-import { type FunctionAppConfig } from "./commands/createFunctionApp/FunctionAppCreateStep";
 import { ResolvedFunctionAppResource } from "./tree/ResolvedFunctionAppResource";
 import { ResolvedContainerizedFunctionAppResource } from "./tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 import { createWebSiteClient } from "./utils/azureClients";
@@ -21,24 +19,19 @@ export class FunctionAppResolver implements AppResourceResolver {
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
                 this.siteCache.clear();
                 const sites = await uiUtils.listAllIterator(client.webApps.list());
-                const sites20231201 = await getSites20231201(context, subContext);
-                await Promise.all(sites.map(async (site): Promise<void> => {
-                    const id = nonNullProp(site, 'id').toLowerCase();
-                    // check for required properties that sometime don't exist in the LIST operation
-                    if (!site.defaultHostName) {
-                        // if this required property doesn't exist, try getting the full site payload
-                        site = await client.webApps.get(nonNullProp(site, 'resourceGroup'), nonNullProp(site, 'name'))
-                        this.siteCache.set(id, site);
-                    }
-
-                    const s = sites20231201.find(s => s.id?.toLowerCase() === site.id?.toLowerCase());
-                    this.siteCache.set(id, Object.assign(site, { isFlex: !!s?.properties?.functionAppConfig }));
-
-                }));
-                this.siteCacheLastUpdated = Date.now();
+                for (const site of sites) {
+                    this.siteCache.set(resource.id, site);
+                    this.siteCacheLastUpdated = Date.now();
+                }
             }
 
-            const site = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
+            let site = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
+            // check for required properties that sometime don't exist in the LIST operation
+            if (!site || !site.defaultHostName) {
+                // if this required property doesn't exist, try getting the full site payload
+                site = await client.webApps.get(getResourceGroupFromId(resource.id), resource.name);
+                this.siteCache.set(resource.id, site);
+            }
 
             if (nonNullValueAndProp(site, 'kind') === 'functionapp,linux,container,azurecontainerapps') {
                 const fullSite = await client.webApps.get(nonNullValueAndProp(site, 'resourceGroup'), nonNullValueAndProp(site, 'name'));
@@ -54,32 +47,4 @@ export class FunctionAppResolver implements AppResourceResolver {
             && !!resource.kind?.includes('functionapp')
             && !resource.kind?.includes('workflowapp'); // exclude logic apps
     }
-}
-
-async function getSites20231201(context: IActionContext, subContext: ISubscriptionContext): Promise<(Site & { properties?: { functionAppConfig: FunctionAppConfig } })[]> {
-    try {
-        const headers = createHttpHeaders({
-            'Content-Type': 'application/json',
-        });
-
-        const armEndpoint = ensureEndingSlash(subContext.environment.resourceManagerEndpointUrl);
-
-        // we need the new api-version to get the functionAppConfig
-        const options: AzExtRequestPrepareOptions = {
-            url: `${armEndpoint}subscriptions/${subContext.subscriptionId}/providers/Microsoft.Web/sites?api-version=2023-12-01`,
-            method: 'GET',
-            headers
-        };
-
-        const client = await createGenericClient(context, subContext);
-        const result = await client.sendRequest(createPipelineRequest(options)) as AzExtPipelineResponse;
-
-        return (result.parsedBody as { value: unknown }).value as (Site & { properties?: { functionAppConfig: FunctionAppConfig } })[] ?? [];
-    } catch (_error) {
-        return [];
-    }
-}
-
-function ensureEndingSlash(url: string): string {
-    return url.endsWith('/') ? url : `${url}/`;
 }

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -38,7 +38,7 @@ export class FunctionAppResolver implements AppResourceResolver {
                 return ResolvedContainerizedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, fullSite);
             }
 
-            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site), site?.isFlex);
+            return ResolvedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, nonNullValue(site));
         });
     }
 

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -63,12 +63,12 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;
 
-    public constructor(subscription: ISubscriptionContext, site: Site, isFlex?: boolean) {
+    public constructor(subscription: ISubscriptionContext, site: Site) {
         super(new ParsedSite(site, subscription))
         this.data = this.site.rawSite;
         this._subscription = subscription;
         this.contextValuesToAdd = [];
-        this._isFlex = !!isFlex;
+        this._isFlex = !!site.functionAppConfig;
         if (this._isFlex) {
             this.contextValuesToAdd.push(ResolvedFunctionAppResource.flexContextValue);
         } else if (this.site.isSlot) {
@@ -91,8 +91,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
     }
 
-    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site, isFlex?: boolean): ResolvedFunctionAppResource {
-        const resource = new ResolvedFunctionAppResource(subscription, site, isFlex);
+    public static createResolvedFunctionAppResource(context: IActionContext, subscription: ISubscriptionContext, site: Site): ResolvedFunctionAppResource {
+        const resource = new ResolvedFunctionAppResource(subscription, site);
         void resource.site.createClient(context).then(async (client) => resource.data.siteConfig = await client.getSiteConfig())
         return resource;
     }


### PR DESCRIPTION
Swapped out my generated requests to use the SDK for flex consumption creation. Note that some things, such as runtimes and locations still use generic requests, but that's due to the fact those are not part of the appservice sdk.

Also fixed a perf bug that caused loading to take forever, especially if we had an error retrieving a function app. 

Note that this will fix the error that Ramya was encountering with loading her function apps though the ones that were failing will still continue to error. I verified that those apps don't show up at all in the portal, so those resources must be in a weird state.