### PR TITLE
Refactor getSite to initSite and use a get site to type guard

### DIFF
--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -7,7 +7,7 @@ import { ResolvedContainerizedFunctionAppResource } from "./tree/containerizedFu
 import { createResourceGraphClient } from "./utils/azureClients";
 
 export type FunctionAppModel = {
-    pricingTier: string,
+    isFlex: boolean,
     id: string,
     kind: string,
     name: string,
@@ -36,11 +36,12 @@ export class FunctionAppResolver implements AppResourceResolver {
     public async resolveResource(subContext: ISubscriptionContext, resource: AppResource): Promise<ResolvedFunctionAppResource | ResolvedContainerizedFunctionAppResource | undefined> {
         return await callWithTelemetryAndErrorHandling('resolveResource', async (context: IActionContext) => {
             if (this.siteCacheLastUpdated < Date.now() - 1000 * 3) {
+                // do this before the graph client is created because the async graph client create takes enough time to mess up the following resolves
+                this.loaded = false;
+                this.siteCache.clear(); // clear the cache before fetching new data
                 this.siteCacheLastUpdated = Date.now();
                 const graphClient = await createResourceGraphClient({ ...context, ...subContext });
                 async function fetchAllApps(graphClient: ResourceGraphClient, subContext: ISubscriptionContext, resolver: FunctionAppResolver): Promise<void> {
-                    resolver.loaded = false;
-                    resolver.siteCache.clear(); // clear the cache before fetching new data
                     const query = `resources | where type == 'microsoft.web/sites' and kind contains 'functionapp' and kind !contains 'workflowapp'`;
 
                     async function fetchApps(skipToken?: string): Promise<void> {
@@ -55,7 +56,7 @@ export class FunctionAppResolver implements AppResourceResolver {
                         const record = response.data as Record<string, FunctionQueryModel>;
                         Object.values(record).forEach(data => {
                             const dataModel: FunctionAppModel = {
-                                pricingTier: data.properties.sku,
+                                isFlex: data.properties.sku.toLocaleLowerCase() === 'flexconsumption',
                                 id: data.id,
                                 kind: data.kind,
                                 name: data.name,
@@ -86,14 +87,15 @@ export class FunctionAppResolver implements AppResourceResolver {
                 await this.listFunctionAppsTask;
             }
 
-            const site = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
-            if (nonNullValueAndProp(site, 'kind') === 'functionapp,linux,container,azurecontainerapps') {
+            const siteModel = this.siteCache.get(nonNullProp(resource, 'id').toLowerCase());
+            if (nonNullValueAndProp(siteModel, 'kind') === 'functionapp,linux,container,azurecontainerapps') {
+                // need the full site to resolve containerized function apps
                 const client = await createWebSiteClient({ ...context, ...subContext });
-                const fullSite = await client.webApps.get(nonNullValueAndProp(site, 'resourceGroup'), nonNullValueAndProp(site, 'name'));
+                const fullSite = await client.webApps.get(nonNullValueAndProp(siteModel, 'resourceGroup'), nonNullValueAndProp(siteModel, 'name'));
                 return ResolvedContainerizedFunctionAppResource.createResolvedFunctionAppResource(context, subContext, fullSite);
             }
-            if (site) {
-                return new ResolvedFunctionAppResource(subContext, site);
+            if (siteModel) {
+                return new ResolvedFunctionAppResource(subContext, undefined, siteModel);
             }
 
             return undefined;

--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -9,6 +9,7 @@ import { createResourceGraphClient } from "./utils/azureClients";
 export type FunctionAppModel = {
     isFlex: boolean,
     id: string,
+    type: string,
     kind: string,
     name: string,
     resourceGroup: string,
@@ -23,6 +24,7 @@ type FunctionQueryModel = {
     },
     location: string,
     id: string,
+    type: string,
     kind: string,
     name: string,
     resourceGroup: string
@@ -58,6 +60,7 @@ export class FunctionAppResolver implements AppResourceResolver {
                             const dataModel: FunctionAppModel = {
                                 isFlex: data.properties.sku.toLocaleLowerCase() === 'flexconsumption',
                                 id: data.id,
+                                type: data.type,
                                 kind: data.kind,
                                 name: data.name,
                                 resourceGroup: data.resourceGroup,

--- a/src/commands/browseWebsite.ts
+++ b/src/commands/browseWebsite.ts
@@ -13,6 +13,6 @@ export async function browseWebsite(context: IActionContext, node?: SlotTreeItem
     if (!node) {
         node = await pickAppResource(context);
     }
-
-    await openUrl(nonNullValueAndProp(await node.getSite(context), 'defaultHostUrl'));
+    await node.initSite(context);
+    await openUrl(nonNullValueAndProp(node.site, 'defaultHostUrl'));
 }

--- a/src/commands/configureDeploymentSource.ts
+++ b/src/commands/configureDeploymentSource.ts
@@ -13,7 +13,8 @@ export async function configureDeploymentSource(context: IActionContext, node?: 
         node = await pickFunctionApp(context);
     }
 
-    const updatedScmType: string | undefined = await editScmType(context, (await node.getSite(context)), node.subscription);
+    await node.initSite(context);
+    const updatedScmType: string | undefined = await editScmType(context, node.site, node.subscription);
     if (updatedScmType !== undefined) {
         context.telemetry.properties.updatedScmType = updatedScmType;
     }

--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -369,10 +369,10 @@ export async function getEolWarningMessages(context: ISubscriptionActionContext,
 
 export async function showEolWarningIfNecessary(context: ISubscriptionActionContext, parent: AzExtParentTreeItem, client?: IAppSettingsClient) {
     if (isResolvedFunctionApp(parent)) {
-        const site = await parent.getSite(context);
-        client = client ?? await site.createClient(context);
+        await parent.initSite(context);
+        client = client ?? await parent.site.createClient(context);
         const eolWarningMessage = await getEolWarningMessages(context, {
-            site: site.rawSite,
+            site: parent.site.rawSite,
             isLinux: client.isLinux,
             isFlex: parent.isFlex,
             client

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -83,7 +83,8 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
         return await getOrCreateFunctionApp(context)
     });
 
-    const site = await node.resolved.getSite(context);
+    await node.initSite(context);
+    const site = node.resolved.site;
 
     if (node.contextValue.includes('container')) {
         const learnMoreLink: string = 'https://aka.ms/deployContainerApps'

--- a/src/commands/deploy/getWarningsForConnectionSettings.ts
+++ b/src/commands/deploy/getWarningsForConnectionSettings.ts
@@ -32,11 +32,11 @@ export async function getWarningsForConnectionSettings(context: IActionContext,
 
         const localConnectionSettings = await getConnectionSettings(localSettings.Values ?? {});
         const remoteConnectionSettings = await getConnectionSettings(options.appSettings?.properties ?? {});
-        const site = await options.node.getSite(context);
+        await options.node.initSite(context);
 
         if (localConnectionSettings.some(setting => setting.type === 'ManagedIdentity')) {
-            if (!site.rawSite.identity ||
-                site.rawSite.identity.type === 'None') {
+            if (!options.node.site.rawSite.identity ||
+                options.node.site.rawSite.identity.type === 'None') {
                 // if they have nothing in remote, warn them to connect a managed identity
                 return localize('configureManagedIdentityWarning',
                     'Your app is not connected to a managed identity. To ensure access, please configure a managed identity. Without it, your application may encounter authorization issues.');

--- a/src/commands/deploy/notifyDeployComplete.ts
+++ b/src/commands/deploy/notifyDeployComplete.ts
@@ -17,7 +17,8 @@ import { startStreamingLogs } from '../logstream/startStreamingLogs';
 import { hasRemoteEventGridBlobTrigger, promptForEventGrid } from './promptForEventGrid';
 
 export async function notifyDeployComplete(context: IActionContext, node: SlotTreeItem, workspaceFolder: WorkspaceFolder, isFlexConsumption?: boolean): Promise<void> {
-    const deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', (await node.getSite(context)).fullName);
+    await node.initSite(context);
+    const deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', node.site.fullName);
     const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
     const streamLogs: MessageItem = { title: localize('streamLogs', 'Stream logs') };
     const uploadSettings: MessageItem = { title: localize('uploadAppSettings', 'Upload settings') };
@@ -37,6 +38,7 @@ export async function notifyDeployComplete(context: IActionContext, node: SlotTr
             postDeployContext.telemetry.properties.dialogResult = result && result.title;
             postDeployContext.valuesToMask.push(...context.valuesToMask);
             context.telemetry.eventVersion = 2;
+            await node.initSite(context);
 
             if (result === viewOutput) {
                 ext.outputChannel.show();
@@ -45,7 +47,7 @@ export async function notifyDeployComplete(context: IActionContext, node: SlotTr
             } else if (result === uploadSettings) {
                 const subContext = {
                     ...postDeployContext,
-                    ...(await node.getSite(context)).subscription
+                    ...node.site.subscription
                 }
                 await uploadAppSettings(subContext, node.appSettingsTreeItem, undefined, workspaceFolder);
             }
@@ -60,7 +62,7 @@ export async function notifyDeployComplete(context: IActionContext, node: SlotTr
                 const message: string = currentAttempt === 1 ?
                     localize('queryingTriggers', 'Querying triggers...') :
                     localize('queryingTriggersAttempt', 'Querying triggers (Attempt {0}/{1})...', currentAttempt, retries + 1);
-                ext.outputChannel.appendLog(message, { resourceName: (await node.getSite(context)).fullName });
+                ext.outputChannel.appendLog(message, { resourceName: node.site.fullName });
                 await listHttpTriggerUrls(context, node);
             },
             { retries, minTimeout: 2 * 1000 }
@@ -77,8 +79,8 @@ async function listHttpTriggerUrls(context: IActionContext, node: SlotTreeItem):
     const children: AzExtTreeItem[] = await node.getCachedChildren(context);
     const functionsNode: RemoteFunctionsTreeItem = <RemoteFunctionsTreeItem>children.find(n => n instanceof RemoteFunctionsTreeItem);
     await node.treeDataProvider.refresh(context, functionsNode);
-
-    const logOptions: {} = { resourceName: (await node.getSite(context)).fullName };
+    await node.initSite(context);
+    const logOptions: {} = { resourceName: node.site.fullName };
     let hasHttpTriggers: boolean = false;
     const functions: AzExtTreeItem[] = await functionsNode.getCachedChildren(context);
     const anonFunctions: RemoteFunctionTreeItem[] = <RemoteFunctionTreeItem[]>functions.filter(f => f instanceof RemoteFunctionTreeItem && f.isHttpTrigger && f.isAnonymous);

--- a/src/commands/deploy/promptForEventGrid.ts
+++ b/src/commands/deploy/promptForEventGrid.ts
@@ -14,7 +14,8 @@ import { getWorkspaceSetting, updateWorkspaceSetting } from "../../vsCodeConfig/
 
 export async function hasRemoteEventGridBlobTrigger(context: IActionContext, node: SlotTreeItem): Promise<boolean> {
     const retries = 3;
-    const client = await (await node.getSite(context)).createClient(context);
+    await node.initSite(context);
+    const client = await node.site.createClient(context);
 
     const funcs = await retry<FunctionEnvelope[]>(
         async () => {

--- a/src/commands/deploy/verifyAppSettings.ts
+++ b/src/commands/deploy/verifyAppSettings.ts
@@ -34,19 +34,20 @@ export async function verifyAppSettings(options: {
 }): Promise<void> {
 
     const { context, node, projectPath, version, language, bools, durableStorageType } = options;
-    const client = await (await node.getSite(context)).createClient(context);
+    await node.initSite(context);
+    const client = await node.site.createClient(context);
     const appSettings: StringDictionary = options.appSettings;
     if (appSettings.properties) {
         const remoteRuntime: string | undefined = appSettings.properties[workerRuntimeKey];
-        await verifyVersionAndLanguage(context, projectPath, (await node.getSite(context)).fullName, version, language, appSettings.properties);
+        await verifyVersionAndLanguage(context, projectPath, node.site.fullName, version, language, appSettings.properties);
 
         // update the settings if the remote runtime was changed
         let updateAppSettings: boolean = appSettings.properties[workerRuntimeKey] !== remoteRuntime;
-        if ((await node.getSite(context)).isLinux) {
+        if (node.site.isLinux) {
             const remoteBuildSettingsChanged = verifyLinuxRemoteBuildSettings(context, appSettings.properties, bools);
             updateAppSettings ||= remoteBuildSettingsChanged;
         } else {
-            updateAppSettings ||= verifyRunFromPackage(context, (await node.getSite(context)), appSettings.properties);
+            updateAppSettings ||= verifyRunFromPackage(context, node.site, appSettings.properties);
         }
 
         const updatedRemoteConnection: boolean = await verifyAndUpdateAppConnectionStrings(context, durableStorageType, appSettings.properties);

--- a/src/commands/executeFunction/executeFunction.ts
+++ b/src/commands/executeFunction/executeFunction.ts
@@ -99,10 +99,11 @@ export async function executeFunctionWithInput(context: IActionContext, function
         const headers = createHttpHeaders({
             'Content-Type': 'application/json',
         });
-
-        const client: SiteClient | undefined = node instanceof RemoteFunctionTreeItem ?
-            await (await node.parent.parent.getSite(context)).createClient(context) :
-            undefined;
+        let client: SiteClient | undefined;
+        if (node instanceof RemoteFunctionTreeItem) {
+            await node.parent.parent.initSite(context);
+            client = await node.parent.parent.site.createClient(context);
+        }
 
         if (client) {
             headers.set('x-functions-key', (await client.listHostKeys()).masterKey ?? '');

--- a/src/commands/identity/assignManagedIdentity.ts
+++ b/src/commands/identity/assignManagedIdentity.ts
@@ -21,17 +21,18 @@ export async function assignManagedIdentity(context: IActionContext, node?: User
         node = node.parent as SlotTreeItem;
     }
 
+    await node.initSite(context);
     const wizardContext: ManagedIdentityAssignContext = {
         ...context,
-        site: (await node.getSite(context)),
+        site: node.site,
         resourceGroup: {
-            name: (await node.getSite(context)).resourceGroup,
-            location: (await node.getSite(context)).location,
+            name: node.site.resourceGroup,
+            location: node.site.location,
         }, // we only need these two properties from the resource group
         ...node.subscription,
         ...(await createActivityContext())
     }
-    await LocationListStep.setLocation(wizardContext, (await node.getSite(context)).location);
+    await LocationListStep.setLocation(wizardContext, node.site.location);
 
     const promptSteps: AzureWizardPromptStep<ManagedIdentityAssignContext>[] = [
         new UserAssignedIdentityListStep()

--- a/src/commands/identity/enableSystemIdentity.ts
+++ b/src/commands/identity/enableSystemIdentity.ts
@@ -19,8 +19,10 @@ export async function enableSystemIdentity(context: IActionContext, node?: Syste
     } else {
         slotTreeItem = node.parent.parent;
     }
-    const site = await slotTreeItem.getSite(context);
-    const title: string = localize('enabling', 'Enable system assigned identity for "{0}".', site.fullName);
+
+    await slotTreeItem.initSite(context);
+    const site = slotTreeItem.site;
+    const title: string = localize('enabling', 'Enable system assigned identity for "{0}".', slotTreeItem.site.fullName);
 
     const wizardContext: ManagedIdentityAssignContext & ExecuteActivityContext = Object.assign(context, {
         site,

--- a/src/commands/identity/unassignManagedIdentity.ts
+++ b/src/commands/identity/unassignManagedIdentity.ts
@@ -14,7 +14,8 @@ import { ManagedIdentityUnassignStep } from './ManagedIdentityUnassignStep';
 export async function unassignManagedIdentity(context: IActionContext, node: UserAssignedIdentityTreeItem): Promise<void> {
 
     const slotTreeItem = node.parent.parent as SlotTreeItem;
-    const site = await slotTreeItem.getSite(context);
+    await slotTreeItem.initSite(context);
+    const site = slotTreeItem.site;
     const wizardContext: ManagedIdentityAssignContext = {
         ...context,
         site,

--- a/src/commands/logstream/startStreamingLogs.ts
+++ b/src/commands/logstream/startStreamingLogs.ts
@@ -23,9 +23,16 @@ export async function startStreamingLogs(context: IActionContext, treeItem?: Slo
         treeItem = await pickFunctionApp(context);
     }
 
-    const site: ParsedSite = isSlotTreeItem(treeItem) ?
-        await treeItem.getSite(context) :
-        await treeItem.parent.parent.getSite(context);
+    let site: ParsedSite;
+    if (isSlotTreeItem(treeItem)) {
+        // If it's a SlotTreeItem, we need to ensure the site is initialized
+        await treeItem.initSite(context);
+        site = treeItem.site;
+    } else {
+        // If it's a RemoteFunctionTreeItem, we need to get the parent SlotTreeItem
+        await treeItem.parent.parent.initSite(context);
+        site = treeItem.parent.parent.site;
+    }
 
     if (site.isLinux) {
         try {

--- a/src/commands/logstream/stopStreamingLogs.ts
+++ b/src/commands/logstream/stopStreamingLogs.ts
@@ -15,8 +15,15 @@ export async function stopStreamingLogs(context: IActionContext, node?: SlotTree
         node = await pickFunctionApp({ ...context, suppressCreatePick: true });
     }
 
-    const site: ParsedSite = isSlotTreeItem(node) ?
-        await node.getSite(context) :
-        await node.parent.parent.getSite(context);
+    let site: ParsedSite;
+    if (isSlotTreeItem(node)) {
+        // If it's a SlotTreeItem, we need to ensure the site is initialized
+        await node.initSite(context);
+        site = node.site;
+    } else {
+        // If it's a RemoteFunctionTreeItem, we need to get the parent SlotTreeItem
+        await node.parent.parent.initSite(context);
+        site = node.parent.parent.site;
+    }
     await appservice.stopStreamingLogs(site, node.logStreamPath);
 }

--- a/src/commands/remoteDebug/startRemoteDebug.ts
+++ b/src/commands/remoteDebug/startRemoteDebug.ts
@@ -16,7 +16,8 @@ export async function startRemoteDebug(context: IActionContext, node?: SlotTreeI
         node = await pickFunctionApp(context);
     }
 
-    const siteClient = await (await node.getSite(context)).createClient(context);
+    await node.initSite(context);
+    const siteClient = await node.site.createClient(context);
     const siteConfig: SiteConfig = await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, cancellable: true }, async (progress, token) => {
         appservice.reportMessage('Fetching site configuration...', progress, token);
         return await siteClient.getSiteConfig();
@@ -26,9 +27,9 @@ export async function startRemoteDebug(context: IActionContext, node?: SlotTreeI
     const language: appservice.RemoteDebugLanguage = getRemoteDebugLanguage(siteConfig, appServicePlan?.sku?.family);
 
     await appservice.startRemoteDebug(context, {
-        site: (await node.getSite(context)),
+        site: node.site,
         siteConfig,
         language,
-        credentials: (await node.getSite(context)).subscription.credentials
+        credentials: node.site.subscription.credentials
     });
 }

--- a/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
+++ b/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
@@ -21,10 +21,11 @@ export async function remoteDebugJavaFunctionApp(context: IActionContext, node?:
     if (!node) {
         node = await pickFunctionApp(context);
     }
-    const client: SiteClient = await (await node.getSite(context)).createClient(context);
+    await node.initSite(context);
+    const client: SiteClient = await node.site.createClient(context);
     const portNumber: number = await findFreePort();
     const publishCredential: User = await client.getWebAppPublishCredential();
-    const debugProxy: DebugProxy = new DebugProxy((await node.getSite(context)), portNumber, publishCredential);
+    const debugProxy: DebugProxy = new DebugProxy(node.site, portNumber, publishCredential);
 
     debugProxy.on('error', (err: Error) => {
         debugProxy.dispose();

--- a/src/commands/startFunctionApp.ts
+++ b/src/commands/startFunctionApp.ts
@@ -14,8 +14,8 @@ export async function startFunctionApp(context: IActionContext, node?: SlotTreeI
         node = await pickFunctionApp(context);
     }
 
-    const site = await node.getSite(context);
-    const client: SiteClient = await site.createClient(context);
+    await node.initSite(context);
+    const client: SiteClient = await node.site.createClient(context);
     await node.runWithTemporaryDescription(
         context,
         localize('starting', 'Starting...'),

--- a/src/commands/stopFunctionApp.ts
+++ b/src/commands/stopFunctionApp.ts
@@ -14,7 +14,8 @@ export async function stopFunctionApp(context: IActionContext, node?: SlotTreeIt
         node = await pickFunctionApp(context);
     }
 
-    const client: SiteClient = await (await node.getSite(context)).createClient(context);
+    await node.initSite(context);
+    const client: SiteClient = await node.site.createClient(context);
     await node.runWithTemporaryDescription(
         context,
         localize('stopping', 'Stopping...'),

--- a/src/commands/swapSlot.ts
+++ b/src/commands/swapSlot.ts
@@ -16,8 +16,8 @@ export async function swapSlot(context: IActionContext, sourceSlotNode?: SlotTre
         });
     }
 
-    const sourceSlotNodeSite = await sourceSlotNode.getSite(context);
+    await sourceSlotNode.initSite(context);
     const deploymentSlots: SlotTreeItem[] = <SlotTreeItem[]>await sourceSlotNode.parent?.getCachedChildren(context);
-    await appservice.swapSlot(context, sourceSlotNodeSite, deploymentSlots.map(ds => ds.site));
+    await appservice.swapSlot(context, sourceSlotNode.site, deploymentSlots.map(ds => ds.site));
     await sourceSlotNode.parent?.parent?.refresh(context);
 }

--- a/src/commands/viewProperties.ts
+++ b/src/commands/viewProperties.ts
@@ -20,7 +20,8 @@ export async function viewProperties(context: IActionContext, node: SlotTreeItem
     } else if (node instanceof ContainerFunctionTreeItem) {
         await openReadOnlyJson(node, node.rawConfig);
     } else {
-        const site: ParsedSite = await node.getSite(context);
+        await node.initSite(context);
+        const site: ParsedSite = node.site;
         await node.runWithTemporaryDescription(context, localize('retrievingProps', 'Retrieving properties...'), async () => {
             // `siteConfig` already exists on `node.site`, but has very limited properties for some reason. We want to get the full site config
             const client = await site.createClient(context);

--- a/src/downloadAzureProject/setupProjectFolder.ts
+++ b/src/downloadAzureProject/setupProjectFolder.ts
@@ -37,7 +37,8 @@ export async function setupProjectFolder(uri: vscode.Uri, vsCodeFilePathUri: vsc
                 throw new Error(localize('failedToFindApp', 'Failed to find function app with id "{0}"', resourceId));
             }
 
-            const site = await slotTreeItem.getSite(context);
+            await slotTreeItem.initSite(context);
+            const site = slotTreeItem.site;
             const client = await site.createClient(context);
             const hostKeys: HostKeys | undefined = await client.listHostKeys();
             const defaultHostName: string | undefined = site.defaultHostName;

--- a/src/tree/ResolvedFunctionAppBase.ts
+++ b/src/tree/ResolvedFunctionAppBase.ts
@@ -3,6 +3,7 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+import { type Site } from "@azure/arm-appservice";
 import { type ParsedSite } from "@microsoft/vscode-azext-azureappservice";
 import { nonNullValueAndProp, type AzExtTreeItem, type IActionContext, type TreeItemIconPath } from "@microsoft/vscode-azext-utils";
 import { type ResolvedAppResourceBase } from "@microsoft/vscode-azext-utils/hostapi";
@@ -13,15 +14,18 @@ import { type ApplicationSettings, type FuncHostRequest } from "./IProjectTreeIt
 import { type ContainerSite } from "./containerizedFunctionApp/ResolvedContainerizedFunctionAppResource";
 
 export abstract class ResolvedFunctionAppBase implements ResolvedAppResourceBase {
-    public site: ContainerSite | ParsedSite;
+    protected abstract _site: ContainerSite | ParsedSite | undefined;
     public get name(): string {
         return this.label;
     }
 
+    public data: Site;
     public abstract label: string;
+    public abstract get site(): ContainerSite | ParsedSite;
+    public abstract set site(value: ContainerSite | ParsedSite);
 
     public get id(): string {
-        return this.site?.id || '';
+        return this.data?.id || '';
     }
 
     public abstract iconPath?: TreeItemIconPath | undefined;
@@ -30,7 +34,7 @@ export abstract class ResolvedFunctionAppBase implements ResolvedAppResourceBase
 
     public get viewProperties(): ViewPropertiesModel {
         return {
-            data: this.site,
+            data: this.data,
             label: this.name,
         }
     }
@@ -41,6 +45,10 @@ export abstract class ResolvedFunctionAppBase implements ResolvedAppResourceBase
 
     public async getHostRequest(): Promise<FuncHostRequest> {
         return { url: nonNullValueAndProp(this.site, 'defaultHostUrl') }
+    }
+
+    public getDefaultHostUrl(): string {
+        return nonNullValueAndProp(this.site, 'defaultHostUrl');
     }
 
     public abstract getApplicationSettings(context: IActionContext): Promise<ApplicationSettings>;

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -105,7 +105,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
                 void this.initSite(context);
             });
             // If the site is not initialized, we should throw an error
-            throw new Error(localize('siteNotSet', 'Site has not initialized. Please try again in a moment.'));
+            throw new Error(localize('siteNotSet', 'Site is not initialized. Please try again in a moment.'));
         }
         return this._site;
     }
@@ -128,6 +128,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         return {
             id: site.id ?? '',
             name: site.name ?? '',
+            type: site.type ?? '',
             kind: site.kind ?? '',
             location: site.location,
             resourceGroup: site.resourceGroup ?? '',
@@ -145,10 +146,11 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     }
 
     public get description(): string | undefined {
-        if (this._isFlex) {
-            return localize('flexFunctionApp', 'Flex Consumption');
+        let state = this._state?.toLowerCase() !== 'running' ? this._state : undefined;
+        if (this._isFlex && !state) {
+            state = localize('flexFunctionAppState', 'Flex Consumption');
         }
-        return this._state?.toLowerCase() !== 'running' ? this._state : undefined;
+        return state;
     }
 
     public get iconPath(): TreeItemIconPath {
@@ -175,6 +177,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         // on refresh, we should reinitialize the site to ensure we have the latest data
         const client = await this.site.createClient(context);
         this._site = new ParsedSite(nonNullValue(await client.getSite(), 'site'), this._subscription);
+        this.dataModel = this.createDataModelFromSite(this._site.rawSite);
     }
 
     public async getVersion(context: IActionContext): Promise<FuncVersion> {

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -74,12 +74,10 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         if (dataModel) {
             this._isFlex = dataModel.isFlex;
             this.dataModel = dataModel;
-            this.data = dataModel
         } else if (site) {
             this._site = new ParsedSite(site, subscription);
             this.dataModel = this.createDataModelFromSite(site);
             this._isFlex = !!site.functionAppConfig;
-            this.data = this.site.rawSite;
             this.addValuesToMask(this.site);
         }
 
@@ -102,7 +100,12 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
 
     public get site(): ParsedSite {
         if (!this._site) {
-            throw new Error(localize('siteNotSet', 'Site is not set. Ensure the site is initialized before accessing it.'));
+            void callWithTelemetryAndErrorHandling('functionApp.initSiteFailed', async (context: IActionContext) => {
+                // try to lazy load the site if it hasn't been initialized yet
+                void this.initSite(context);
+            });
+            // If the site is not initialized, we should throw an error
+            throw new Error(localize('siteNotSet', 'Site has not initialized. Please try again in a moment.'));
         }
         return this._site;
     }

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -30,10 +30,9 @@ export function isResolvedFunctionApp(ti: unknown): ti is ResolvedFunctionAppRes
 }
 
 export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase implements ResolvedAppResourceBase {
-    private _site: ParsedSite;
-
+    protected _site: ParsedSite | undefined = undefined;
     public data: Site;
-    public queryResult: FunctionAppModel;
+    public dataModel: FunctionAppModel;
 
     private _subscription: ISubscriptionContext;
     public logStreamPath: string = '';
@@ -68,20 +67,20 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     tooltip?: string | undefined;
     commandArgs?: unknown[] | undefined;
 
-    public constructor(subscription: ISubscriptionContext, dataModel: FunctionAppModel | Site) {
+    public constructor(subscription: ISubscriptionContext, site: Site | undefined, dataModel?: FunctionAppModel) {
         super();
         this._subscription = subscription;
         this.contextValuesToAdd = [];
-        if ('pricingTier' in dataModel) {
-            // dataModel is narrowed to FunctionAppModel due to the above check
-            this._isFlex = dataModel.pricingTier.toLocaleLowerCase() === 'FlexConsumption'.toLocaleLowerCase();
-            this.queryResult = dataModel;
-            this.data = dataModel;
-        } else {
-            this._site = new ParsedSite(dataModel, subscription);
-            this._isFlex = !!dataModel.functionAppConfig;
-            this.data = this._site.rawSite;
-            this.addValuesToMask(this._site);
+        if (dataModel) {
+            this._isFlex = dataModel.isFlex;
+            this.dataModel = dataModel;
+            this.data = dataModel
+        } else if (site) {
+            this._site = new ParsedSite(site, subscription);
+            this.dataModel = this.createDataModelFromSite(site);
+            this._isFlex = !!site.functionAppConfig;
+            this.data = this.site.rawSite;
+            this.addValuesToMask(this.site);
         }
 
         if (this._isFlex) {
@@ -91,18 +90,21 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
     }
 
-    public async getSite(context: IActionContext): Promise<ParsedSite> {
-        let site: ParsedSite | undefined = this._site;
-        if (!site) {
+    public async initSite(context: IActionContext): Promise<void> {
+        if (!this._site) {
             const webClient = await createWebSiteClient({ ...context, ...this._subscription });
-            const rawSite = await webClient.webApps.get(this.queryResult.resourceGroup, this.queryResult.name);
-            site = new ParsedSite(rawSite, this._subscription);
+            const rawSite = await webClient.webApps.get(this.dataModel.resourceGroup, this.dataModel.name);
+            this._site = new ParsedSite(rawSite, this._subscription);
             this.data = rawSite;
-            this._site = site;
             this.addValuesToMask(this._site);
         }
+    }
 
-        return site;
+    public get site(): ParsedSite {
+        if (!this._site) {
+            throw new Error(localize('siteNotSet', 'Site is not set. Ensure the site is initialized before accessing it.'));
+        }
+        return this._site;
     }
 
     private addValuesToMask(site: ParsedSite): void {
@@ -119,12 +121,24 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         }
     }
 
+    private createDataModelFromSite(site: Site): FunctionAppModel {
+        return {
+            id: site.id ?? '',
+            name: site.name ?? '',
+            kind: site.kind ?? '',
+            location: site.location,
+            resourceGroup: site.resourceGroup ?? '',
+            status: site.state ?? 'Unknown',
+            isFlex: !!site.functionAppConfig
+        };
+    }
+
     public get label(): string {
-        return this._site?.slotName ?? this._site?.fullName ?? this.queryResult.name;
+        return this.dataModel.name;
     }
 
     public get logStreamLabel(): string {
-        return this._site.fullName ?? this.queryResult.name;
+        return this.dataModel.name;
     }
 
     public get description(): string | undefined {
@@ -140,7 +154,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     }
 
     private get _state(): string | undefined {
-        return this._site?.rawSite.state ?? this.queryResult.status;
+        return this.dataModel.status;
     }
 
     public get isFlex(): boolean {
@@ -156,7 +170,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         this._cachedIsConsumption = undefined;
 
         // on refresh, we should reinitialize the site to ensure we have the latest data
-        const client = await this._site.createClient(context);
+        const client = await this.site.createClient(context);
         this._site = new ParsedSite(nonNullValue(await client.getSite(), 'site'), this._subscription);
     }
 
@@ -165,8 +179,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         if (result === undefined) {
             let version: FuncVersion | undefined;
             try {
-                const site = await this.getSite(context);
-                const client = await site.createClient(context);
+                await this.initSite(context);
+                const client = await this.site.createClient(context);
                 const appSettings: StringDictionary = await client.listApplicationSettings();
                 version = tryParseFuncVersion(appSettings.properties && appSettings.properties.FUNCTIONS_EXTENSION_VERSION);
             } catch {
@@ -185,9 +199,9 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             let data: any;
             try {
-                const site = await this.getSite(context);
+                await this.initSite(context);
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                data = JSON.parse((await getFile(context, site, 'site/wwwroot/host.json')).data);
+                data = JSON.parse((await getFile(context, this.site, 'site/wwwroot/host.json')).data);
             } catch {
                 // ignore and use default
             }
@@ -200,15 +214,15 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     }
 
     public async getApplicationSettings(context: IActionContext): Promise<ApplicationSettings> {
-        const site = await this.getSite(context);
-        const client = await site.createClient(context);
+        await this.initSite(context);
+        const client = await this.site.createClient(context);
         const appSettings: StringDictionary = await client.listApplicationSettings();
         return appSettings.properties || {};
     }
 
     public async setApplicationSetting(context: IActionContext, key: string, value: string): Promise<void> {
-        const site = await this.getSite(context);
-        const client = await site.createClient(context);
+        await this.initSite(context);
+        const client = await this.site.createClient(context);
         const settings: StringDictionary = await client.listApplicationSettings();
         if (!settings.properties) {
             settings.properties = {};
@@ -221,8 +235,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
         let result: boolean | undefined = this._cachedIsConsumption;
         if (result === undefined) {
             try {
-                const site = await this.getSite(context);
-                const client = await site.createClient(context);
+                await this.initSite(context);
+                const client = await this.site.createClient(context);
                 result = await client.getIsConsumption(context);
             } catch {
                 // ignore and use default
@@ -235,28 +249,28 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     }
 
     public async loadMoreChildrenImpl(_clearCache: boolean, context: IActionContext): Promise<AzExtTreeItem[]> {
-        const site = await this.getSite(context);
-        const client = await site.createClient(context);
+        await this.initSite(context);
+        const client = await this.site.createClient(context);
         const siteConfig: SiteConfig = await client.getSiteConfig();
         const sourceControl: SiteSourceControl = await client.getSourceControl();
         const proxyTree: SlotTreeItem = this as unknown as SlotTreeItem;
 
         this.deploymentsNode = new DeploymentsTreeItem(proxyTree, {
-            site,
+            site: this.site,
             siteConfig,
             sourceControl,
             contextValuesToAdd: ['azFunc']
         });
-        this.appSettingsTreeItem = await AppSettingsTreeItem.createAppSettingsTreeItem(context, proxyTree, site, ext.prefix, {
+        this.appSettingsTreeItem = await AppSettingsTreeItem.createAppSettingsTreeItem(context, proxyTree, this.site, ext.prefix, {
             contextValuesToAdd: ['azFunc'],
         });
         this._siteFilesTreeItem = new SiteFilesTreeItem(proxyTree, {
-            site,
+            site: this.site,
             isReadOnly: true,
             contextValuesToAdd: ['azFunc']
         });
         this._logFilesTreeItem = new LogFilesTreeItem(proxyTree, {
-            site,
+            site: this.site,
             contextValuesToAdd: ['azFunc']
         });
 
@@ -273,7 +287,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
             children.push(this.deploymentsNode);
         }
 
-        if (!site.isSlot && !this._isFlex) {
+        if (!this.site.isSlot && !this._isFlex) {
             this._slotsTreeItem = new SlotsTreeItem(proxyTree);
             children.push(this._slotsTreeItem);
         }
@@ -284,8 +298,8 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     // eslint-disable-next-line @typescript-eslint/require-await
     public async pickTreeItemImpl(expectedContextValues: (string | RegExp)[]): Promise<AzExtTreeItem | undefined> {
         return await callWithTelemetryAndErrorHandling('functionApp.pickTreeItem', async (context: IActionContext) => {
-            const site = await this.getSite(context);
-            if (!site.isSlot) {
+            await this.initSite(context);
+            if (!this.site.isSlot) {
                 for (const expectedContextValue of expectedContextValues) {
                     switch (expectedContextValue) {
                         case SlotsTreeItem.contextValue:
@@ -331,26 +345,26 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
     }
 
     public async isReadOnly(context: IActionContext): Promise<boolean> {
-        const site = await this.getSite(context);
-        const client = await site.createClient(context);
+        await this.initSite(context);
+        const client = await this.site.createClient(context);
         const appSettings: StringDictionary = await client.listApplicationSettings();
         return [runFromPackageKey, 'WEBSITE_RUN_FROM_ZIP'].some(key => appSettings.properties && envUtils.isEnvironmentVariableSet(appSettings.properties[key]));
     }
 
     public async deleteTreeItemImpl(context: IActionContext): Promise<void> {
-        const site = await this.getSite(context);
+        await this.initSite(context);
         const wizardContext: IDeleteSiteWizardContext = Object.assign(context, {
-            site,
+            site: this.site,
             ...(await createActivityContext())
         });
 
-        const confirmationMessage: string = site.isSlot ?
-            localize('confirmDeleteSlot', 'Are you sure you want to delete slot "{0}"?', site.fullName) :
-            localize('confirmDeleteFunctionApp', 'Are you sure you want to delete function app "{0}"?', site.fullName);
+        const confirmationMessage: string = this.site.isSlot ?
+            localize('confirmDeleteSlot', 'Are you sure you want to delete slot "{0}"?', this.site.fullName) :
+            localize('confirmDeleteFunctionApp', 'Are you sure you want to delete function app "{0}"?', this.site.fullName);
 
-        const title: string = site.isSlot ?
-            localize('deleteSlot', 'Delete Slot "{0}"', site.fullName) :
-            localize('deleteFunctionApp', 'Delete Function App "{0}"', site.fullName);
+        const title: string = this.site.isSlot ?
+            localize('deleteSlot', 'Delete Slot "{0}"', this.site.fullName) :
+            localize('deleteFunctionApp', 'Delete Function App "{0}"', this.site.fullName);
 
         const wizard = new AzureWizard(wizardContext, {
             promptSteps: [new DeleteConfirmationStep(confirmationMessage), new DeleteLastServicePlanStep()],

--- a/src/tree/SlotTreeItem.ts
+++ b/src/tree/SlotTreeItem.ts
@@ -27,26 +27,32 @@ export class SlotTreeItem extends SlotContainerTreeItemBase {
 
     public resolved: ResolvedFunctionAppResource;
 
-    public constructor(parent: AzExtParentTreeItem, resolvedFunctionAppResource: ResolvedFunctionAppResource) {
+    private constructor(parent: AzExtParentTreeItem, resolvedFunctionAppResource: ResolvedFunctionAppResource, site: ParsedSite) {
         super(parent, resolvedFunctionAppResource);
         this.resolved = resolvedFunctionAppResource;
         // this is for the slotContextValue because it never gets resolved by the Resources extension
-        const slotContextValue = this.resolved.site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue;
+        const slotContextValue = site.isSlot ? ResolvedFunctionAppResource.slotContextValue : ResolvedFunctionAppResource.productionContextValue;
         const contextValues = [slotContextValue, 'slot'];
         this.contextValue = Array.from(new Set(contextValues)).sort().join(';');
-        this.site = this.resolved.site as ParsedSite;
+        this.site = site;
         this.iconPath = treeUtils.getIconPath(slotContextValue);
     }
+
+    public static async createSlotTreeItem(parent: AzExtParentTreeItem, resolvedFunctionAppResource: ResolvedFunctionAppResource): Promise<SlotTreeItem> {
+        await resolvedFunctionAppResource.initSite({} as IActionContext);
+        return new SlotTreeItem(parent, resolvedFunctionAppResource, resolvedFunctionAppResource.site);
+    }
+
+    public async initSite(context: IActionContext): Promise<void> {
+        await this.initSite(context);
+    }
+
     public get logStreamLabel(): string {
         return this.resolved.logStreamLabel;
     }
 
     public get description(): string | undefined {
         return this.resolved.description;
-    }
-
-    public async getSite(context: IActionContext): Promise<ParsedSite> {
-        return await this.resolved.getSite(context);
     }
 
     /**

--- a/src/tree/SlotsTreeItem.ts
+++ b/src/tree/SlotsTreeItem.ts
@@ -43,7 +43,8 @@ export class SlotsTreeItem extends AzExtParentTreeItem {
         if (clearCache) {
             this._nextLink = undefined;
         }
-        const site = await this.parent.getSite(context);
+        await this.parent.initSite(context);
+        const site = this.parent.site;
         const client: WebSiteManagementClient = await createWebSiteClient([context, this.subscription]);
         // https://github.com/Azure/azure-sdk-for-js/issues/20380
         const webAppCollection: Site[] = await uiUtils.listAllIterator(client.webApps.listSlots(site.resourceGroup, site.siteName));
@@ -51,8 +52,8 @@ export class SlotsTreeItem extends AzExtParentTreeItem {
         return await this.createTreeItemsWithErrorHandling(
             webAppCollection,
             'azFuncInvalidSlot',
-            (site: Site) => {
-                return new SlotTreeItem(this, new ResolvedFunctionAppResource(this.subscription, site));
+            async (site: Site) => {
+                return await SlotTreeItem.createSlotTreeItem(this, new ResolvedFunctionAppResource(this.subscription, site));
             },
             (site: Site) => {
                 return site.name;
@@ -62,8 +63,9 @@ export class SlotsTreeItem extends AzExtParentTreeItem {
 
     public async createChildImpl(context: ICreateChildImplContext): Promise<AzExtTreeItem> {
         const existingSlots: SlotTreeItem[] = <SlotTreeItem[]>await this.getCachedChildren(context);
-        const site = await this.parent.getSite(context);
+        await this.parent.initSite(context);
+        const site = this.parent.site;
         const newSite: Site = await createSlot(site, existingSlots.map(s => s.site), context);
-        return new SlotTreeItem(this, new ResolvedFunctionAppResource(this.subscription, newSite));
+        return await SlotTreeItem.createSlotTreeItem(this, new ResolvedFunctionAppResource(this.subscription, newSite));
     }
 }

--- a/src/tree/SubscriptionTreeItem.ts
+++ b/src/tree/SubscriptionTreeItem.ts
@@ -68,9 +68,9 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             'azFuncInvalidFunctionApp',
             async (site: Site) => {
                 const resolved = new ResolvedFunctionAppResource(this.subscription, site);
-                const pSite = await resolved.getSite(context);
-                if (pSite.isFunctionApp) {
-                    return new SlotTreeItem(this, resolved);
+                await resolved.initSite(context);
+                if (resolved.site.isFunctionApp) {
+                    return await SlotTreeItem.createSlotTreeItem(this, resolved);
                 }
                 return undefined;
             },
@@ -112,7 +112,7 @@ export class SubscriptionTreeItem extends SubscriptionTreeItemBase {
             node = new ContainerTreeItem(subscription, resolved);
         } else {
             const resolved = new ResolvedFunctionAppResource(subscription.subscription, nonNullProp(wizardContext, 'site'));
-            node = new SlotTreeItem(subscription, resolved);
+            node = await SlotTreeItem.createSlotTreeItem(subscription, resolved);
         }
 
         await ext.rgApi.tree.refresh(context);

--- a/src/tree/containerizedFunctionApp/AppSettingsClient.ts
+++ b/src/tree/containerizedFunctionApp/AppSettingsClient.ts
@@ -18,8 +18,8 @@ export class ContainerAppSettingsClientProvider implements AppSettingsClientProv
     }
     public async createClient(context: IActionContext): Promise<IAppSettingsClient> {
         const client = await createWebSiteClient([context, this._subscription]);
-        const site = this._node.getSite();
-        return new ContainerAppSettingsClient(site, client);
+        await this._node.initSite(context);
+        return new ContainerAppSettingsClient(this._node.site, client);
     }
 }
 

--- a/src/tree/containerizedFunctionApp/ContainerTreeItem.ts
+++ b/src/tree/containerizedFunctionApp/ContainerTreeItem.ts
@@ -3,7 +3,7 @@
 *  Licensed under the MIT License. See License.md in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { type AzExtParentTreeItem } from "@microsoft/vscode-azext-utils";
+import { type AzExtParentTreeItem, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { SlotContainerTreeItemBase } from "../SlotContainerTreeItemBase";
 import { ProjectSource } from "../projectContextValues";
 import { type ContainerSite, type ResolvedContainerizedFunctionAppResource } from "./ResolvedContainerizedFunctionAppResource";
@@ -26,7 +26,7 @@ export class ContainerTreeItem extends SlotContainerTreeItemBase {
         return await this.resolved.isReadOnly();
     }
 
-    public getSite(): ContainerSite {
-        return this.resolved.site;
+    public async initSite(context: IActionContext): Promise<void> {
+        await this.initSite(context);
     }
 }

--- a/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
+++ b/src/tree/containerizedFunctionApp/ResolvedContainerizedFunctionAppResource.ts
@@ -28,7 +28,7 @@ import { ImageTreeItem } from "./ImageTreeItem";
 export type ContainerSite = Site & { defaultHostUrl?: string; fullName?: string; isSlot?: boolean };
 
 export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAppBase implements ResolvedAppResourceBase {
-    public site: ContainerSite;
+    protected _site: ContainerSite;
     public maskedValuesToAdd: string[] = [];
     public contextValuesToAdd?: string[] | undefined;
     public static containerContextValue: string = 'azFuncContainer';
@@ -46,7 +46,7 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
 
     public constructor(subscription: ISubscriptionContext, site: Site) {
         super();
-        this.site = Object.assign(site, { defaultHostUrl: `https://${site.defaultHostName}`, fullName: site.name, isSlot: false });
+        this._site = Object.assign(site, { defaultHostUrl: `https://${site.defaultHostName}`, fullName: site.name, isSlot: false });
         this._subscription = subscription;
         this.contextValuesToAdd = ['azFuncProductionSlot', 'container'];
 
@@ -71,6 +71,17 @@ export class ResolvedContainerizedFunctionAppResource extends ResolvedFunctionAp
 
     public get label(): string {
         return nonNullProp(this.site, 'name');
+    }
+
+    public get site(): ContainerSite {
+        if (!this._site) {
+            throw new Error(localize('siteNotSet', 'Site is not set. Ensure the site is initialized before accessing it.'));
+        }
+        return this._site;
+    }
+
+    public async initSite(_context: IActionContext): Promise<void> {
+        // the site is included in the constructor, so this is a no-op for containerized function apps but needed for interface compliance
     }
 
     public get iconPath(): TreeItemIconPath {

--- a/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
+++ b/src/tree/remoteProject/RemoteFunctionsTreeItem.ts
@@ -54,8 +54,8 @@ export class RemoteFunctionsTreeItem extends FunctionsTreeItemBase {
             Under these circumstances, we will attempt to do the call 3 times during warmup before throwing the error.
         */
         const retries = 3;
-        const site = await this.parent.getSite(context);
-        const client = await site.createClient(context);
+        await this.parent.initSite(context);
+        const client = await this.parent.site.createClient(context);
 
         const funcs = await retry<FunctionEnvelope[]>(
             async (attempt: number) => {

--- a/src/tree/remoteProject/SystemIdentityTreeItemBase.ts
+++ b/src/tree/remoteProject/SystemIdentityTreeItemBase.ts
@@ -11,11 +11,11 @@ import { type ManagedIdentityTreeItem } from './ManagedIdentityTreeItem';
 
 export type SystemIdentityTreeItemBase = SystemIdentityTreeItem | DisabledIdentityTreeItem;
 export async function createSystemIdentityTreeItem(context: IActionContext, parent: ManagedIdentityTreeItem): Promise<SystemIdentityTreeItem | DisabledIdentityTreeItem> {
-    const site = await parent.parent.getSite(context);
-    if (!site.rawSite.identity?.type?.includes('SystemAssigned')) {
+    await parent.parent.initSite(context);
+    if (!parent.parent.site.rawSite.identity?.type?.includes('SystemAssigned')) {
         return new DisabledIdentityTreeItem(parent);
     } else {
-        return new SystemIdentityTreeItem(parent, site.rawSite.identity);
+        return new SystemIdentityTreeItem(parent, parent.parent.site.rawSite.identity);
     }
 }
 

--- a/src/tree/remoteProject/UserAssignedIdentitiesTreeItem.ts
+++ b/src/tree/remoteProject/UserAssignedIdentitiesTreeItem.ts
@@ -38,8 +38,8 @@ export class UserAssignedIdentitiesTreeItem extends AzExtParentTreeItem {
             this._nextLink = undefined;
         }
 
-        const site = await this.parent.getSite(context);
-        const myIdentity = site.rawSite.identity;
+        await this.parent.initSite(context);
+        const myIdentity = this.parent.site.rawSite.identity;
         const identities: Identity[] = [];
         const identityClient = await createManagedServiceIdentityClient([context, this.parent.subscription]);
         const userAssignedIdentities = await uiUtils.listAllIterator(identityClient.userAssignedIdentities.listBySubscription());


### PR DESCRIPTION
TLDR:
Basically, the async getSite calls weren't really working everywhere due to SiteClient referencing .site in places (I think.) It was easier to just type guard everything with a get site that throws an error if site isn't initialized, and use initSite to initialize the sites anytime it was required.

Overall, I think it's a bit clunkier of a solution, but it looks cleaner since you can reference node.site directly again.

COPILOT SUMMARY:

This pull request introduces several changes to improve the handling of site initialization and caching in the Azure Functions extension codebase. The most significant updates include replacing multiple calls to `getSite` with a new `initSite` method for initializing site data, modifying the `FunctionAppModel` type to include an `isFlex` property, and optimizing cache management within the `FunctionAppResolver` class.