### PR TITLE
Add custom runtime for flex consumption

### DIFF
--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -187,7 +187,7 @@ async function getFlexStacks(context: ISubscriptionActionContext & { _stacks?: F
     const client: ServiceClient = await createGenericClient(context, context);
     location = location ?? (await LocationListStep.getLocation(context)).name;
     const flexFunctionAppStacks: FunctionAppStack[] = [];
-    const stacks = ['dotnet', 'java', 'node', 'powershell', 'python'];
+    const stacks = ['dotnet', 'java', 'node', 'powershell', 'python', 'custom'];
     if (!context._stacks) {
         const getFlexStack = async (stack: string) => {
             const result: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({


### PR DESCRIPTION
Custom handlers was added to flex and deployed to the stacks API so we just need to add the filter to the array so that a user could select it.

I created one and confirmed that it worked, but we still need to deploy via the func cli since there's some special deployment logic.