### PR TITLE
Expose API command to start a func task and to check if CLI tools is installed

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -29,7 +29,8 @@ let downloadLink;
 async function getFuncLink() {
     const client = new msRest.ServiceClient();
     const cliFeed = (await client.sendRequest({ method: 'GET', url: 'https://aka.ms/V00v5v' })).parsedBody;
-    const version = cliFeed.tags['v4-prerelease'].release;
+    // const version = cliFeed.tags['v4-prerelease'].release;
+    const version = '4.91.0';
     console.log(`Func cli feed version: ${version}`);
     const cliRelease = cliFeed.releases[version].coreTools.find((rel) => {
         return rel.Architecture === 'x64' && (

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -38,7 +38,7 @@ export async function startFuncProcessFromApi(
         funcHostStartCmd += ` ${args.join(' ')}`;
     }
 
-    await callWithTelemetryAndErrorHandling('startFuncProcessFromApi', async (context: IActionContext) => {
+    await callWithTelemetryAndErrorHandling('azureFunctions.api.startFuncProcess', async (context: IActionContext) => {
         try {
             await waitForPrevFuncTaskToStop(workspaceFolder);
             const funcTask = new vscode.Task({ type: 'func' },

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { sendRequestWithTimeout, type AzExtRequestPrepareOptions } from '@microsoft/vscode-azext-azureutils';
-import { UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, parseError, UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as unixPsTree from 'ps-tree';
 import * as vscode from 'vscode';
 import { hostStartTaskName } from '../constants';
@@ -15,11 +15,50 @@ import { localize } from '../localize';
 import { delay } from '../utils/delay';
 import { requestUtils } from '../utils/requestUtils';
 import { taskUtils } from '../utils/taskUtils';
-import { ProcessDataFlag, getWindowsProcessTree, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
+import { getWindowsProcessTree, ProcessDataFlag, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
+import path = require('path');
 
 const funcTaskReadyEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder>();
 export const onDotnetFuncTaskReady = funcTaskReadyEmitter.event;
+
+export async function startFuncProcessFromApi(
+    workspaceFolder: vscode.WorkspaceFolder,
+    buildPath: string,
+    args?: string[]
+): Promise<{ processId: string; success: boolean; error: string }> {
+    const result = {
+        processId: '',
+        success: false,
+        error: ''
+    };
+
+    let funcHostStartCmd: string = 'func host start';
+    if (args) {
+        funcHostStartCmd += ` ${args.join(' ')}`;
+    }
+
+    await callWithTelemetryAndErrorHandling('startFuncProcessFromApi', async (context: IActionContext) => {
+        try {
+            await waitForPrevFuncTaskToStop(workspaceFolder);
+            const funcTask = new vscode.Task({ type: 'func' },
+                workspaceFolder,
+                hostStartTaskName, 'func',
+                new vscode.ShellExecution(funcHostStartCmd, {
+                    cwd: path.posix.join('${workspaceFolder}', buildPath),
+                }));
+
+            const taskInfo = await startFuncTask(context, workspaceFolder, funcTask);
+            result.processId = await pickChildProcess(taskInfo);
+            result.success = true;
+        } catch (err) {
+            const pError = parseError(err);
+            result.error = pError.message;
+        }
+    });
+
+    return result
+}
 
 export async function pickFuncProcess(context: IActionContext, debugConfig: vscode.DebugConfiguration): Promise<string | undefined> {
     const result: IPreDebugValidateResult = await preDebugValidate(context, debugConfig);

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -17,7 +17,6 @@ import { requestUtils } from '../utils/requestUtils';
 import { taskUtils } from '../utils/taskUtils';
 import { getWindowsProcessTree, ProcessDataFlag, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
-import path = require('path');
 
 const funcTaskReadyEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder>();
 export const onDotnetFuncTaskReady = funcTaskReadyEmitter.event;
@@ -45,7 +44,7 @@ export async function startFuncProcessFromApi(
                 workspaceFolder,
                 hostStartTaskName, 'func',
                 new vscode.ShellExecution(funcHostStartCmd, {
-                    cwd: path.posix.join('${workspaceFolder}', buildPath),
+                    cwd: buildPath,
                 }));
 
             const taskInfo = await startFuncTask(context, workspaceFolder, funcTask);

--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { hostStartTaskName } from '../constants';
 import { preDebugValidate, type IPreDebugValidateResult } from '../debug/validatePreDebug';
 import { ext } from '../extensionVariables';
-import { getFuncPortFromTaskOrProject, isFuncHostTask, runningFuncTaskMap, stopFuncTaskIfRunning, type IRunningFuncTask } from '../funcCoreTools/funcHostTask';
+import { AzureFunctionTaskDefinition, getFuncPortFromTaskOrProject, isFuncHostTask, runningFuncTaskMap, stopFuncTaskIfRunning, type IRunningFuncTask } from '../funcCoreTools/funcHostTask';
 import { localize } from '../localize';
 import { delay } from '../utils/delay';
 import { requestUtils } from '../utils/requestUtils';
@@ -18,19 +18,28 @@ import { taskUtils } from '../utils/taskUtils';
 import { getWindowsProcessTree, ProcessDataFlag, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 
-const funcTaskReadyEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder>();
+const funcTaskReadyEmitter = new vscode.EventEmitter<string>();
 export const onDotnetFuncTaskReady = funcTaskReadyEmitter.event;
 
 export async function startFuncProcessFromApi(
-    workspaceFolder: vscode.WorkspaceFolder,
     buildPath: string,
-    args?: string[]
+    args: string[],
+    env: { [key: string]: string }
 ): Promise<{ processId: string; success: boolean; error: string }> {
     const result = {
         processId: '',
         success: false,
         error: ''
     };
+
+    const uriFile: vscode.Uri = vscode.Uri.file(buildPath)
+
+    const azFuncTaskDefinition: AzureFunctionTaskDefinition = {
+        // VS Code will only run a single instance of a task `type`,
+        // the path will be used here to make each project be unique.
+        type: `func ${uriFile.fsPath}`,
+        functionsApp: uriFile.fsPath
+    }
 
     let funcHostStartCmd: string = 'func host start';
     if (args) {
@@ -39,15 +48,16 @@ export async function startFuncProcessFromApi(
 
     await callWithTelemetryAndErrorHandling('azureFunctions.api.startFuncProcess', async (context: IActionContext) => {
         try {
-            await waitForPrevFuncTaskToStop(workspaceFolder);
-            const funcTask = new vscode.Task({ type: 'func' },
-                workspaceFolder,
+            await waitForPrevFuncTaskToStop(azFuncTaskDefinition.functionsApp);
+            const funcTask = new vscode.Task(azFuncTaskDefinition,
+                vscode.TaskScope.Global,
                 hostStartTaskName, 'func',
                 new vscode.ShellExecution(funcHostStartCmd, {
                     cwd: buildPath,
+                    env: env
                 }));
 
-            const taskInfo = await startFuncTask(context, workspaceFolder, funcTask);
+            const taskInfo = await startFuncTask(context, funcTask);
             result.processId = await pickChildProcess(taskInfo);
             result.success = true;
         } catch (err) {
@@ -65,7 +75,7 @@ export async function pickFuncProcess(context: IActionContext, debugConfig: vsco
         throw new UserCancelledError('preDebugValidate');
     }
 
-    await waitForPrevFuncTaskToStop(result.workspace);
+    await waitForPrevFuncTaskToStop(result.workspace.uri.fsPath);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const preLaunchTaskName: string | undefined = debugConfig.preLaunchTask;
@@ -78,17 +88,17 @@ export async function pickFuncProcess(context: IActionContext, debugConfig: vsco
         throw new Error(localize('noFuncTask', 'Failed to find "{0}" task.', preLaunchTaskName || hostStartTaskName));
     }
 
-    const taskInfo = await startFuncTask(context, result.workspace, funcTask);
+    const taskInfo = await startFuncTask(context, funcTask);
     return await pickChildProcess(taskInfo);
 }
 
-async function waitForPrevFuncTaskToStop(workspaceFolder: vscode.WorkspaceFolder): Promise<void> {
-    stopFuncTaskIfRunning(workspaceFolder);
+async function waitForPrevFuncTaskToStop(functionApp: string): Promise<void> {
+    stopFuncTaskIfRunning(functionApp);
 
     const timeoutInSeconds: number = 30;
     const maxTime: number = Date.now() + timeoutInSeconds * 1000;
     while (Date.now() < maxTime) {
-        if (!runningFuncTaskMap.has(workspaceFolder)) {
+        if (!runningFuncTaskMap.has(functionApp)) {
             return;
         }
         await delay(1000);
@@ -96,7 +106,7 @@ async function waitForPrevFuncTaskToStop(workspaceFolder: vscode.WorkspaceFolder
     throw new Error(localize('failedToFindFuncHost', 'Failed to stop previous running Functions host within "{0}" seconds. Make sure the task has stopped before you debug again.', timeoutInSeconds));
 }
 
-async function startFuncTask(context: IActionContext, workspaceFolder: vscode.WorkspaceFolder, funcTask: vscode.Task): Promise<IRunningFuncTask> {
+async function startFuncTask(context: IActionContext, funcTask: vscode.Task): Promise<IRunningFuncTask> {
     const settingKey: string = 'pickProcessTimeout';
     const settingValue: number | undefined = getWorkspaceSetting<number>(settingKey);
     const timeoutInSeconds: number = Number(settingValue);
@@ -105,64 +115,71 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
     }
     context.telemetry.properties.timeoutInSeconds = timeoutInSeconds.toString();
 
-    let taskError: Error | undefined;
-    const errorListener: vscode.Disposable = vscode.tasks.onDidEndTaskProcess((e: vscode.TaskProcessEndEvent) => {
-        if (e.execution.task.scope === workspaceFolder && e.exitCode !== 0) {
-            context.errorHandling.suppressReportIssue = true;
-            // Throw if _any_ task fails, not just funcTask (since funcTask often depends on build/clean tasks)
-            taskError = new Error(localize('taskFailed', 'Error exists after running preLaunchTask "{0}". View task output for more information.', e.execution.task.name, e.exitCode));
-            errorListener.dispose();
-        }
-    });
-
-    try {
-        // The "IfNotActive" part helps when the user starts, stops and restarts debugging quickly in succession. We want to use the already-active task to avoid two func tasks causing a port conflict error
-        // The most common case we hit this is if the "clean" or "build" task is running when we get here. It's unlikely the "func host start" task is active, since we would've stopped it in `waitForPrevFuncTaskToStop` above
-        await taskUtils.executeIfNotActive(funcTask);
-
-        const intervalMs: number = 500;
-        const funcPort: string = await getFuncPortFromTaskOrProject(context, funcTask, workspaceFolder);
-        let statusRequestTimeout: number = intervalMs;
-        const maxTime: number = Date.now() + timeoutInSeconds * 1000;
-        while (Date.now() < maxTime) {
-            if (taskError !== undefined) {
-                throw taskError;
+    if (AzureFunctionTaskDefinition.is(funcTask.definition)) {
+        let taskError: Error | undefined;
+        const errorListener: vscode.Disposable = vscode.tasks.onDidEndTaskProcess((e: vscode.TaskProcessEndEvent) => {
+            if (AzureFunctionTaskDefinition.is(e.execution.task.definition) && e.execution.task.definition.functionsApp === funcTask.definition.functionsApp && e.exitCode !== 0) {
+                context.errorHandling.suppressReportIssue = true;
+                // Throw if _any_ task fails, not just funcTask (since funcTask often depends on build/clean tasks)
+                taskError = new Error(localize('taskFailed', 'Error exists after running preLaunchTask "{0}". View task output for more information.', e.execution.task.name, e.exitCode));
+                errorListener.dispose();
             }
+        });
 
-            const taskInfo: IRunningFuncTask | undefined = runningFuncTaskMap.get(workspaceFolder);
-            if (taskInfo) {
-                for (const scheme of ['http', 'https']) {
-                    const statusRequest: AzExtRequestPrepareOptions = { url: `${scheme}://localhost:${funcPort}/admin/host/status`, method: 'GET' };
-                    if (scheme === 'https') {
-                        statusRequest.rejectUnauthorized = false;
-                    }
+        const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(funcTask.definition.functionsApp))
 
-                    try {
-                        // wait for status url to indicate functions host is running
-                        const response = await sendRequestWithTimeout(context, statusRequest, statusRequestTimeout, undefined);
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-                        if (response.parsedBody.state.toLowerCase() === 'running') {
-                            funcTaskReadyEmitter.fire(workspaceFolder);
-                            return taskInfo;
+        try {
+            // The "IfNotActive" part helps when the user starts, stops and restarts debugging quickly in succession. We want to use the already-active task to avoid two func tasks causing a port conflict error
+            // The most common case we hit this is if the "clean" or "build" task is running when we get here. It's unlikely the "func host start" task is active, since we would've stopped it in `waitForPrevFuncTaskToStop` above
+            await taskUtils.executeIfNotActive(funcTask);
+
+            const intervalMs: number = 500;
+            const funcPort: string = await getFuncPortFromTaskOrProject(context, funcTask, workspaceFolder);
+            let statusRequestTimeout: number = intervalMs;
+            const maxTime: number = Date.now() + timeoutInSeconds * 1000;
+            while (Date.now() < maxTime) {
+                if (taskError !== undefined) {
+                    throw taskError;
+                }
+
+                const taskInfo: IRunningFuncTask | undefined = runningFuncTaskMap.get(funcTask.definition.functionsApp);
+                if (taskInfo) {
+                    for (const scheme of ['http', 'https']) {
+                        const statusRequest: AzExtRequestPrepareOptions = { url: `${scheme}://localhost:${funcPort}/admin/host/status`, method: 'GET' };
+                        if (scheme === 'https') {
+                            statusRequest.rejectUnauthorized = false;
                         }
-                    } catch (error) {
-                        if (requestUtils.isTimeoutError(error)) {
-                            // Timeout likely means localhost isn't ready yet, but we'll increase the timeout each time it fails just in case it's a slow computer that can't handle a request that fast
-                            statusRequestTimeout *= 2;
-                            context.telemetry.measurements.maxStatusTimeout = statusRequestTimeout;
-                        } else {
-                            // ignore
+
+                        try {
+                            // wait for status url to indicate functions host is running
+                            const response = await sendRequestWithTimeout(context, statusRequest, statusRequestTimeout, undefined);
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+                            if (response.parsedBody.state.toLowerCase() === 'running') {
+                                funcTaskReadyEmitter.fire(funcTask.definition.functionsApp);
+                                return taskInfo;
+                            }
+                        } catch (error) {
+                            if (requestUtils.isTimeoutError(error)) {
+                                // Timeout likely means localhost isn't ready yet, but we'll increase the timeout each time it fails just in case it's a slow computer that can't handle a request that fast
+                                statusRequestTimeout *= 2;
+                                context.telemetry.measurements.maxStatusTimeout = statusRequestTimeout;
+                            } else {
+                                // ignore
+                            }
                         }
                     }
                 }
+
+                await delay(intervalMs);
             }
 
-            await delay(intervalMs);
+            throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${ext.prefix}.${settingKey}`));
+        } finally {
+            errorListener.dispose();
         }
-
-        throw new Error(localize('failedToFindFuncHost', 'Failed to detect running Functions host within "{0}" seconds. You may want to adjust the "{1}" setting.', timeoutInSeconds, `${ext.prefix}.${settingKey}`));
-    } finally {
-        errorListener.dispose();
+    }
+    else {
+        throw new Error(localize('failedToFindFuncTask', 'Failed to detect AzFunctions Task'));
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,8 +113,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         uploadAppSettings: uploadAppSettingsFromApi,
         listLocalProjects: listLocalProjects,
         listLocalFunctions: listLocalFunctions,
-        isFuncCoreToolsInstalled: async (context: IActionContext) => {
-            return await validateFuncCoreToolsInstalled(context, '', undefined);
+        isFuncCoreToolsInstalled: async (message: string) => {
+            return await callWithTelemetryAndErrorHandling('azureFunctions.api.isFuncCoreToolsInstalled', async (context: IActionContext) => {
+                return await validateFuncCoreToolsInstalled(context, message, undefined);
+            });
         },
         startFuncProcess: startFuncProcessFromApi,
         apiVersion: '1.9.0'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             });
         },
         startFuncProcess: startFuncProcessFromApi,
-        apiVersion: '1.9.0'
+        apiVersion: '2.0.0'
     }]);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { downloadAppSettingsFromApi } from './commands/api/downloadAppSettingsFr
 import { revealTreeItem } from './commands/api/revealTreeItem';
 import { uploadAppSettingsFromApi } from './commands/api/uploadAppSettingsFromApi';
 import { runPostFunctionCreateStepsFromCache } from './commands/createFunction/FunctionCreateStepBase';
+import { startFuncProcessFromApi } from './commands/pickFuncProcess';
 import { registerCommands } from './commands/registerCommands';
 import { func } from './constants';
 import { BallerinaDebugProvider } from './debug/BallerinaDebugProvider';
@@ -28,6 +29,7 @@ import { PythonDebugProvider } from './debug/PythonDebugProvider';
 import { handleUri } from './downloadAzureProject/handleUri';
 import { ext } from './extensionVariables';
 import { registerFuncHostTaskEvents } from './funcCoreTools/funcHostTask';
+import { validateFuncCoreToolsInstalled } from './funcCoreTools/validateFuncCoreToolsInstalled';
 import { validateFuncCoreToolsIsLatest } from './funcCoreTools/validateFuncCoreToolsIsLatest';
 import { getResourceGroupsApi } from './getExtensionApi';
 import { CentralTemplateProvider } from './templates/CentralTemplateProvider';
@@ -111,6 +113,10 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         uploadAppSettings: uploadAppSettingsFromApi,
         listLocalProjects: listLocalProjects,
         listLocalFunctions: listLocalFunctions,
+        isFuncCoreToolsInstalled: async (context: IActionContext) => {
+            return await validateFuncCoreToolsInstalled(context, '', undefined);
+        },
+        startFuncProcess: startFuncProcessFromApi,
         apiVersion: '1.9.0'
     }]);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
             });
         },
         startFuncProcess: startFuncProcessFromApi,
-        apiVersion: '2.0.0'
+        apiVersion: '1.10.0'
     }]);
 }
 

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -7,20 +7,43 @@ import { registerEvent, type IActionContext } from '@microsoft/vscode-azext-util
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIsProject';
-import { localSettingsFileName } from '../constants';
+import { func, localSettingsFileName } from '../constants';
 import { getLocalSettingsJson } from '../funcConfig/local.settings';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
 
 export interface IRunningFuncTask {
+    taskExecution: vscode.TaskExecution;
     processId: number;
 }
 
-export const runningFuncTaskMap: Map<vscode.WorkspaceFolder | vscode.TaskScope, IRunningFuncTask> = new Map<vscode.WorkspaceFolder | vscode.TaskScope, IRunningFuncTask>();
+export class AzureFunctionTaskDefinition implements vscode.TaskDefinition {
+    type: string;
+    // This is either:
+    // - vscode.WorkspaceFolder.uri.fsPath (used for most of the scenarios in this extension.)
+    // - If using the exported API 'startFuncProcessFromApi', it will be the binary path wrapped with vscode.Uri.file().fsPath
+    functionsApp: string
 
-const funcTaskStartedEmitter = new vscode.EventEmitter<vscode.WorkspaceFolder | vscode.TaskScope | undefined>();
+    static is(taskDefinition: vscode.TaskDefinition): taskDefinition is AzureFunctionTaskDefinition {
+        return taskDefinition.type.startsWith(func) && "functionsApp" in taskDefinition;
+    }
+}
+
+interface DotnetDebugDebugConfiguration extends vscode.DebugConfiguration {
+    launchServiceData: { [key: string]: string }
+}
+
+namespace DotnetDebugDebugConfiguration {
+    export function is(debugConfiguration: vscode.DebugConfiguration): debugConfiguration is DotnetDebugDebugConfiguration {
+        return debugConfiguration.type === 'coreclr' && 'launchServiceData' in debugConfiguration
+    }
+}
+
+export const runningFuncTaskMap: Map<string, IRunningFuncTask> = new Map<string, IRunningFuncTask>();
+
+const funcTaskStartedEmitter = new vscode.EventEmitter<string>();
 export const onFuncTaskStarted = funcTaskStartedEmitter.event;
 
-export const runningFuncPortMap = new Map<vscode.WorkspaceFolder | vscode.TaskScope | undefined, string>();
+export const runningFuncPortMap = new Map<string | undefined, string>();
 const defaultFuncPort: string = '7071';
 
 export function isFuncHostTask(task: vscode.Task): boolean {
@@ -32,18 +55,20 @@ export function registerFuncHostTaskEvents(): void {
     registerEvent('azureFunctions.onDidStartTask', vscode.tasks.onDidStartTaskProcess, async (context: IActionContext, e: vscode.TaskProcessStartEvent) => {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
-        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
-            runningFuncTaskMap.set(e.execution.task.scope, { processId: e.processId });
-            runningFuncPortMap.set(e.execution.task.scope, await getFuncPortFromTaskOrProject(context, e.execution.task, e.execution.task.scope));
-            funcTaskStartedEmitter.fire(e.execution.task.scope);
+        if (AzureFunctionTaskDefinition.is(e.execution.task.definition) && isFuncHostTask(e.execution.task)) {
+            const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(e.execution.task.definition.functionsApp))
+
+            runningFuncTaskMap.set(e.execution.task.definition.functionsApp, { taskExecution: e.execution, processId: e.processId });
+            runningFuncPortMap.set(e.execution.task.definition.functionsApp, await getFuncPortFromTaskOrProject(context, e.execution.task, workspaceFolder));
+            funcTaskStartedEmitter.fire(e.execution.task.definition.functionsApp);
         }
     });
 
     registerEvent('azureFunctions.onDidEndTask', vscode.tasks.onDidEndTaskProcess, (context: IActionContext, e: vscode.TaskProcessEndEvent) => {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
-        if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
-            runningFuncTaskMap.delete(e.execution.task.scope);
+        if (AzureFunctionTaskDefinition.is(e.execution.task.definition) && isFuncHostTask(e.execution.task)) {
+            runningFuncTaskMap.delete(e.execution.task.definition.functionsApp);
         }
     });
 
@@ -51,24 +76,37 @@ export function registerFuncHostTaskEvents(): void {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.suppressIfSuccessful = true;
 
+        // Used to stop the task started with pickFuncProcess.ts startFuncProcessFromApi.
+        if (DotnetDebugDebugConfiguration.is(debugSession.configuration) && debugSession.configuration.launchServiceData.buildPath) {
+            const buildPathUri: vscode.Uri = vscode.Uri.file(debugSession.configuration.launchServiceData.buildPath)
+            stopFuncTaskIfRunning(buildPathUri.fsPath, /* terminate */ true)
+        }
+
         // NOTE: Only stop the func task if this is the root debug session (aka does not have a parentSession) to fix https://github.com/microsoft/vscode-azurefunctions/issues/2925
         if (getWorkspaceSetting<boolean>('stopFuncTaskPostDebug') && !debugSession.parentSession && debugSession.workspaceFolder) {
-            stopFuncTaskIfRunning(debugSession.workspaceFolder);
+            stopFuncTaskIfRunning(debugSession.workspaceFolder.uri.fsPath);
         }
     });
 }
 
-export function stopFuncTaskIfRunning(workspaceFolder: vscode.WorkspaceFolder): void {
-    const runningFuncTask: IRunningFuncTask | undefined = runningFuncTaskMap.get(workspaceFolder);
+export function stopFuncTaskIfRunning(functionApp: string, terminate: boolean = false): void {
+    const runningFuncTask: IRunningFuncTask | undefined = runningFuncTaskMap.get(functionApp);
     if (runningFuncTask !== undefined) {
-        // Use `process.kill` because `TaskExecution.terminate` closes the terminal pane and erases all output
-        // Also to hopefully fix https://github.com/microsoft/vscode-azurefunctions/issues/1401
-        process.kill(runningFuncTask.processId);
-        runningFuncTaskMap.delete(workspaceFolder);
+        if (terminate) {
+            // Tasks that are spun up by an API will execute quickly that process.kill does not terminate the func host fast enough
+            // that it hangs on to the port needed by a debug-restart event.
+            runningFuncTask.taskExecution.terminate();
+        }
+        else {
+            // Use `process.kill` because `TaskExecution.terminate` closes the terminal pane and erases all output
+            // Also to hopefully fix https://github.com/microsoft/vscode-azurefunctions/issues/1401
+            process.kill(runningFuncTask.processId);
+        }
+        runningFuncTaskMap.delete(functionApp);
     }
 }
 
-export async function getFuncPortFromTaskOrProject(context: IActionContext, funcTask: vscode.Task | undefined, projectPathOrTaskScope: string | vscode.WorkspaceFolder | vscode.TaskScope): Promise<string> {
+export async function getFuncPortFromTaskOrProject(context: IActionContext, funcTask: vscode.Task | undefined, projectPathOrTaskScope: string | vscode.WorkspaceFolder | vscode.TaskScope | undefined): Promise<string> {
     try {
         // First, check the task itself
         if (funcTask && funcTask.execution instanceof vscode.ShellExecution) {

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -71,8 +71,8 @@ export function stopFuncTaskIfRunning(workspaceFolder: vscode.WorkspaceFolder): 
 export async function getFuncPortFromTaskOrProject(context: IActionContext, funcTask: vscode.Task | undefined, projectPathOrTaskScope: string | vscode.WorkspaceFolder | vscode.TaskScope): Promise<string> {
     try {
         // First, check the task itself
-        if (funcTask && typeof funcTask.definition.command === 'string') {
-            const match = funcTask.definition.command.match(/\s+(?:"|'|)(?:-p|--port)(?:"|'|)\s+(?:"|'|)([0-9]+)/i);
+        if (funcTask && funcTask.execution instanceof vscode.ShellExecution) {
+            const match = funcTask.execution?.commandLine?.match(/\s+(?:"|'|)(?:-p|--port)(?:"|'|)\s+(?:"|'|)([0-9]+)/i);
             if (match) {
                 return match[1];
             }

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -5,7 +5,7 @@
 
 import { callWithTelemetryAndErrorHandling, type AzExtParentTreeItem, type AzExtTreeItem, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { Disposable, type TaskScope, type WorkspaceFolder } from 'vscode';
+import { Disposable, type WorkspaceFolder } from 'vscode';
 import { type FuncVersion } from '../../FuncVersion';
 import { onDotnetFuncTaskReady } from '../../commands/pickFuncProcess';
 import { functionJsonFileName, localSettingsFileName, type ProjectLanguage } from '../../constants';
@@ -105,9 +105,9 @@ export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Di
         await this.project.setApplicationSetting(context, key, value);
     }
 
-    private async onFuncTaskChanged(scope: WorkspaceFolder | TaskScope | undefined): Promise<void> {
+    private async onFuncTaskChanged(scope: string): Promise<void> {
         await callWithTelemetryAndErrorHandling('onFuncTaskChanged', async (context: IActionContext) => {
-            if (this.workspaceFolder === scope) {
+            if (this.workspaceFolder.uri.fsPath === scope) {
                 context.errorHandling.suppressDisplay = true;
                 context.telemetry.suppressIfSuccessful = true;
                 await this.refresh(context);

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -78,16 +78,16 @@ export interface AzureFunctionsExtensionApi {
     /**
      * Starts a new function process and returns the process id of the new process. This is for .NET projects only.
      *
-     * @param {vscode.WorkspaceFolder} workspaceFolder - The workspace folder of the root of the project.
      * @param {string} buildPath - The fully qualified path to the project's build output.
      * @param {string[]} args - A list of command-line arguments to pass to the process.
+     * @param {{ [key: string]: string }} env - A map of key-value pairs representing environment variables to pass to the process.
      *
      * @returns {Promise<{ processId: string; success: boolean; error: string }>} -
      * - `processId` {string}: The ID of the started process.
      * - `success` {boolean}: Whether the process started successfully.
      * - `error` {string}: Error message in case the process fails to start, otherwise an empty string.
     */
-    startFuncProcess(workspaceFolder: vscode.WorkspaceFolder, buildPath: string, args: string[]): Promise<{ processId: string; success: boolean; error: string }>;
+    startFuncProcess(buildPath: string, args: string[], env: { [key: string]: string }): Promise<{ processId: string; success: boolean; error: string }>;
 }
 
 export type ProjectLanguage = 'JavaScript' | 'TypeScript' | 'C#' | 'Python' | 'PowerShell' | 'Java';

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -67,7 +67,14 @@ export interface AzureFunctionsExtensionApi {
     listLocalProjects(): Promise<ListLocalProjectsResult>;
     listLocalFunctions(localProject: WorkspaceProject): Promise<ListLocalFunctionsResult>;
 
-    isFuncCoreToolsInstalled(context: IActionContext): Promise<boolean>;
+    /**
+     *
+     * @param notInstalledMessage The message to show if the tools are not installed
+     * If it is not installed, the extension will prompt the user to install the tools.
+     * If they install, the function will retrn true after installing the Func Core Tools.
+     * If they cancel, the function will return false.
+     */
+    isFuncCoreToolsInstalled(notInstalledMessage: string): Promise<boolean>;
     /**
      * Starts a new function process and returns the process id of the new process. This is for .NET projects only.
      *

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -79,7 +79,7 @@ export interface AzureFunctionsExtensionApi {
      * Starts a new function process and returns the process id of the new process. This is for .NET projects only.
      *
      * @param {vscode.WorkspaceFolder} workspaceFolder - The workspace folder of the root of the project.
-     * @param {string} buildPath - The relative path to the project's build output.
+     * @param {string} buildPath - The fully qualified path to the project's build output.
      * @param {string[]} args - A list of command-line arguments to pass to the process.
      *
      * @returns {Promise<{ processId: string; success: boolean; error: string }>} -

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -5,7 +5,6 @@
 
 import { type AzureWizardExecuteStep, type IActionContext } from "@microsoft/vscode-azext-utils";
 import type * as vscode from 'vscode';
-import { type JobType } from "./templates/script/parseScriptTemplatesV2";
 
 export interface ILocalFunction {
     name: string;
@@ -67,6 +66,21 @@ export interface AzureFunctionsExtensionApi {
 
     listLocalProjects(): Promise<ListLocalProjectsResult>;
     listLocalFunctions(localProject: WorkspaceProject): Promise<ListLocalFunctionsResult>;
+
+    isFuncCoreToolsInstalled(context: IActionContext): Promise<boolean>;
+    /**
+     * Starts a new function process and returns the process id of the new process. This is for .NET projects only.
+     *
+     * @param {vscode.WorkspaceFolder} workspaceFolder - The workspace folder of the root of the project.
+     * @param {string} buildPath - The relative path to the project's build output.
+     * @param {string[]} args - A list of command-line arguments to pass to the process.
+     *
+     * @returns {Promise<{ processId: string; success: boolean; error: string }>} -
+     * - `processId` {string}: The ID of the started process.
+     * - `success` {boolean}: Whether the process started successfully.
+     * - `error` {string}: Error message in case the process fails to start, otherwise an empty string.
+    */
+    startFuncProcess(workspaceFolder: vscode.WorkspaceFolder, buildPath: string, args: string[]): Promise<{ processId: string; success: boolean; error: string }>;
 }
 
 export type ProjectLanguage = 'JavaScript' | 'TypeScript' | 'C#' | 'Python' | 'PowerShell' | 'Java';
@@ -81,7 +95,6 @@ export interface IAppSettingsClient {
 interface IStringDictionary {
     properties?: { [propertyName: string]: string };
 }
-
 
 /**
  * The options to use when creating a function. If an option is not specified, the default will be used or the user will be prompted
@@ -108,8 +121,6 @@ export interface ICreateFunctionOptions {
     languageFilter?: RegExp;
 
     languageModel?: number;
-
-    jobType?: JobType;
 
     /**
      * The version of the project. Defaults to the latest GA version

--- a/src/workspace/LocalProject.ts
+++ b/src/workspace/LocalProject.ts
@@ -42,7 +42,7 @@ export class LocalProject implements LocalProjectInternal {
     }
 
     public async getHostRequest(context: IActionContext): Promise<FuncHostRequest> {
-        let port = runningFuncPortMap.get(this.options.folder);
+        let port = runningFuncPortMap.get(this.options.folder.uri.fsPath);
         if (!port) {
             const funcTask: Task | undefined = (await tasks.fetchTasks()).find(t => t.scope === this.options.folder && isFuncHostTask(t));
             port = await getFuncPortFromTaskOrProject(context, funcTask, this.options.effectiveProjectPath);

--- a/src/workspace/listLocalFunctions.ts
+++ b/src/workspace/listLocalFunctions.ts
@@ -76,7 +76,7 @@ function getHostStartTimeoutMS(): number {
  * Some projects (e.g. .NET Isolated and PyStein (i.e. Python model >=2)) don't have typical "function.json" files, so we'll have to ping localhost to get functions (only available if the project is running)
 */
 async function getFunctionsForHostedProject(context: IActionContext, project: LocalProjectInternal): Promise<ILocalFunction[]> {
-    if (runningFuncTaskMap.has(project.options.folder)) {
+    if (runningFuncTaskMap.has(project.options.folder.uri.fsPath)) {
         const hostRequest = await project.getHostRequest(context);
         const timeout = getHostStartTimeoutMS();
         const startTime = Date.now();


### PR DESCRIPTION
Exposing these commands to be used by external teams. Basically, they just need a way to start a func task but without using our VS Code launch/task configuration.

In order to launch the func host cli, it needs to be installed, so just exposing a way for them to see if it is or not.