### PR TITLE
Relax regex matching to allow PATH files preceeding func host

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -83,7 +83,7 @@ const defaultFuncPort: string = '7071';
 
 export function isFuncHostTask(task: vscode.Task): boolean {
     const commandLine: string | undefined = task.execution && (<vscode.ShellExecution>task.execution).commandLine;
-    return /func (host )?start/i.test(commandLine || '');
+    return /(?:^|[\\/])(func(?:\.exe)?)\s+host\s+start$/i.test(commandLine || '');
 }
 
 export function registerFuncHostTaskEvents(): void {


### PR DESCRIPTION
A new change in Insiders changes the output of `task.execution.commandLine` which we use to check if the task is a func host task.

Old output (from Stable):
<img width="531" height="247" alt="image" src="https://github.com/user-attachments/assets/762e1f14-91af-45e7-8603-c396d5dfc652" />


New output (from latest Insiders):
<img width="783" height="290" alt="image" src="https://github.com/user-attachments/assets/9d561ada-2587-4a74-9f29-01a677510504" />

The binary is now being referenced instead of just the name of the command. Not really sure what caused this, but I made the regex accept either strings.