### PR TITLE
Add app settings required for MI for triggers keys

### DIFF
--- a/src/utils/managedIdentityUtils.ts
+++ b/src/utils/managedIdentityUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { type NameValuePair } from "@azure/arm-appservice";
+import { nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type IFunctionAppWizardContext } from "../commands/createFunctionApp/IFunctionAppWizardContext";
 import { ConnectionKey } from "../constants";
 
@@ -22,6 +23,14 @@ export function createAzureWebJobsStorageManagedIdentitySettings(context: IFunct
         appSettings.push({
             name: `${ConnectionKey.Storage}__tableServiceUri`,
             value: `https://${storageAccountName}.table.core.windows.net`
+        });
+        appSettings.push({
+            name: `${ConnectionKey.Storage}__clientId`,
+            value: nonNullValueAndProp(context.managedIdentity, 'clientId')
+        });
+        appSettings.push({
+            name: `${ConnectionKey.Storage}__credential`,
+            value: 'managedIdentity'
         });
     }
 


### PR DESCRIPTION
I didn't think that these settings were required for all triggers, just like storage and other Azure specific ones, but turns out the keys can't be retrieved for even http triggers without them, so we should just add it on app creation.