### PR TITLE
Don't use `getCompiledProjectInfo` in `pickProcess`

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -140,9 +140,7 @@ export function stopFuncTaskIfRunning(workspaceFolder: vscode.WorkspaceFolder | 
         runningFuncTask = [runningFuncTaskMap.get(workspaceFolder, buildPath)];
     }
 
-    if (runningFuncTask !== undefined) {
-
-
+    if (runningFuncTask !== undefined && runningFuncTask.length > 0) {
         for (const runningFuncTaskItem of runningFuncTask) {
             if (!runningFuncTaskItem) break;
             if (terminate) {

--- a/src/workspace/listLocalProjects.ts
+++ b/src/workspace/listLocalProjects.ts
@@ -92,7 +92,7 @@ export async function listLocalProjects(): Promise<ListLocalProjectsResult> {
 
 type CompiledProjectInfo = { compiledProjectPath: string; isIsolated: boolean };
 
-export async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
+async function getCompiledProjectInfo(context: IActionContext, projectPath: string, projectLanguage: ProjectLanguage): Promise<CompiledProjectInfo | undefined> {
     if (projectLanguage === ProjectLanguage.CSharp || projectLanguage === ProjectLanguage.FSharp) {
         const projFiles: dotnetUtils.ProjectFile[] = await dotnetUtils.getProjFiles(context, projectLanguage, projectPath);
         if (projFiles.length === 1) {

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -53,7 +53,7 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
     if (!funcExtension) {
         throw new Error('Could not find the Azure Functions extension.');
     }
-    await funcExtension.activate(); // activate the extension before tests begin
+    // await funcExtension.activate(); // activate the extension before tests begin
 
     ext.outputChannel = new TestOutputChannel();
 

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -41,6 +41,7 @@ export function getTestWorkspaceFolder(): string {
 
 // Runs before all tests
 suiteSetup(async function (this: Mocha.Context): Promise<void> {
+    this.skip();
     this.timeout(4 * 60 * 1000);
     oldRequestTimeout = getGlobalSetting(requestTimeoutKey);
     await updateGlobalSetting(requestTimeoutKey, 45);

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -41,7 +41,6 @@ export function getTestWorkspaceFolder(): string {
 
 // Runs before all tests
 suiteSetup(async function (this: Mocha.Context): Promise<void> {
-    this.skip();
     this.timeout(4 * 60 * 1000);
     oldRequestTimeout = getGlobalSetting(requestTimeoutKey);
     await updateGlobalSetting(requestTimeoutKey, 45);
@@ -53,7 +52,7 @@ suiteSetup(async function (this: Mocha.Context): Promise<void> {
     if (!funcExtension) {
         throw new Error('Could not find the Azure Functions extension.');
     }
-    // await funcExtension.activate(); // activate the extension before tests begin
+    await funcExtension.activate(); // activate the extension before tests begin
 
     ext.outputChannel = new TestOutputChannel();
 


### PR DESCRIPTION
I had originally thought it'd be smart to use it to get the buildPath easily, but it turns out that it throws an error if there is more than one csproj file. This, unsurprisingly, causes a lot of issues for users trying to debug.

Also fixed another issue where it said it could not find the process id. That is because `runningFuncTask` could also be an empty array, in which case, not undefined, but no process to kill.