### PR TITLE
Add python 3.12 into supported version

### DIFF
--- a/src/commands/createNewProject/pythonSteps/pythonVersion.ts
+++ b/src/commands/createNewProject/pythonSteps/pythonVersion.ts
@@ -36,7 +36,9 @@ export async function getSupportedPythonVersions(context: IActionContext, funcVe
         ['3.0.2245', '3.8'],
         ['3.0.3216', '3.9'],
         ['4.0.4915', '3.10'],
-        ['4.0.5348', '3.11']
+        ['4.0.5348', '3.11'],
+        // not sure if this is the minimum version, but I confirmed that 4.0.7030 works with Python 3.12
+        ['4.0.7030', '3.12'],
     ];
 
     for (const [minFuncVersion, pyVersion] of versionInfo) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4499

If I find out the actual minimum version for 3.12, I'll change it but I figured that there's no harm in making sure that the user is somewhat up to date with the Functions CLI.

Confirmed project creates and debugs and that 3.12 is also available on the Azure Portal.