### PR TITLE
Fix container name always lowercase

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -95,7 +95,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStepWithActivityOut
             deployment: {
                 storage: {
                     type: 'blobContainer',
-                    value: `${context.storageAccount?.primaryEndpoints?.blob}app-package-${context.newSiteName?.substring(0, 32)}-${randomUtils.getRandomHexString(7)}`,
+                    value: `${context.storageAccount?.primaryEndpoints?.blob}app-package-${context.newSiteName?.substring(0, 32)?.toLowerCase()}-${randomUtils.getRandomHexString(7)}`,
                     authentication: createDeploymentStorageAuthentication(context)
                 }
             },


### PR DESCRIPTION
Closes #4575. The container name should be lowercase. `newSiteName` is same as function app name which can contain capital letters. This causes the deployment to fail sometimes.