### PR TITLE
Update supported python versions and remove old ones

### DIFF
--- a/src/commands/createNewProject/pythonSteps/pythonVersion.ts
+++ b/src/commands/createNewProject/pythonSteps/pythonVersion.ts
@@ -31,14 +31,14 @@ export async function getSupportedPythonVersions(context: IActionContext, funcVe
 
     const result: string[] = [];
 
+    // TODO: https://github.com/microsoft/vscode-azurefunctions/issues/4778
     const versionInfo: [string, string][] = [
-        ['2.7.1846', '3.7'],
-        ['3.0.2245', '3.8'],
-        ['3.0.3216', '3.9'],
         ['4.0.4915', '3.10'],
         ['4.0.5348', '3.11'],
         // not sure if this is the minimum version, but I confirmed that 4.0.7030 works with Python 3.12
         ['4.0.7030', '3.12'],
+        ['4.0.7030', '3.13'],
+        ['4.0.7030', '3.14'],
     ];
 
     for (const [minFuncVersion, pyVersion] of versionInfo) {


### PR DESCRIPTION
According to this document, these are the currently supported versions of Python:
https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=isolated-process%2Cv4&pivots=programming-language-python#languages

3.14 (preview) will be available in a couple of weeks, so going ahead and just adding it to the list.

I'm not sure how Eric was finding the func version numbers for the Python support, but I'll probably remove that check when I start retrieving from the Stacks API.