### PR TITLE
Fix priority for `Add Local Project Identity Connections...` command

### DIFF
--- a/src/commands/addMIConnections/LocalSettingsAddStep.ts
+++ b/src/commands/addMIConnections/LocalSettingsAddStep.ts
@@ -11,7 +11,7 @@ import { getLocalSettingsFile } from "../appSettings/localSettings/getLocalSetti
 import { type AddMIConnectionsContext } from "./AddMIConnectionsContext";
 
 export class LocalSettingsAddStep extends AzureWizardExecuteStep<AddMIConnectionsContext> {
-    public priority: number = 125;
+    public priority: number = 160;
 
     public async execute(context: AddMIConnectionsContext): Promise<void> {
         // If right clicking on a connection we will have the connections to convert but not the local settings path


### PR DESCRIPTION
The `LocalSettingsAddStep` needs to come after the `SettingsAddBaseStep`. The priority for `SettingsAddBaseStep` was changed here #4451