### PR TITLE
Add undo to Connections List Step

### DIFF
--- a/src/commands/addMIConnections/ConnectionsListStep.ts
+++ b/src/commands/addMIConnections/ConnectionsListStep.ts
@@ -41,6 +41,10 @@ export class ConnectionsListStep extends AzureWizardPromptStep<AddMIConnectionsC
         return !context.connections || context.connections.length === 0;
     }
 
+    public undo(context: AddMIConnectionsContext): void | Promise<void> {
+        context.connections = [];
+    }
+
     private async getPicks(context: AddMIConnectionsContext): Promise<IAzureQuickPickItem<Connection>[]> {
         return context.functionapp ? this.getRemoteQuickPicks(context) : this.getLocalQuickPicks(context)
     }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4445

Going back doesn't reset objects on the context, it also undoes primitives by default. There is an undo function that will allow you to set specialized behavior for steps which is what I did.