### PR TITLE
Add eol warning to app setting changes

### DIFF
--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -11,7 +11,7 @@ import { type IAppSettingsClient } from '@microsoft/vscode-azext-azureappsetting
 import { createGenericClient, LocationListStep, type AzExtPipelineResponse } from '@microsoft/vscode-azext-azureutils';
 import { maskUserInfo, nonNullValue, openUrl, parseError, type AgentQuickPickItem, type AzExtParentTreeItem, type IAzureQuickPickItem, type ISubscriptionActionContext } from '@microsoft/vscode-azext-utils';
 import { type MessageItem } from 'vscode';
-import { hiddenStacksSetting, noRuntimeStacksAvailableLabel } from '../../../constants';
+import { hiddenStacksSetting, noRuntimeStacksAvailableLabel, stackUpgradeLearnMoreLink } from '../../../constants';
 import { previewDescription } from '../../../constants-nls';
 import { funcVersionLink } from '../../../FuncVersion';
 import { localize } from '../../../localize';
@@ -373,7 +373,7 @@ export async function showEolWarningIfNecessary(context: ISubscriptionActionCont
             client
         });
         const continueOn: MessageItem = { title: localize('continueOn', 'Continue') };
-        await context.ui.showWarningMessage(eolWarningMessage, { modal: true }, continueOn);
+        await context.ui.showWarningMessage(eolWarningMessage, { modal: true, learnMoreLink: stackUpgradeLearnMoreLink }, continueOn);
     }
 }
 
@@ -407,14 +407,14 @@ async function getEOLLinuxFxVersion(context: ISubscriptionActionContext, linuxFx
         )
     );
     const versionFilteredStacks = stacks[0].majorVersions.filter(mv => mv.minorVersions.some(minor => minor.stackSettings.linuxRuntimeSettings?.runtimeVersion === linuxFxVersion));
-    const filteredStack = versionFilteredStacks[0].minorVersions[0];
-    const displayVersion = filteredStack?.displayText;
+    const filteredStack = versionFilteredStacks[0].minorVersions.find(minor => minor.stackSettings.linuxRuntimeSettings?.runtimeVersion === linuxFxVersion);
+    const displayVersion = filteredStack?.displayText ?? localize('unknownVersion', 'Unknown version');
     const endOfLifeDate = filteredStack?.stackSettings.linuxRuntimeSettings?.endOfLifeDate;
     if (endOfLifeDate) {
         const endOfLife = new Date(endOfLifeDate)
         return {
             endOfLife,
-            displayVersion
+            displayVersion: displayVersion
         }
     }
     return {

--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -414,7 +414,7 @@ async function getEOLLinuxFxVersion(context: ISubscriptionActionContext, linuxFx
         const endOfLife = new Date(endOfLifeDate)
         return {
             endOfLife,
-            displayVersion: displayVersion
+            displayVersion
         }
     }
     return {

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -8,7 +8,7 @@ import { getDeployFsPath, getDeployNode, deploy as innerDeploy, showDeployConfir
 import { DialogResponses, type ExecuteActivityContext, type IActionContext, type ISubscriptionActionContext } from '@microsoft/vscode-azext-utils';
 import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import type * as vscode from 'vscode';
-import { CodeAction, ConnectionType, deploySubpathSetting, DurableBackend, hostFileName, ProjectLanguage, remoteBuildSetting, ScmType, type DurableBackendValues } from '../../constants';
+import { CodeAction, ConnectionType, deploySubpathSetting, DurableBackend, hostFileName, ProjectLanguage, remoteBuildSetting, ScmType, stackUpgradeLearnMoreLink, type DurableBackendValues } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
@@ -175,7 +175,8 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         deploymentWarningMessages.length > 0) {
         // if there is a warning message, we want to show the deploy confirmation regardless of the setting
         const deployCommandId = 'azureFunctions.deploy';
-        await showDeployConfirmation(context, node.site, deployCommandId, deploymentWarningMessages, `https://aka.ms/FunctionsStackUpgrade`);
+        await showDeployConfirmation(context, node.site, deployCommandId, deploymentWarningMessages,
+            eolWarningMessage ? stackUpgradeLearnMoreLink : undefined);
     }
 
     await runPreDeployTask(context, context.effectiveDeployFsPath, siteConfig.scmType);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -180,6 +180,7 @@ const pythonV1Model: IAzureQuickPickItem<number | undefined> = { data: undefined
 
 export const pythonModels = [pythonV2Model, pythonV1Model];
 export const pythonLearnMoreLink = 'https://aka.ms/AAmlyrc';
+export const stackUpgradeLearnMoreLink = 'https://aka.ms/FunctionsStackUpgrade';
 
 export const webProvider: string = 'Microsoft.Web';
 export const functionFilter = {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4440

There was also a bug when getting the LinuxFxVersion that I went ahead and fixed. Also the learn more button was being displayed for every deploy, not just for when there was an EOL warning.