### PR TITLE
Fix overwrite of required debugger environment settings

### DIFF
--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -127,6 +127,7 @@ export class FuncTaskProvider implements TaskProvider {
                 ...options.env,
                 // The purpose of setting this manually is so that we can honor any custom Azurite connection settings that the user may have already set up
                 // See: https://github.com/microsoft/vscode-azurefunctions/pull/4703
+                // Todo: https://github.com/microsoft/vscode-azurefunctions/issues/4735
                 "AzureWebJobsStorage": azureWebJobsStorage
             };
         }


### PR DESCRIPTION
Fixes #4715
Fixes #4719

We recently started intercepting and adding a custom env variable for `AzureWebJobsStorage`.  This was to better support the fact that users could have custom connection settings for Azurite.  

It looks like in the process of doing this, we accidentally overwrote the environment setting required to properly start the python debugger.  The simple fix here would be to preserve the existing env settings and only change the one setting.

Edit: This affects other runtimes as well