### PR TITLE
feat: add dynamic Azurite connection string generation using workspace settings

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -146,6 +146,8 @@ export const localhost: string = '127.0.0.1';
 export const tsDefaultOutDir: string = 'dist';
 export const tsConfigFileName: string = 'tsconfig.json';
 
+// standard Azurite emulator account key
+export const azuriteAccountKey: string = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq';
 export const localStorageEmulatorConnectionString: string = 'UseDevelopmentStorage=true';
 export const localEventHubsEmulatorConnectionString: string = 'SingleHost';
 export const localEventHubsEmulatorConnectionRegExp: RegExp = new RegExp(`${localEventHubsEmulatorConnectionString}|MemoryF|Memory`);

--- a/src/debug/storageProviders/validateStorageConnectionPreDebug.ts
+++ b/src/debug/storageProviders/validateStorageConnectionPreDebug.ts
@@ -14,7 +14,7 @@ export async function validateStorageConnectionPreDebug(context: IActionContext,
     const projectPathContext = Object.assign(context, { projectPath });
     const storageConnectionKey: string = ConnectionKey.Storage;
     const storageConnection: string | undefined = await getStorageLocalSettingsValue(projectPathContext, storageConnectionKey);
-    const storageIdentityConnection: string | undefined = await getLocalSettingsConnectionString(context, ConnectionKey.StorageIdentity, projectPath);
+    const storageIdentityConnection: string | undefined = (await getLocalSettingsConnectionString(context, ConnectionKey.StorageIdentity, projectPath))[0];
 
     if (storageConnection || storageIdentityConnection) {
         return;

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -10,7 +10,7 @@ import * as semver from 'semver';
 import * as vscode from 'vscode';
 import { type ISetConnectionSettingContext } from '../commands/appSettings/connectionSettings/ISetConnectionSettingContext';
 import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIsProject';
-import { CodeAction, ConnectionKey, DurableBackend, ProjectLanguage, functionJsonFileName, localSettingsFileName, localStorageEmulatorConnectionString, projectLanguageModelSetting, projectLanguageSetting, workerRuntimeKey } from "../constants";
+import { CodeAction, ConnectionKey, DurableBackend, ProjectLanguage, functionJsonFileName, localSettingsFileName, projectLanguageModelSetting, projectLanguageSetting, workerRuntimeKey } from "../constants";
 import { ParsedFunctionJson } from "../funcConfig/function";
 import { MismatchBehavior, getLocalSettingsConnectionString, setLocalAppSetting } from "../funcConfig/local.settings";
 import { getLocalFuncCoreToolsVersion } from '../funcCoreTools/getLocalFuncCoreToolsVersion';
@@ -196,8 +196,8 @@ async function validateAzureWebJobsStorage(context: IPreDebugContext, projectLan
  * If AzureWebJobsStorage is set, pings the emulator to make sure it's actually running
  */
 async function validateEmulatorIsRunning(context: IActionContext, projectPath: string): Promise<boolean> {
-    const azureWebJobsStorage: string | undefined = await getLocalSettingsConnectionString(context, ConnectionKey.Storage, projectPath);
-    if (azureWebJobsStorage && azureWebJobsStorage.toLowerCase() === localStorageEmulatorConnectionString.toLowerCase()) {
+    const [azureWebJobsStorage, isEmulator] = await getLocalSettingsConnectionString(context, ConnectionKey.Storage, projectPath);
+    if (azureWebJobsStorage && isEmulator) {
         try {
             const client = BlobServiceClient.fromConnectionString(azureWebJobsStorage, { retryOptions: { maxTries: 1 } });
             await client.getProperties();

--- a/src/funcConfig/local.settings.ts
+++ b/src/funcConfig/local.settings.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { decryptLocalSettings } from '../commands/appSettings/localSettings/decryptLocalSettings';
 import { encryptLocalSettings } from '../commands/appSettings/localSettings/encryptLocalSettings';
-import { localSettingsFileName, localStorageEmulatorConnectionString, type ConnectionKey } from '../constants';
+import { azuriteAccountKey, localSettingsFileName, localStorageEmulatorConnectionString, type ConnectionKey } from '../constants';
 import { localize } from '../localize';
 import { parseJson } from '../utils/parseJson';
 import { getWorkspaceSetting } from '../vsCodeConfig/settings';
@@ -23,7 +23,7 @@ export interface ILocalSettingsJson {
 export async function getLocalSettingsConnectionString(context: IActionContext, connectionKey: ConnectionKey, projectPath: string): Promise<[string | undefined, boolean]> {
     // func cli uses environment variable if it's defined on the machine, so no need to prompt
     if (process.env[connectionKey]) {
-        return [process.env[connectionKey], true];
+        return [process.env[connectionKey], isConnectionStringEmulator(process.env[connectionKey])];
     }
 
     const settings: ILocalSettingsJson = await getLocalSettingsJson(context, path.join(projectPath, localSettingsFileName));
@@ -45,7 +45,7 @@ function getLocalSettingsEmulatorConnectionString(): string {
     const tablePort = getWorkspaceSetting('tablePort', undefined, 'azurite') || '10002';
 
     const protocol = getTransferProtocol();
-    return `DefaultEndpointsProtocol=${protocol};AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=${protocol}://${blobHost}:${blobPort}/devstoreaccount1;QueueEndpoint=${protocol}://${queueHost}:${queuePort}/devstoreaccount1;TableEndpoint=${protocol}://${tableHost}:${tablePort}/devstoreaccount1;`;
+    return `DefaultEndpointsProtocol=${protocol};AccountName=devstoreaccount1;AccountKey=${azuriteAccountKey}/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=${protocol}://${blobHost}:${blobPort}/devstoreaccount1;QueueEndpoint=${protocol}://${queueHost}:${queuePort}/devstoreaccount1;TableEndpoint=${protocol}://${tableHost}:${tablePort}/devstoreaccount1;`;
 }
 
 function isConnectionStringEmulator(connectionString: string | undefined): boolean {
@@ -56,8 +56,7 @@ function isConnectionStringEmulator(connectionString: string | undefined): boole
     return !!connectionString &&
         (connectionString.includes(blobHost) ||
             connectionString.includes(queueHost) ||
-            connectionString.includes(tableHost) ||
-            connectionString.includes('localhost')
+            connectionString.includes(tableHost)
         );
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the Azurite integration by dynamically generating complete connection strings using workspace settings instead of returning partial URLs.

## Changes
- **Complete connection string generation**: Now generates full Azure Storage connection strings with all endpoints (blob, queue, table) instead of just blob URLs
- **Dynamic configuration**: Uses Azurite workspace settings for flexible host/port configuration:
  - `azurite.blobHost`, `azurite.queueHost`, `azurite.tableHost` (defaults to 127.0.0.1)
  - `azurite.blobPort`, `azurite.queuePort`, `azurite.tablePort` (defaults to 10000, 10001, 10002)
- **Protocol support**: Automatically detects HTTP/HTTPS based on certificate settings
- **Emulator detection**: Added improved logic to detect when a connection string is for an emulator

## Connection String Format
The generated connection string follows the standard Azure Storage format:
```
DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;
```

## References
- Fixes #3876
- Implementation reference: https://github.com/microsoft/vscode-azurestorage/commit/88cfaf97101335752941ac74136580c1ed48563d

## Testing
- [x] Generates proper connection strings with default Azurite settings
- [x] Respects custom workspace configuration
- [x] Handles both HTTP and HTTPS protocols
- [x] Maintains backward compatibility