### PR TITLE
Initialize `copilot-instructions` file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 # Coding Instructions for GitHub Copilot
 
-- Do not commit or suggest changes to `main.js` when they are automatically generated as part of our webpack build process.
+- Do not commit or suggest changes to `main.js` when those changes are automatically generated as part of the webpack build process.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Coding Instructions for GitHub Copilot
+
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 # Coding Instructions for GitHub Copilot
 
-
+- Do not commit or suggest changes to `main.js` when they are automatically generated as part of our webpack build process.

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,3 @@ resources/backupTemplates/dotnet/**/cache/
 
 # macOS related extra files
 .DS_Store
-
-# Copilot instructions (internal development documentation)
-.github/copilot-instructions.md

--- a/COPILOT_INSTRUCTIONS.md
+++ b/COPILOT_INSTRUCTIONS.md
@@ -1,4 +1,3 @@
-
 # Coding Instructions for GitHub Copilot
 
 - Do not commit or suggest changes to `main.js` when they are generated to prepare for the webpack build process.

--- a/COPILOT_INSTRUCTIONS.md
+++ b/COPILOT_INSTRUCTIONS.md
@@ -1,3 +1,3 @@
 # Coding Instructions for GitHub Copilot
 
-- Do not commit or suggest changes to `main.js` when they are generated to prepare for the webpack build process.
+- Do not commit or suggest changes to `main.js` when they are automatically generated as part of our webpack build process.

--- a/COPILOT_INSTRUCTIONS.md
+++ b/COPILOT_INSTRUCTIONS.md
@@ -1,0 +1,4 @@
+
+# Coding Instructions for GitHub Copilot
+
+- Do not commit or suggest changes to `main.js` when they are generated to prepare for the webpack build process.

--- a/COPILOT_INSTRUCTIONS.md
+++ b/COPILOT_INSTRUCTIONS.md
@@ -1,3 +1,0 @@
-# Coding Instructions for GitHub Copilot
-
-- Do not commit or suggest changes to `main.js` when they are automatically generated as part of our webpack build process.


### PR DESCRIPTION
We should definitely add onto this, but preventing `main.js` from being edited is kind of a bare minimum starting point