### PR TITLE
Add setting to allow users to select programming model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1291,6 +1291,11 @@
                         "type": "boolean",
                         "description": "%azureFunctions.showMarkdownPreview%",
                         "default": true
+                    },
+                    "azureFunctions.allowProgrammingModelSelection": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.allowProgrammingModelSelection%",
+                        "default": false
                     }
                 }
             }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,6 @@
 {
     "azureFunctions.addBinding": "Add binding...",
+    "azureFunctions.allowProgrammingModelSelection": "Allow the user to select a programming model when creating a new function project.",
     "azureFunctions.appSettings.add": "Add New Setting...",
     "azureFunctions.appSettings.decrypt": "Decrypt Settings",
     "azureFunctions.appSettings.delete": "Delete Setting...",

--- a/src/commands/createNewProject/ProgrammingModelStep.ts
+++ b/src/commands/createNewProject/ProgrammingModelStep.ts
@@ -8,6 +8,7 @@ import { FuncVersion } from '../../FuncVersion';
 import { recommendedDescription } from '../../constants-nls';
 import { localize } from '../../localize';
 import { getTemplateVersionFromLanguageAndModel } from '../../utils/templateVersionUtils';
+import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { type IProjectWizardContext } from './IProjectWizardContext';
 
 export class ProgrammingModelStep extends AzureWizardPromptStep<IProjectWizardContext> {
@@ -59,7 +60,7 @@ export class ProgrammingModelStep extends AzureWizardPromptStep<IProjectWizardCo
         // auto-select the default model if there is only one
         if (this._options.models.length === 1) {
             context.languageModel = this._options.models[0].data;
-        } else if (this._options.defaultModel !== undefined) {
+        } else if (this._options.defaultModel !== undefined && !getWorkspaceSetting("allowProgrammingModelSelection")) {
             context.languageModel = this._options.defaultModel;
         }
     }


### PR DESCRIPTION
There are some triggers that exist in the newest models (such as SQL Trigger).

I really don't like blocking users from existing features if they were utilizing it before, so I'd at least like to enable users to get access to the old models again if they do need it.