### PR TITLE
Check if we need to disable storage SAS in the deployment entry point

### DIFF
--- a/src/commands/deploy/getOrCreateFunctionApp.ts
+++ b/src/commands/deploy/getOrCreateFunctionApp.ts
@@ -37,6 +37,7 @@ export async function getOrCreateFunctionApp(context: IFuncDeployContext & Parti
     // if there was no node, then the user is creating a new function app
     if (!node) {
         context.activityTitle = localize('functionAppCreateActivityTitle', 'Create Function App "{0}"', nonNullProp(context, 'newSiteName'))
+        context.disableSharedKeyAccess = context.useManagedIdentity && context.useFlexConsumptionPlan;
         await wizard.execute();
 
         const resolved = context.dockerfilePath ? new ResolvedContainerizedFunctionAppResource(context as ISubscriptionContext, nonNullProp(context, 'site')) :


### PR DESCRIPTION
There was a bug where if your entry point for creating a new function app was from Deploy to Azure..., the new storage account that was created would not disable shared access keys connecting via managed identities.  This was causing our internal policy to prevent the creation of the storage account and causing the create and the subsequent deploy to fail.

Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4304 (although this was technically fixed a while back)