### PR TITLE
Use the port number to find the func pid

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -99,7 +99,7 @@ export async function pickFuncProcess(context: IActionContext, debugConfig: vsco
 }
 
 async function waitForPrevFuncTaskToStop(workspaceFolder: vscode.WorkspaceFolder, buildPath?: string): Promise<void> {
-    stopFuncTaskIfRunning(workspaceFolder, buildPath);
+    await stopFuncTaskIfRunning(workspaceFolder, buildPath);
 
     const timeoutInSeconds: number = 30;
     const maxTime: number = Date.now() + timeoutInSeconds * 1000;

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -179,6 +179,7 @@ async function killFuncProcessByPortOrPid(runningFuncTask: IRunningFuncTask, wor
 
         throw new Error(`Could not find func process for port ${runningFuncTask.portNumber}`);
     } catch (error) {
+        // don't look for the port and just terminate the whole process
         await stopFuncTaskIfRunning(workspaceFolder, undefined, true, true);
     }
 }
@@ -270,7 +271,7 @@ async function findPidByPort(port: string | number): Promise<number | undefined>
             }
         }
     } catch (error) {
-        console.log(`Error finding PID for port ${port}:`, error);
+        // ignore error
     }
 
     return undefined;

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -173,7 +173,6 @@ async function killFuncProcessByPortOrPid(runningFuncTask: IRunningFuncTask, wor
         const realFuncPid = await findPidByPort(runningFuncTask.portNumber);
 
         if (realFuncPid && realFuncPid !== runningFuncTask.processId) {
-            console.log(`Found real func process PID ${realFuncPid} listening on port ${runningFuncTask.portNumber} (shell PID: ${runningFuncTask.processId})`);
             process.kill(realFuncPid);
             return;
         }


### PR DESCRIPTION
Reverts always terminating the func process introduced in this [PR](https://github.com/microsoft/vscode-azurefunctions/pull/4675)

I mentioned it in that PR, but if you kill the entire shell process, the terminal also gets deleted. I thought it wouldn't be that annoying, but there are times when your func process errors, and it just immediately disappears so it looks like the debug was a no-op.

I thought that there must be a better way and tried to find the real PID by looking for the port number instead. This seems to work quite a bit better.

Mac testers would be greatly appreciated.