### PR TITLE
Various bug fixes

### DIFF
--- a/src/commands/addMIConnections/addRemoteMIConnections.ts
+++ b/src/commands/addMIConnections/addRemoteMIConnections.ts
@@ -20,6 +20,7 @@ export async function addRemoteMIConnections(context: AddMIConnectionsContext, n
     const connections: Connection[] = [];
     if (!node) {
         context.functionapp = await pickFunctionApp(context);
+        await context.functionapp.initSite(context);
         await addRemoteMIConnectionsInternal(context, connections);
     } else {
         if (node instanceof AppSettingTreeItem) {

--- a/src/commands/deployments/connectToGitHub.ts
+++ b/src/commands/deployments/connectToGitHub.ts
@@ -7,7 +7,7 @@ import { DeploymentsTreeItem, editScmType } from "@microsoft/vscode-azext-azurea
 import { type GenericTreeItem, type IActionContext } from "@microsoft/vscode-azext-utils";
 import { ScmType, functionFilter } from "../../constants";
 import { ext } from "../../extensionVariables";
-import { isSlotTreeItem } from "../../tree/SlotTreeItem";
+import { isSlotTreeItem, type SlotTreeItem } from "../../tree/SlotTreeItem";
 
 export async function connectToGitHub(context: IActionContext, target?: GenericTreeItem): Promise<void> {
     let deployments: DeploymentsTreeItem;
@@ -21,7 +21,10 @@ export async function connectToGitHub(context: IActionContext, target?: GenericT
         deployments = <DeploymentsTreeItem>target.parent;
     }
 
+    await deployments.init(context);
     if (deployments.parent && isSlotTreeItem(deployments.parent)) {
+        const siteItem = deployments.parent as SlotTreeItem;
+        await siteItem.initSite(context);
         await editScmType(context, deployments.site, deployments.subscription, ScmType.GitHub);
         await deployments.refresh(context);
     } else {

--- a/src/tree/ResolvedFunctionAppResource.ts
+++ b/src/tree/ResolvedFunctionAppResource.ts
@@ -315,7 +315,7 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
                     }
                 }
             }
-
+            const flexError = localize('flexFunctionAppDeploymentsNotSupported', 'Command not supported for Flex Consumption apps.');
             for (const expectedContextValue of expectedContextValues) {
                 if (expectedContextValue instanceof RegExp) {
                     const appSettingsContextValues = [AppSettingsTreeItem.contextValue, AppSettingTreeItem.contextValue];
@@ -324,10 +324,19 @@ export class ResolvedFunctionAppResource extends ResolvedFunctionAppBase impleme
                     }
                     const deploymentsContextValues = [DeploymentsTreeItem.contextValueConnected, DeploymentsTreeItem.contextValueUnconnected, DeploymentTreeItem.contextValue];
                     if (matchContextValue(expectedContextValue, deploymentsContextValues)) {
+                        if (this.isFlex) {
+                            context.errorHandling.rethrow = true;
+                            throw new Error(flexError);
+                        }
+                        await this.deploymentsNode?.init(context);
                         return this.deploymentsNode;
                     }
 
                     if (matchContextValue(expectedContextValue, [ResolvedFunctionAppResource.slotContextValue])) {
+                        if (this.isFlex) {
+                            context.errorHandling.rethrow = true;
+                            throw new Error(flexError);
+                        }
                         return this._slotsTreeItem;
                     }
                 }

--- a/src/tree/SlotTreeItem.ts
+++ b/src/tree/SlotTreeItem.ts
@@ -13,7 +13,7 @@ import { ProjectSource } from './projectContextValues';
 import { type RemoteFunctionTreeItem } from './remoteProject/RemoteFunctionTreeItem';
 
 export function isSlotTreeItem(treeItem: SlotTreeItem | RemoteFunctionTreeItem | AzExtParentTreeItem): treeItem is SlotTreeItem {
-    return !!(treeItem as SlotTreeItem).site;
+    return !!(treeItem as SlotTreeItem).contextValue.includes('FunctionApp;')
 }
 
 export class SlotTreeItem extends SlotContainerTreeItemBase {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4586
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4585

Slot and deployment tree nodes don't exist under flex, so just throwing an error if the command palette tries to get it for a flex item.