### PR TITLE
Add `AzureWebJobsStorage` to task dynamically if using emulator

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,6 +103,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         // These don't actually overwrite "node", "python", etc. - they just add to it
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('node', nodeDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('python', pythonDebugProvider));
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('debugpy', pythonDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', javaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('ballerina', ballerinaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('PowerShell', powershellDebugProvider));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/3876

`func host start` will respect the env variable over the local.settings.json. Since we are building the connection string based off Azurite, we should overwrite the `AzureWebJobsStorage` setting to respect custom azurite settings.