### PR TITLE
Update minimum Azure Container Apps API version to `v1.0.0`

### DIFF
--- a/src/getExtensionApi.ts
+++ b/src/getExtensionApi.ts
@@ -27,7 +27,7 @@ export async function getAzureContainerAppsApi(context: IActionContext, installM
     const acaExtension: apiUtils.AzureExtensionApiProvider | undefined = await apiUtils.getExtensionExports(acaExtensionId);
 
     if (acaExtension) {
-        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('^0.0.1');
+        return acaExtension.getApi<acaApi.AzureContainerAppsExtensionApi>('^1.0.0');
     }
 
     await context.ui.showWarningMessage(installMessage ??


### PR DESCRIPTION
We will need to ship ACA and Functions around the same time.  I'm going to send out ACA for testing with a build from this branch to start with.  We can send the main build of Functions for release test next week.