### PR TITLE
Add local settings node under local project in workspace view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@azure/core-rest-pipeline": "^1.11.0",
                 "@azure/storage-blob": "^12.5.0",
                 "@microsoft/vscode-azext-azureappservice": "^3.3.1",
-                "@microsoft/vscode-azext-azureappsettings": "^0.2.1",
+                "@microsoft/vscode-azext-azureappsettings": "^0.2.2",
                 "@microsoft/vscode-azext-azureutils": "^3.1.3",
                 "@microsoft/vscode-azext-serviceconnector": "^0.1.3",
                 "@microsoft/vscode-azext-utils": "^2.5.7",
@@ -1140,9 +1140,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappsettings": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.1.tgz",
-            "integrity": "sha512-YfYnXC/Gmx86+U+lAwui0EUlzRtOxSSrPcSmYsJHR7iVZ1Xzr7nblQveNTHKOUHaphSoNGnz9+2mzcYQwJnpNQ==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.2.tgz",
+            "integrity": "sha512-qZr7jtP9628k7KeltK2FQP5wEK/oVr3eR26X9Yts3QIzHOsMpbpGATyaczBcXq6w+Qro8A0SAIGg6v+c4QcVTQ==",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1239,7 +1239,7 @@
         "@azure/core-rest-pipeline": "^1.11.0",
         "@azure/storage-blob": "^12.5.0",
         "@microsoft/vscode-azext-azureappservice": "^3.3.1",
-        "@microsoft/vscode-azext-azureappsettings": "^0.2.1",
+        "@microsoft/vscode-azext-azureappsettings": "^0.2.2",
         "@microsoft/vscode-azext-azureutils": "^3.1.3",
         "@microsoft/vscode-azext-serviceconnector": "^0.1.3",
         "@microsoft/vscode-azext-utils": "^2.5.7",

