### PR TITLE
Remove warning for `Deployment_Storage_Connection_String` setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@azure/core-rest-pipeline": "^1.11.0",
                 "@azure/storage-blob": "^12.5.0",
                 "@microsoft/vscode-azext-azureappservice": "^3.5.4",
-                "@microsoft/vscode-azext-azureappsettings": "^0.2.6",
+                "@microsoft/vscode-azext-azureappsettings": "^0.2.7",
                 "@microsoft/vscode-azext-azureutils": "^3.1.7",
                 "@microsoft/vscode-azext-utils": "^2.6.3",
                 "@microsoft/vscode-azureresources-api": "^2.0.4",
@@ -1197,9 +1197,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappsettings": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.6.tgz",
-            "integrity": "sha512-oFPNGuLGh4r5Lqtnx5GL+0Cj/bcm0cLnCmuG4uegVUqx1lSWakI8rUmxOc0zcSVA27gSefEGVdstXZFxZi/xJA==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappsettings/-/vscode-azext-azureappsettings-0.2.7.tgz",
+            "integrity": "sha512-iknvX6U0M8boHeA9ZQtqx9Ul9rPFYs9K5IHV7jqItbGkiJ7wygQx8IwT8dItBPY4xAUpL7IS5Oai4JmZl0eKXA==",
             "dependencies": {
                 "@microsoft/vscode-azext-utils": "^2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -1392,7 +1392,7 @@
         "@azure/core-rest-pipeline": "^1.11.0",
         "@azure/storage-blob": "^12.5.0",
         "@microsoft/vscode-azext-azureappservice": "^3.5.4",
-        "@microsoft/vscode-azext-azureappsettings": "^0.2.6",
+        "@microsoft/vscode-azext-azureappsettings": "^0.2.7",
         "@microsoft/vscode-azext-azureutils": "^3.1.7",
         "@microsoft/vscode-azext-utils": "^2.6.3",
         "@microsoft/vscode-azureresources-api": "^2.0.4",

--- a/src/commands/addMIConnections/ConnectionsListStep.ts
+++ b/src/commands/addMIConnections/ConnectionsListStep.ts
@@ -74,7 +74,7 @@ export class ConnectionsListStep extends AzureWizardPromptStep<AddMIConnectionsC
 
 function addPicks(settings: { [key: string]: string }, picks: IAzureQuickPickItem<Connection>[]): IAzureQuickPickItem<Connection>[] {
     for (const [key, value] of Object.entries(settings)) {
-        if (!isSettingConnectionString(value)) {
+        if (!isSettingConnectionString(key, value)) {
             continue;
         }
 

--- a/src/commands/deploy/getWarningsForConnectionSettings.ts
+++ b/src/commands/deploy/getWarningsForConnectionSettings.ts
@@ -45,7 +45,7 @@ export async function getWarningsForConnectionSettings(context: IActionContext,
 }
 
 function checkForConnectionSettings(property: { [propertyName: string]: string }): ConnectionSetting | undefined {
-    if (isSettingConnectionString(property.value)) {
+    if (isSettingConnectionString(property.key, property.value)) {
         // if the setting is convertible, we can assume it's a connection string
         return {
             name: property.propertyName,

--- a/src/tree/localProject/LocalProjectTreeItem.ts
+++ b/src/tree/localProject/LocalProjectTreeItem.ts
@@ -138,8 +138,8 @@ export class LocalProjectTreeItem extends LocalProjectTreeItemBase implements Di
         if (localSettingsPath) {
             const localSettings = await getLocalSettingsJson(context, localSettingsPath, false);
             if (localSettings.Values) {
-                for (const value of Object.values(localSettings.Values)) {
-                    if (!isSettingConnectionString(value)) {
+                for (const [key, value] of Object.entries(localSettings.Values)) {
+                    if (!isSettingConnectionString(key, value)) {
                         continue;
                     }
 


### PR DESCRIPTION
We don't want this to setting to have a warning or be able to be called by the `Add Function App Identity Connections...` command or `Add Local Project Identity Connections...` command.