### PR TITLE
Pin core tools to fix tests

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -29,7 +29,8 @@ let downloadLink;
 async function getFuncLink() {
     const client = new msRest.ServiceClient();
     const cliFeed = (await client.sendRequest({ method: 'GET', url: 'https://aka.ms/V00v5v' })).parsedBody;
-    const version = cliFeed.tags['v4'].release;
+    // const version = cliFeed.tags['v4-prerelease'].release;
+    const version = '4.91.0';
     console.log(`Func cli feed version: ${version}`);
     const cliRelease = cliFeed.releases[version].coreTools.find((rel) => {
         return rel.Architecture === 'x64' && (

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -29,7 +29,7 @@ let downloadLink;
 async function getFuncLink() {
     const client = new msRest.ServiceClient();
     const cliFeed = (await client.sendRequest({ method: 'GET', url: 'https://aka.ms/V00v5v' })).parsedBody;
-    const version = cliFeed.tags['v4-prerelease'].release;
+    const version = cliFeed.tags['v4'].release;
     console.log(`Func cli feed version: ${version}`);
     const cliRelease = cliFeed.releases[version].coreTools.find((rel) => {
         return rel.Architecture === 'x64' && (


### PR DESCRIPTION
Temporarily pin core tools to an older version to fix CI tests. There must be a breaking change in a recent version. I couldn't just change it to v4 instead of v4-prerelease since both tags point to the same version.

<img width="343" alt="image" src="https://github.com/user-attachments/assets/347760a0-60d9-44f1-8454-64b54b570841">

See https://github.com/microsoft/vscode-azurefunctions/pull/4299#issuecomment-2450983156 for more context. Thanks @captainsafia for the help!