### PR TITLE
Default flex consumption for basic creation

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -36,6 +36,12 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
     public shouldPrompt(context: IFunctionAppWizardContext): boolean {
         return context.useConsumptionPlan === undefined && context.dockerfilePath === undefined;
     }
+
+    public configureBeforePrompt(context: IFunctionAppWizardContext): void | Promise<void> {
+        if (!context.advancedCreation) {
+            setFlexConsumptionPlanProperties(context);
+        }
+    }
 }
 
 export function setConsumptionPlanProperties(context: IFunctionAppWizardContext): void {

--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -17,8 +17,8 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
     public async prompt(context: IFunctionAppWizardContext): Promise<void> {
         const placeHolder: string = localize('selectHostingPlan', 'Select a hosting plan.');
         const picks: IAzureQuickPickItem<[boolean, RegExp | undefined]>[] = [
+            { label: localize('flexConsumption', 'Flex Consumption'), data: [false, undefined] },
             { label: localize('consumption', 'Consumption'), data: [true, undefined] },
-            { label: localize('flexConsumption', 'Flex Consumption'), description: 'Preview', data: [false, undefined] },
             { label: localize('premium', 'Premium'), data: [false, /^EP$/i] },
             { label: localize('dedicated', 'App Service Plan'), data: [false, /^((?!EP|Y|FC).)*$/i] }
         ];

--- a/src/commands/createFunctionApp/UniqueNamePromptStep.ts
+++ b/src/commands/createFunctionApp/UniqueNamePromptStep.ts
@@ -6,7 +6,6 @@
 import { type IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice";
 import { AzureWizardPromptStep } from "@microsoft/vscode-azext-utils";
 import { localize } from "../../localize";
-import { setConsumptionPlanProperties } from "./FunctionAppHostingPlanStep";
 import { type IFunctionAppWizardContext } from "./IFunctionAppWizardContext";
 
 export class ConfigureCommonNamesStep extends AzureWizardPromptStep<IAppServiceWizardContext> {
@@ -26,7 +25,6 @@ export class ConfigureCommonNamesStep extends AzureWizardPromptStep<IAppServiceW
                 throw new Error(localize('noUniqueName', 'Failed to generate unique name for resources. Use advanced creation to manually enter resource names.'));
             }
             context.newResourceGroupName = context.newResourceGroupName || newName;
-            setConsumptionPlanProperties(context);
             context.newStorageAccountName = newName;
             context.newAppInsightsName = newName;
         }

--- a/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
+++ b/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
@@ -131,11 +131,8 @@ async function createFunctionAppWizard(wizardContext: IFunctionAppWizardContext)
     const promptSteps: AzureWizardPromptStep<IAppServiceWizardContext>[] = [];
     const executeSteps: AzureWizardExecuteStep<IAppServiceWizardContext>[] = [];
 
-    if (wizardContext.advancedCreation) {
-        promptSteps.push(new FunctionAppHostingPlanStep());
-        // location is required to get flex runtimes, so prompt before stack step
-        CustomLocationListStep.addStep(wizardContext, promptSteps);
-    }
+    promptSteps.push(new FunctionAppHostingPlanStep());
+    CustomLocationListStep.addStep(wizardContext, promptSteps);
 
     promptSteps.push(new FunctionAppStackStep());
 

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -107,7 +107,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
 
     public get description(): string | undefined {
         if (this._isFlex) {
-            return localize('flexFunctionApp', 'Flex (Preview)');
+            return localize('flexFunctionApp', 'Flex Consumption');
         }
         return this._state?.toLowerCase() !== 'running' ? this._state : undefined;
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4335

I moved `setFlexConsumptionPlanProperties` from `UniqueNamePromptStep` because it doesn't really make sense for it to be there. I had a reason before, but it's not important 😁 