### PR TITLE
Terminate the whole shell process instead of using process kill

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -102,7 +102,6 @@ export function registerFuncHostTaskEvents(): void {
         context.telemetry.suppressIfSuccessful = true;
         if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
             runningFuncTaskMap.delete(e.execution.task.scope, (e.execution.task.execution as vscode.ShellExecution).options?.cwd);
-            stopFuncTaskIfRunning(e.execution.task.scope, undefined, true, true);
         }
     });
 

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -102,6 +102,7 @@ export function registerFuncHostTaskEvents(): void {
         context.telemetry.suppressIfSuccessful = true;
         if (e.execution.task.scope !== undefined && isFuncHostTask(e.execution.task)) {
             runningFuncTaskMap.delete(e.execution.task.scope, (e.execution.task.execution as vscode.ShellExecution).options?.cwd);
+            stopFuncTaskIfRunning(e.execution.task.scope, undefined, true, true);
         }
     });
 
@@ -126,7 +127,7 @@ export function registerFuncHostTaskEvents(): void {
         // NOTE: Only stop the func task if this is the root debug session (aka does not have a parentSession) to fix https://github.com/microsoft/vscode-azurefunctions/issues/2925
         if (getWorkspaceSetting<boolean>('stopFuncTaskPostDebug') && !debugSession.parentSession && debugSession.workspaceFolder) {
             // TODO: Find the exact function task from the debug session, but for now just stop all tasks in the workspace folder
-            stopFuncTaskIfRunning(debugSession.workspaceFolder, undefined, true);
+            stopFuncTaskIfRunning(debugSession.workspaceFolder, undefined, true, true);
         }
     });
 }


### PR DESCRIPTION
We were trying to use the precise pid to kill the process. I think something must have changed about how VS Code spins up the process because the pid that we have set on the map is the pid that spawns the func process.

If we use terminate, it kills the entire tree. It'll close the terminal which kind of sucks, but it's so annoying that the process isn't being killed in the background so lesser of two evils.