### PR TITLE
Account for the fact that properties can be null

### DIFF
--- a/src/FunctionAppResolver.ts
+++ b/src/FunctionAppResolver.ts
@@ -58,15 +58,16 @@ export class FunctionAppResolver implements AppResourceResolver {
                         });
 
                         const record = response.data as Record<string, FunctionQueryModel>;
+                        // seems as if properties can be null, so we need to check for that
                         Object.values(record).forEach(data => {
                             const dataModel: FunctionAppModel = {
-                                isFlex: data.properties.sku.toLocaleLowerCase() === 'flexconsumption',
+                                isFlex: data.properties?.sku?.toLocaleLowerCase() === 'flexconsumption',
                                 id: data.id,
                                 type: data.type,
                                 kind: data.kind,
                                 name: data.name,
                                 resourceGroup: data.resourceGroup,
-                                status: data.properties.state,
+                                status: data.properties?.state,
                                 location: data.location
                             }
                             resolver.siteCache.set(dataModel.id.toLowerCase(), dataModel);


### PR DESCRIPTION
Based on the error that we are seeing in telemetry is: `Cannot read properties of null (reading "toLocaleLowerCase")`, it's almost certainly this line of code causing the issue.

I assume that not everyone can access the properties of the apps which is causing this issue.