### PR TITLE
Fix: Advanced creation no longer prompts for user identity if secret-based access is used

### DIFF
--- a/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
+++ b/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCreateStep, AppServicePlanListStep, CustomLocationListStep, LogAnalyticsCreateStep, SiteNameStep, WebsiteOS, type IAppServiceWizardContext } from "@microsoft/vscode-azext-azureappservice";
-import { CommonRoleDefinitions, createRoleId, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, RoleAssignmentExecuteStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, UserAssignedIdentityListStep, type INewStorageAccountDefaults, type Role } from "@microsoft/vscode-azext-azureutils";
+import { CommonRoleDefinitions, createRoleId, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, RoleAssignmentExecuteStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, type INewStorageAccountDefaults, type Role } from "@microsoft/vscode-azext-azureutils";
 import { type AzureWizardExecuteStep, type AzureWizardPromptStep, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from "../../FuncVersion";
 import { DurableBackend, funcVersionSetting } from "../../constants";
@@ -103,7 +103,6 @@ export async function createCreateFunctionAppComponents(context: ICreateFunction
             }
         ));
         promptSteps.push(new AppInsightsListStep());
-        promptSteps.push(new UserAssignedIdentityListStep());
     }
 
     executeSteps.push(new RoleAssignmentExecuteStep(() => {


### PR DESCRIPTION
### Problem
In advanced Function App creation, the wizard always prompts for a User Assigned Identity, even when secret-based access is used and no identity is needed.

### Fix
`promptSteps.push(new UserAssignedIdentityListStep());` would prompt for user-assigned identity regardless of the access method specified. It is not needed as it is already inside `promptSteps.push(new AuthenticationPromptStep())` (at line 72).

### Testing
- Tested the function app creation for both advanced and default mode. No breaks and access method specified is respected.
- Ran `npm test` successfully.