### PR TITLE
Add step to prompt about app's authentication type

### DIFF
--- a/src/commands/addMIConnections/SettingsAddBaseStep.ts
+++ b/src/commands/addMIConnections/SettingsAddBaseStep.ts
@@ -158,7 +158,7 @@ function getClientIdAndCredentialPropertiesForRemote(context: AddMIConnectionsCo
             },
             {
                 name: `${connectionName}__credential`,
-                value: 'managedIdentity'
+                value: 'managedidentity'
             }
         );
     }

--- a/src/commands/createFunctionApp/AuthenticationPromptStep.ts
+++ b/src/commands/createFunctionApp/AuthenticationPromptStep.ts
@@ -6,6 +6,8 @@
 import { UserAssignedIdentityListStep } from "@microsoft/vscode-azext-azureutils";
 import { AzureWizardPromptStep, type IAzureQuickPickOptions, type IWizardOptions } from "@microsoft/vscode-azext-utils";
 import { type QuickPickItem } from "vscode";
+
+import { localize } from "../../localize";
 import { type IFunctionAppWizardContext } from "./IFunctionAppWizardContext";
 
 export class AuthenticationPromptStep<T extends IFunctionAppWizardContext> extends AzureWizardPromptStep<T> {
@@ -35,14 +37,15 @@ export class AuthenticationPromptStep<T extends IFunctionAppWizardContext> exten
         return undefined;
     }
 
