### PR TITLE
Fix "Add Function App Identity Connections..." command when selecting "+ Create new user assigned identity"

### DIFF
--- a/src/commands/addMIConnections/RemoteSettingsAddStep.ts
+++ b/src/commands/addMIConnections/RemoteSettingsAddStep.ts
@@ -9,7 +9,7 @@ import { localize } from "../../localize";
 import { type AddMIConnectionsContext } from "./AddMIConnectionsContext";
 
 export class RemoteSettingsAddStep extends AzureWizardExecuteStep<AddMIConnectionsContext> {
-    public priority: number = 110;
+    public priority: number = 160;
 
     public async execute(context: AddMIConnectionsContext): Promise<void> {
         const client = await nonNullProp(context, 'functionapp').site.createClient(context);

--- a/src/commands/addMIConnections/SettingsAddBaseStep.ts
+++ b/src/commands/addMIConnections/SettingsAddBaseStep.ts
@@ -11,7 +11,7 @@ import { type AddMIConnectionsContext } from "./AddMIConnectionsContext";
 import { type Connection } from "./ConnectionsListStep";
 
 export class SettingsAddBaseStep extends AzureWizardExecuteStep<AddMIConnectionsContext> {
-    public priority: number = 100;
+    public priority: number = 150;
 
     public async execute(context: AddMIConnectionsContext): Promise<void> {
         context.roles = [];


### PR DESCRIPTION
Fixes #4446.

This is happening since the managed identity wasn't being created before trying to set settings for the clientId property. By changing the priorities to make these steps happen after the managed identity is created the problem seems to be solved.