### PR TITLE
Remove EnableWorkerIndexing feature flag

### DIFF
--- a/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/ScriptProjectCreateStep.ts
@@ -11,7 +11,6 @@ import { FuncVersion } from '../../../FuncVersion';
 import { gitignoreFileName, hostFileName, localSettingsFileName, workerRuntimeKey } from '../../../constants';
 import { type IHostJsonV1, type IHostJsonV2 } from '../../../funcConfig/host';
 import { type ILocalSettingsJson } from '../../../funcConfig/local.settings';
-import { TemplateSchemaVersion } from '../../../templates/TemplateProviderBase';
 import { bundleFeedUtils } from '../../../utils/bundleFeedUtils';
 import { confirmOverwriteFile } from "../../../utils/fs";
 import { nonNullProp } from '../../../utils/nonNull';
@@ -44,12 +43,6 @@ export class ScriptProjectCreateStep extends ProjectCreateStepBase {
             if (functionsWorkerRuntime) {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 this.localSettingsJson.Values![workerRuntimeKey] = functionsWorkerRuntime;
-            }
-
-            // feature flag needs to be enabled to use multiple entry points
-            if (isNodeV4Plus(context) || context.templateSchemaVersion === TemplateSchemaVersion.v2) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                this.localSettingsJson.Values!["AzureWebJobsFeatureFlags"] = "EnableWorkerIndexing";
             }
 
             await AzExtFsExtra.writeJSON(localSettingsJsonPath, this.localSettingsJson);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -161,7 +161,6 @@ export const extensionVersionKey: string = 'FUNCTIONS_EXTENSION_VERSION';
 export const runFromPackageKey: string = 'WEBSITE_RUN_FROM_PACKAGE';
 export const contentConnectionStringKey: string = 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING';
 export const contentShareKey: string = 'WEBSITE_CONTENTSHARE';
-export const azureWebJobsFeatureFlags: string = 'AzureWebJobsFeatureFlags';
 
 /**
  * The "current" Node.js model is 3 (and assumed, if the number is omitted).


### PR DESCRIPTION
The flag is no longer required as of host v4.28 which finished rolling out in Azure in January. Release notes [here](https://github.com/Azure/azure-functions-host/releases/tag/v4.28.0) and PR [here](https://github.com/Azure/azure-functions-host/pull/9574).

The flag was no longer required in core tools even earlier, release [v4.0.5382](https://github.com/Azure/azure-functions-core-tools/releases/tag/4.0.5382) in Sept of last year. Technically people could run into problems if their core tools is too old, but we feel like a year is plenty of time.

Main goal is just to simplify and reduce confusion for new model projects. We've already removed this flag from a lot of docs.