### PR TITLE
Remove 'Linux' from Consumption hosting plan label

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts
@@ -20,7 +20,7 @@ export class FunctionAppHostingPlanStep extends AzureWizardPromptStep<IFunctionA
         const placeHolder: string = localize('selectHostingPlan', 'Select a hosting plan.');
         const picks: IAzureQuickPickItem<[boolean, boolean, RegExp | undefined]>[] = [
             { label: localize('flexConsumption', 'Flex Consumption'), data: [false, true, undefined] },
-            { label: localize('consumption', 'Linux Consumption'), description: localize('legacy', 'Legacy'), data: [true, false, undefined] },
+            { label: localize('consumption', 'Consumption'), description: localize('legacy', 'Legacy'), data: [true, false, undefined] },
             { label: localize('premium', 'Premium'), data: [false, false, premiumSkuFilter] },
             { label: localize('dedicated', 'App Service Plan'), data: [false, false, /^((?!EP|Y|FC).)*$/i] }
         ];


### PR DESCRIPTION
In the PR we updated the label, I think someone had told me to change it to Linux Consumption, not realizing that you can actually pick the OS. Changing it back to avoid confusion.

## Changes
This PR removes "Linux" from the Consumption hosting plan label in the function app creation wizard.

## Problem
The current label shows "Linux Consumption" which is misleading because:
- Consumption plans support both Linux and Windows runtimes
- The label suggests it's only for Linux applications
- Other hosting plan options don't specify the OS in their labels

## Solution
Changed the label from "Linux Consumption" to simply "Consumption" to:
- ✅ Remove OS-specific confusion
- ✅ Align with other hosting plan labels
- ✅ Better represent that consumption plans work for all runtimes

## Files Changed
- `src/commands/createFunctionApp/FunctionAppHostingPlanStep.ts`: Updated the label text

## Testing
- [x] Verified the change compiles without errors
- [x] Confirmed the label change is visible in the hosting plan selection UI

This is a minor UX improvement to make the hosting plan selection clearer for users.