--- a/src/commands/appSettings/localSettings/LocalSettingsClient.ts
+++ b/src/commands/appSettings/localSettings/LocalSettingsClient.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { type StringDictionary } from "@azure/arm-appservice";
+import { type AppSettingsClientProvider, type IAppSettingsClient } from "@microsoft/vscode-azext-azureappsettings";
+import { AzExtFsExtra, callWithTelemetryAndErrorHandling, type IActionContext } from "@microsoft/vscode-azext-utils";
+import * as vscode from 'vscode';
+import { type ILocalSettingsJson } from "../../../funcConfig/local.settings";
+import { type LocalProjectTreeItem } from "../../../tree/localProject/LocalProjectTreeItem";
+import { decryptLocalSettings } from "./decryptLocalSettings";
+import { encryptLocalSettings } from "./encryptLocalSettings";
+import { getLocalSettingsFileNoPrompt } from "./getLocalSettingsFile";
+
+export class LocalSettingsClientProvider implements AppSettingsClientProvider {
+    private _node: LocalProjectTreeItem;
+    constructor(node: LocalProjectTreeItem) {
+        this._node = node;
+    }
+
+    public async createClient(): Promise<IAppSettingsClient> {
+        return new LocalSettingsClient(this._node);
+    }
+}
+
+export class LocalSettingsClient implements IAppSettingsClient {
+    public fullName: string;
+    public isLinux: boolean;
+
+    private _node: LocalProjectTreeItem;
+
+    constructor(node: LocalProjectTreeItem) {
+        this.isLinux = false;
+        this._node = node;
+    }
+
+    public async listApplicationSettings(): Promise<StringDictionary> {
+        const result = await callWithTelemetryAndErrorHandling<StringDictionary | undefined>('listApplicationSettings', async (context: IActionContext) => {
+            const localSettingsPath: string | undefined = await getLocalSettingsFileNoPrompt(context, this._node.workspaceFolder);
+            if (localSettingsPath === undefined) {
+                return { properties: {} };
+            } else {
+                const localSettingsUri: vscode.Uri = vscode.Uri.file(localSettingsPath);
+
+                let localSettings: ILocalSettingsJson = <ILocalSettingsJson>await AzExtFsExtra.readJSON(localSettingsPath);
+                if (localSettings.IsEncrypted) {
+                    await decryptLocalSettings(context, localSettingsUri);
+                    try {
+                        localSettings = await AzExtFsExtra.readJSON<ILocalSettingsJson>(localSettingsPath);
+                    } finally {
+                        await encryptLocalSettings(context, localSettingsUri);
+                    }
+                }
+                return { properties: localSettings.Values };
+            }
+        });
+        return result ?? { properties: {} };
+    }
+
+    public async updateApplicationSettings(): Promise<StringDictionary> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/commands/appSettings/localSettings/LocalSettingsClient.ts
+++ b/src/commands/appSettings/localSettings/LocalSettingsClient.ts
@@ -27,11 +27,11 @@ export class LocalSettingsClientProvider implements AppSettingsClientProvider {
 export class LocalSettingsClient implements IAppSettingsClient {
     public fullName: string;
     public isLinux: boolean;
-
     private _node: LocalProjectTreeItem;
 
     constructor(node: LocalProjectTreeItem) {
         this.isLinux = false;
+        this.fullName = 'local';
         this._node = node;
     }
 

--- a/src/commands/appSettings/localSettings/getLocalSettingsFile.ts
+++ b/src/commands/appSettings/localSettings/getLocalSettingsFile.ts
@@ -5,7 +5,7 @@
 
 import { AzExtFsExtra, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { type WorkspaceFolder } from "vscode";
+import type * as vscode from 'vscode';
 import { localSettingsFileName } from '../../../constants';
 import { getRootWorkspaceFolder, selectWorkspaceFile } from '../../../utils/workspace';
 import { tryGetFunctionProjectRoot } from '../../createNewProject/verifyIsProject';
@@ -14,7 +14,7 @@ import { tryGetFunctionProjectRoot } from '../../createNewProject/verifyIsProjec
  * If only one project is open and the default local settings file exists, return that.
  * Otherwise, prompt
  */
-export async function getLocalSettingsFile(context: IActionContext, message: string, workspaceFolder?: WorkspaceFolder): Promise<string> {
+export async function getLocalSettingsFile(context: IActionContext, message: string, workspaceFolder?: vscode.WorkspaceFolder): Promise<string> {
     workspaceFolder ||= await getRootWorkspaceFolder();
     if (workspaceFolder) {
         const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder);
@@ -26,8 +26,19 @@ export async function getLocalSettingsFile(context: IActionContext, message: str
         }
     }
 
-    return await selectWorkspaceFile(context, message, async (f: WorkspaceFolder): Promise<string> => {
+    return await selectWorkspaceFile(context, message, async (f: vscode.WorkspaceFolder): Promise<string> => {
         const projectPath: string = await tryGetFunctionProjectRoot(context, f) || f.uri.fsPath;
         return path.relative(f.uri.fsPath, path.join(projectPath, localSettingsFileName));
     });
+}
+
+export async function getLocalSettingsFileNoPrompt(context: IActionContext, workspaceFolder: vscode.WorkspaceFolder): Promise<string | undefined> {
+    const projectPath: string | undefined = await tryGetFunctionProjectRoot(context, workspaceFolder);
+    if (projectPath) {
+        const localSettingsFile: string = path.join(projectPath, localSettingsFileName);
+        if (await AzExtFsExtra.pathExists(localSettingsFile)) {
+            return localSettingsFile;
+        }
+    }
+    return undefined;
 }


### PR DESCRIPTION
This is to prepare for the local functions project settings conversion work. 

Here is how the new node looks: 
![image](https://github.com/user-attachments/assets/4c5a3741-665d-44b7-b1d4-3fc10a13d90d)


Todo: 

- [x] Once changes are merged and release on the appsettings tool package update the version here