-    private async getQuickPicks(_wizardContext: T): Promise<QuickPickItem[]> {
+    private getQuickPicks(_wizardContext: T): QuickPickItem[] {
         return [
             {
-                label: 'Secrets',
+                label: localize('secrets', 'Secrets'),
+                detail: localize('secretsDetails', 'Uses storage connection strings which may be insecure and expose sensitive credentials.')
             },
             {
-                label: 'Managed identity',
-                detail: 'For best security practice, use managed idenity authentication when available (some resources may only use secrets).',
+                label: localize('managedIdentity', 'Managed identity'),
+                detail: localize('managedIdentityDetails', 'For best security practice, use managed identity authentication when available.'),
             },
         ]
     }

--- a/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
+++ b/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, AppServicePlanListStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice";
-import { CommonRoleDefinitions, createRoleId, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, RoleAssignmentExecuteStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, UserAssignedIdentityCreateStep, UserAssignedIdentityListStep, type INewStorageAccountDefaults, type Role } from "@microsoft/vscode-azext-azureutils";
+import { CommonRoleDefinitions, createRoleId, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, RoleAssignmentExecuteStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, UserAssignedIdentityListStep, type INewStorageAccountDefaults, type Role } from "@microsoft/vscode-azext-azureutils";
 import { type AzureWizardExecuteStep, type AzureWizardPromptStep, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from "../../FuncVersion";
 import { funcVersionSetting } from "../../constants";
@@ -12,6 +12,7 @@ import { tryGetLocalFuncVersion } from "../../funcCoreTools/tryGetLocalFuncVersi
 import { type ICreateFunctionAppContext } from "../../tree/SubscriptionTreeItem";
 import { createActivityContext } from "../../utils/activityUtils";
 import { getRootFunctionsWorkerRuntime, getWorkspaceSetting, getWorkspaceSettingFromAnyFolder } from "../../vsCodeConfig/settings";
+import { AuthenticationPromptStep } from "./AuthenticationPromptStep";
 import { FunctionAppCreateStep } from "./FunctionAppCreateStep";
 import { FunctionAppHostingPlanStep } from "./FunctionAppHostingPlanStep";
 import { type IFunctionAppWizardContext } from "./IFunctionAppWizardContext";
@@ -64,6 +65,7 @@ export async function createCreateFunctionAppComponents(context: ICreateFunction
         promptSteps.push(...functionAppWizard.promptSteps);
         executeSteps.push(...functionAppWizard.executeSteps);
     }
+    promptSteps.push(new AuthenticationPromptStep());
 
     if (!wizardContext.advancedCreation) {
         LocationListStep.addStep(wizardContext, promptSteps);
@@ -73,7 +75,6 @@ export async function createCreateFunctionAppComponents(context: ICreateFunction
         executeSteps.push(new ResourceGroupCreateStep());
         executeSteps.push(new StorageAccountCreateStep(storageAccountCreateOptions));
         executeSteps.push(new AppInsightsCreateStep());
-        executeSteps.push(new UserAssignedIdentityCreateStep());
         if (!context.dockerfilePath) {
             executeSteps.push(new AppServicePlanCreateStep());
             executeSteps.push(new LogAnalyticsCreateStep());

--- a/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
+++ b/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
@@ -104,8 +104,8 @@ export async function createCreateFunctionAppComponents(context: ICreateFunction
     executeSteps.push(new RoleAssignmentExecuteStep(() => {
         const role: Role = {
             scopeId: wizardContext?.storageAccount?.id,
-            roleDefinitionId: createRoleId(wizardContext?.subscriptionId, CommonRoleDefinitions.storageBlobDataOwner),
-            roleDefinitionName: CommonRoleDefinitions.storageBlobDataOwner.roleName
+            roleDefinitionId: createRoleId(wizardContext?.subscriptionId, CommonRoleDefinitions.storageBlobDataContributor),
+            roleDefinitionName: CommonRoleDefinitions.storageBlobDataContributor.roleName
         };
 
         return [role];

--- a/src/commands/createFunctionApp/flex/InstanceMemoryMBPromptStep.ts
+++ b/src/commands/createFunctionApp/flex/InstanceMemoryMBPromptStep.ts
@@ -22,6 +22,13 @@ export class InstanceMemoryMBPromptStep extends AzureWizardPromptStep<IFlexFunct
         return !context.newFlexInstanceMemoryMB;
     }
 
+    public configureBeforePrompt(context: IFlexFunctionAppWizardContext): void | Promise<void> {
+        // use default instance memory size if not using advanced creation
+        if (!context.advancedCreation) {
+            context.newFlexInstanceMemoryMB = context.newFlexSku?.instanceMemoryMB.find(im => im.isDefault)?.size;
+        }
+    }
+
     private getPicks(flexSku: Sku): IAzureQuickPickItem<number>[] {
         const picks = flexSku.instanceMemoryMB.map(im => { return { label: im.size.toString(), data: im.size, description: im.isDefault ? 'Default' : undefined } });
         return picks.sort((a, b) => Number(!!b.description) - Number(!!a.description));

--- a/src/commands/createFunctionApp/flex/MaximumInstanceCountPromptStep.ts
+++ b/src/commands/createFunctionApp/flex/MaximumInstanceCountPromptStep.ts
@@ -24,6 +24,13 @@ export class MaximumInstanceCountPromptStep extends AzureWizardPromptStep<IFlexF
         return !context.newFlexMaximumInstanceCount;
     }
 
+    public configureBeforePrompt(context: IFlexFunctionAppWizardContext): void | Promise<void> {
+        // use default maximum instance count if not using advanced creation
+        if (!context.advancedCreation) {
+            context.newFlexMaximumInstanceCount = context.newFlexSku?.maximumInstanceCount.defaultValue;
+        }
+    }
+
     private validateInput(flexSku: Sku, val: string): string | undefined {
         const num = Number(val);
 

--- a/src/utils/managedIdentityUtils.ts
+++ b/src/utils/managedIdentityUtils.ts
@@ -30,7 +30,7 @@ export function createAzureWebJobsStorageManagedIdentitySettings(context: IFunct
         });
         appSettings.push({
             name: `${ConnectionKey.Storage}__credential`,
-            value: 'managedIdentity'
+            value: 'managedidentity'
         });
     }
 


### PR DESCRIPTION
The new prompt asks a user for using secrets of managed identity. There have been enough issues with MI that we should offer users the old method of creating even if it's less secure.

Other small changes include:
- The app setting is supposed to be `managedidentity` apparently (note the lack of a capitial I)
- Documentation/Portal states that you only need Storage Data Blob Contributor role
- Don't prompt for instance memory size or maximum instance count for basic create