### PR TITLE
Fix host.json version not showing for AzureExtensionsBundle

### DIFF
--- a/src/utils/bundleFeedUtils.ts
+++ b/src/utils/bundleFeedUtils.ts
@@ -90,7 +90,7 @@ export namespace bundleFeedUtils {
     export async function addDefaultBundle(context: IActionContext, hostJson: IHostJsonV2): Promise<void> {
         let versionRange: string;
         try {
-            versionRange = await getLatestVersionRange(context);
+            versionRange = (await getLatestVersionRange(context)) ?? defaultVersionRange;
         } catch {
             versionRange = defaultVersionRange;
         }


### PR DESCRIPTION
Fixes #4594

Added a nullish coalescing operator to take care of the case when the returned value is `null` or `undefined`. Changing the `getLatestVersionRange` to throw error didn't make sense as it is just for trying to get the latest version. It's fine if the latest version cannot be retreived and the function returns null.