### PR TITLE
Redirect all links to new functions cdn domain

### DIFF
--- a/src/How to parse v2 Templates.md
+++ b/src/How to parse v2 Templates.md
@@ -2,7 +2,7 @@
 
 ### Bundle feed
 
-The templates come from the extension [bundle feed](https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index-v2.json) under the `templates.v2` property.
+The templates come from the extension [bundle feed](https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index-v2.json) under the `templates.v2` property.
 The extension looks at the `bundleVersions` to determine what the latest version is. It then uses the three properties `functions`, `userPrompts`, and `resources` to retrieve the jsons used to parse the templates.
 
 **NOTE: For v1, we use `bindings` instead of `userPrompts`**

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -26,7 +26,7 @@ Backup templates should be updated every time there is a major change in the lat
 
 Basic script templates (i.e. http and timer) are retrieved from the 'templates' property in each entry of the [CLI Feed](https://aka.ms/funcCliFeedV4). More advanced templates (i.e. blob and cosmos) are retrieved from another feed specific to the extension bundle for that project. For example, the default bundle is 'Microsoft.Azure.Functions.ExtensionBundle' and the matching feed is https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index-v2.json
 
-> NOTE: Both template feeds support 'staging' environments for us to test against before moving to production. The main CLI Feed uses a "vX-prerelease" tag, while the bundle feed has a completely different url leveraging "functionscdnstaging" instead of "functionscdn".
+> NOTE: Both template feeds support 'staging' environments for us to test against before moving to production. The main CLI Feed uses a "vX-prerelease" tag, while the bundle feed has a completely different url leveraging "cdn-staging.functions.azure.com" instead of "cdn.functions.azure.com ".
 
 In both cases, the templates are split into three parts: templates.json, bindings.json, and resources.json. See below for an example of the schema for the TimerTrigger template:
 

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -1,6 +1,6 @@
 # Azure Function Templates
 
-The code in this folder is used to parse and model the [function templates](https://github.com/Azure/azure-webjobs-sdk-templates) provided by the [Azure Functions CLI Feed](https://aka.ms/AAbbk68). The Functions CLI Feed provides a central location to get the latest version of all templates used for functions.
+The code in this folder is used to parse and model the [function templates](https://github.com/Azure/azure-webjobs-sdk-templates) provided by the [Azure Functions CLI Feed](https://aka.ms/funcCliFeedV4). The Functions CLI Feed provides a central location to get the latest version of all templates used for functions.
 
 ## Template Sources
 
@@ -24,7 +24,7 @@ Backup templates should be updated every time there is a major change in the lat
 
 ## Script Templates
 
-Basic script templates (i.e. http and timer) are retrieved from the 'templates' property in each entry of the [CLI Feed](https://aka.ms/AAbbk68). More advanced templates (i.e. blob and cosmos) are retrieved from another feed specific to the extension bundle for that project. For example, the default bundle is 'Microsoft.Azure.Functions.ExtensionBundle' and the matching feed is https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index-v2.json
+Basic script templates (i.e. http and timer) are retrieved from the 'templates' property in each entry of the [CLI Feed](https://aka.ms/funcCliFeedV4). More advanced templates (i.e. blob and cosmos) are retrieved from another feed specific to the extension bundle for that project. For example, the default bundle is 'Microsoft.Azure.Functions.ExtensionBundle' and the matching feed is https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/index-v2.json
 
 > NOTE: Both template feeds support 'staging' environments for us to test against before moving to production. The main CLI Feed uses a "vX-prerelease" tag, while the bundle feed has a completely different url leveraging "functionscdnstaging" instead of "functionscdn".
 

--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -68,7 +68,7 @@ export namespace bundleFeedUtils {
 
     export async function getReleaseV2(templateVersion: string): Promise<ITemplatesReleaseV2> {
         // build the url ourselves because the index-v2.json file is no longer publishing version updates for v2 templates
-        const functionsCdn: string = 'https://functionscdn.azureedge.net/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/';
+        const functionsCdn: string = 'https://cdn.functions.azure.com/public/ExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/';
         return {
             functions: `${functionsCdn}${templateVersion}/StaticContent/v2/templates/templates.json`,
             bindings: `${functionsCdn}${templateVersion}/StaticContent/v2/bindings/userPrompts.json`,
@@ -113,10 +113,10 @@ export namespace bundleFeedUtils {
         let url: string;
         const templateProvider = ext.templateProvider.get(context);
         if (!envVarUri && bundleId === defaultBundleId && templateProvider.templateSource !== TemplateSource.Staging) {
-            url = 'https://aka.ms/AA66i2x';
+            url = 'https://aka.ms/bundleFeedUtilsV2';
         } else {
-            const suffix: string = templateProvider.templateSource === TemplateSource.Staging ? 'staging' : '';
-            const baseUrl: string = envVarUri || `https://functionscdn${suffix}.azureedge.net/public`;
+            const suffix: string = templateProvider.templateSource === TemplateSource.Staging ? '-staging' : '';
+            const baseUrl: string = envVarUri || `https://cdn${suffix}.functions.azure.com/public`;
             url = `${baseUrl}/ExtensionBundles/${bundleId}/index-v2.json`;
         }
 

--- a/src/utils/cliFeedUtils.ts
+++ b/src/utils/cliFeedUtils.ts
@@ -11,7 +11,7 @@ import { localize } from '../localize';
 import { feedUtils } from './feedUtils';
 
 export namespace cliFeedUtils {
-    const funcCliFeedV4Url: string = 'https://aka.ms/AAbbk68';
+    const funcCliFeedV4Url: string = 'https://aka.ms/funcCliFeedV4';
 
     interface ICliFeed {
         tags: {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4373

Links were also updated in aka.ms where appropriate.