### PR TITLE
Make sure we can run `npm run package` on main

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -81,7 +81,7 @@
     "azureFunctions.showDeprecatedStacks": "Show deprecated runtime stacks when creating a Function App in Azure. WARNING: These stacks may be removed at any time and may not be available in all regions.",
     "azureFunctions.showExplorer": "Show or hide the Azure Functions Explorer",
     "azureFunctions.showExtensionsCsprojWarning": "Show a warning when an Azure Functions project was detected that has mismatched \"extensions.csproj\" configuration.",
-    "%azureFunctions.showFlexEventGridWarning%": "Show a warning when deploying a Azure Blob Storage Trigger (using Event Grid) to a Flex Consumption Function App.",
+    "azureFunctions.showFlexEventGridWarning": "Show a warning when deploying a Azure Blob Storage Trigger (using Event Grid) to a Flex Consumption Function App.",
     "azureFunctions.showHiddenStacks": "Show hidden runtime stacks when creating a Function App in Azure. WARNING: These stacks may be in preview or may not be available in all regions.",
     "azureFunctions.showMultiCoreToolsWarning": "Show a warning if multiple installs of Azure Functions Core Tools are detected.",
     "azureFunctions.showProjectWarning": "Show a warning when an Azure Functions project was detected that has not been initialized for use in VS Code.",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es2018",
         "outDir": "out",
         "lib": [
             "es6"


### PR DESCRIPTION
Due to some recent changes on the main branch, including upgrading `gulp` from `4.x` to `5`, running `npm run package` on the main branch currently fails 🫠 This PR makes sure it runs successfully, by:

- Removing the `%` from a placeholder text in `package.nls.json`
- Updating the target in the `tsconfig` to `es2018` to allow us to use regular expressions in the gulpfile

Never trust bots man