### PR TITLE
Throw an error if there is no system key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@azure/core-client": "^1.7.3",
                 "@azure/core-rest-pipeline": "^1.11.0",
                 "@azure/storage-blob": "^12.5.0",
-                "@microsoft/vscode-azext-azureappservice": "^3.6.7",
+                "@microsoft/vscode-azext-azureappservice": "^3.6.9",
                 "@microsoft/vscode-azext-azureappsettings": "^0.2.11",
                 "@microsoft/vscode-azext-azureutils": "^3.5.2",
                 "@microsoft/vscode-azext-utils": "^3.5.0",
@@ -1114,9 +1114,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappservice": {
-            "version": "3.6.7",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-3.6.7.tgz",
-            "integrity": "sha512-8aQDAXFZH92V6x8HeERx1DUuILEO0W/VBnCO/JSidq5Cjmk4hSi59eleDmgKedZ7jJFZTRBOwXYSTxFfHpWTqQ==",
+            "version": "3.6.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-3.6.9.tgz",
+            "integrity": "sha512-jPXiL7YUFk5UmaW+sdgjyxf9DbMeLDzsZFwT2fSmIT33KJpkmIApcRrK33TQ0MyWFyd+IwktPRivE7yry4/y3w==",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",
                 "@azure/arm-appinsights": "^5.0.0-beta.4",

--- a/package.json
+++ b/package.json
@@ -1497,7 +1497,7 @@
         "@azure/core-client": "^1.7.3",
         "@azure/core-rest-pipeline": "^1.11.0",
         "@azure/storage-blob": "^12.5.0",
-        "@microsoft/vscode-azext-azureappservice": "^3.6.7",
+        "@microsoft/vscode-azext-azureappservice": "^3.6.9",
         "@microsoft/vscode-azext-azureappsettings": "^0.2.11",
         "@microsoft/vscode-azext-azureutils": "^3.5.2",
         "@microsoft/vscode-azext-utils": "^3.5.0",

--- a/src/commands/createNewProject/mcpServerSteps/MCPProjectCreateStep.ts
+++ b/src/commands/createNewProject/mcpServerSteps/MCPProjectCreateStep.ts
@@ -26,7 +26,7 @@ export class MCPProjectCreateStep extends ProjectCreateStepBase {
             }
             const functionArtifactFiles: GitHubFileMetadata[] = sampleFiles.filter(f => essentialFileNames.includes(f.name));
             for (const file of functionArtifactFiles) {
-                await MCPDownloadSnippetsExecuteStep.downloadSingleFile(context, file);
+                await MCPDownloadSnippetsExecuteStep.downloadSingleFile(context, file, context.projectPath);
             }
         }
         return;

--- a/src/commands/deploy/CreateRemoteMcpServerExecuteStep.ts
+++ b/src/commands/deploy/CreateRemoteMcpServerExecuteStep.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ActivityChildItem, ActivityChildType, activityInfoContext, AzureWizardExecuteStep, createContextValue, nonNullProp, type ExecuteActivityOutput } from "@microsoft/vscode-azext-utils";
+import * as path from 'path';
+import { ThemeIcon, Uri } from "vscode";
+import { mcpProjectTypeSetting, type McpProjectType } from "../../constants";
+import { localize } from "../../localize";
+import { addRemoteMcpServer, checkIfMcpServerExists, getOrCreateMcpJson, getRemoteServerName, saveMcpJson } from "../../utils/mcpUtils";
+import { getWorkspaceSetting } from "../../vsCodeConfig/settings";
+import { type IFuncDeployContext } from "./deploy";
+
+export class CreateRemoteMcpServerExecuteStep<T extends IFuncDeployContext> extends AzureWizardExecuteStep<T> {
+    public priority: number = 999;
+    public stepName: string = 'CreateRemoteMcpServerExecuteStep';
+
+    public async execute(context: T): Promise<void> {
+        const node = nonNullProp(context, 'deployedNode');
+        const mcpJson = await getOrCreateMcpJson(context.workspaceFolder.uri.fsPath);
+        const serverName = getRemoteServerName(node);
+        const mcpProjectType = getWorkspaceSetting(mcpProjectTypeSetting, context.workspaceFolder.uri.fsPath) as McpProjectType;
+        // only add if it doesn't already exist
+        if (!checkIfMcpServerExists(mcpJson, serverName)) {
+            const newMcpJson = await addRemoteMcpServer(mcpJson, node, mcpProjectType);
+            await saveMcpJson(context.workspaceFolder.uri.fsPath, newMcpJson);
+        }
+    }
+
+    public createSuccessOutput(context: T): ExecuteActivityOutput {
+        const connectMcpServer: string = localize('connectMcpServer', 'Connect to MCP Server');
+        const mcpJsonFilePath: string = path.join(context.workspaceFolder.uri.fsPath, '.vscode', 'mcp.json');
+        return {
+            item: new ActivityChildItem({
+                label: connectMcpServer,
+                id: `${context.site?.id}-connectMcpServer`,
+                command: {
+                    command: 'vscode.open',
+                    title: connectMcpServer,
+                    arguments: [Uri.file(mcpJsonFilePath)]
+                },
+                activityType: ActivityChildType.Info,
+                contextValue: createContextValue([activityInfoContext, 'connectMcpServer']),
+                iconPath: new ThemeIcon('debug-disconnect'),
+                // a little trick to remove the description timer on activity children
+                description: ' '
+            })
+        };
+    }
+
+    public shouldExecute(context: T): boolean {
+        return context.isMcpProject === true;
+    }
+}

--- a/src/commands/deploy/DeployFunctionCoreToolsStep.ts
+++ b/src/commands/deploy/DeployFunctionCoreToolsStep.ts
@@ -86,7 +86,7 @@ export class DeployFunctionCoreToolsStep extends AzureWizardExecuteStep<InnerDep
     }
     public priority: number = 100;
     public async execute(context: InnerDeployContext, progress: Progress<{ message?: string; increment?: number; }>): Promise<void> {
-        const message = l10n.t('Publishing "{0}" to "{1}" with Functiontion Core Tools...', context.originalDeployFsPath, context.site.fullName);
+        const message = l10n.t('Publishing "{0}" to "{1}" with Function Core Tools...', context.originalDeployFsPath, context.site.fullName);
         progress.report({ message });
         context.activityAttributes = context.activityAttributes ?? { logs: [] };
         const args = ['func', 'azure', 'functionapp', 'publish', context.site.siteName];

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -33,6 +33,7 @@ import { getNetheriteConnectionIfNeeded } from '../appSettings/connectionSetting
 import { getSQLConnectionIfNeeded } from '../appSettings/connectionSettings/sqlDatabase/getSQLConnection';
 import { getEolWarningMessages } from '../createFunctionApp/stacks/getStackPicks';
 import { tryGetFunctionProjectRoot } from '../createNewProject/verifyIsProject';
+import { CreateRemoteMcpServerExecuteStep } from './CreateRemoteMcpServerExecuteStep';
 import { DeployFunctionCoreToolsStep } from './DeployFunctionCoreToolsStep';
 import { getOrCreateFunctionApp } from './getOrCreateFunctionApp';
 import { getWarningForExtensionBundle } from './getWarningForExtensionBundle';
@@ -44,7 +45,7 @@ import { validateRemoteBuild } from './validateRemoteBuild';
 import { verifyAppSettings } from './verifyAppSettings';
 
 // context that is used for deployment but since creation is an option in the deployment command, include ICreateFunctionAppContext
-export type IFuncDeployContext = { site?: Site, subscription?: AzureSubscription } &
+export type IFuncDeployContext = { site?: Site, subscription?: AzureSubscription, isMcpProject?: boolean, deployedNode?: SlotTreeItem } &
     Partial<ICreateFunctionAppContext> & IDeployContext & ISetConnectionSettingContext & ExecuteActivityContext;
 
 export async function deployProductionSlot(context: IActionContext, target?: vscode.Uri | string | SlotTreeItem): Promise<void> {
@@ -251,6 +252,8 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     }
 
     let deployedWithFuncCli = false;
+    context.isMcpProject = await isMcpProject(context.effectiveDeployFsPath);
+    context.deployedNode = node;
     await node.runWithTemporaryDescription(
         context,
         localize('deploying', 'Deploying...'),
@@ -286,11 +289,10 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
                 }
                 const deployContext = Object.assign(context, await createActivityContext());
                 deployContext.activityChildren = [];
-                await innerDeploy(site, deployFsPath, deployContext);
+                await innerDeploy(site, deployFsPath, deployContext, [new CreateRemoteMcpServerExecuteStep()]);
             }
         }
     );
-
     await notifyDeployComplete(context, node, context.workspaceFolder, isFlexConsumption, deployedWithFuncCli);
 }
 

--- a/src/commands/deploy/notifyDeployComplete.ts
+++ b/src/commands/deploy/notifyDeployComplete.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type IDeployContext } from '@microsoft/vscode-azext-azureappservice';
 import { callWithTelemetryAndErrorHandling, type AzExtTreeItem, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as retry from 'p-retry';
 import * as path from 'path';
@@ -14,110 +13,90 @@ import { localize } from '../../localize';
 import { type SlotTreeItem } from '../../tree/SlotTreeItem';
 import { RemoteFunctionTreeItem } from '../../tree/remoteProject/RemoteFunctionTreeItem';
 import { RemoteFunctionsTreeItem } from '../../tree/remoteProject/RemoteFunctionsTreeItem';
-import { addRemoteMcpServer, checkIfMcpServerExists, getOrCreateMcpJson, getRemoteServerName, isMcpProject, saveMcpJson } from '../../utils/mcpUtils';
 import { nonNullValue } from '../../utils/nonNull';
 import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { uploadAppSettings } from '../appSettings/uploadAppSettings';
 import { startStreamingLogs } from '../logstream/startStreamingLogs';
+import { type IFuncDeployContext } from './deploy';
 import { hasRemoteEventGridBlobTrigger, promptForEventGrid } from './promptForEventGrid';
 
-export async function notifyDeployComplete(context: IDeployContext, node: SlotTreeItem, workspaceFolder: WorkspaceFolder, isFlexConsumption?: boolean, deployedWithFuncCli?: boolean): Promise<void> {
+export async function notifyDeployComplete(context: IFuncDeployContext, node: SlotTreeItem, workspaceFolder: WorkspaceFolder, isFlexConsumption?: boolean, deployedWithFuncCli?: boolean): Promise<void> {
     await node.initSite(context);
-    const deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', node.site.fullName);
-    if (await isMcpProject(workspaceFolder.uri.fsPath)) {
+    let deployComplete: string = localize('deployComplete', 'Deployment to "{0}" completed.', node.site.fullName);
+    try {
+        const shouldCheckEventSystemTopics = isFlexConsumption && await hasRemoteEventGridBlobTrigger(context, node);
+        if (shouldCheckEventSystemTopics) {
+            await promptForEventGrid(context, workspaceFolder);
+        }
+    } catch (err) {
+        // ignore this error, don't block deploy for this check
+    }
+    const messageItems: MessageItem[] = [];
+    const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
+    const streamLogs: MessageItem = { title: localize('streamLogs', 'Stream logs') };
+    const uploadSettings: MessageItem = { title: localize('uploadAppSettings', 'Upload settings') };
+    const connectMcpServer: MessageItem = { title: localize('connectMcpServer', 'Connect to MCP Server') };
+    if (context.isMcpProject) {
+        messageItems.push(connectMcpServer);
         const mcpRecommendedActions: string = `Recommended actions: Learn more about [built-in server authorization](https://aka.ms/mcp-easy-auth) and authentication and Azure Functions [MCP server integration](https://aka.ms/mcp-integration).`;
+        deployComplete = `${deployComplete} ${mcpRecommendedActions}`;
+    } else {
+        messageItems.push(streamLogs, uploadSettings, viewOutput);
+    }
 
-        const connectMcpServer: MessageItem = { title: localize('connectMcpServer', 'Connect MCP Server') };
-        void window.showInformationMessage(`${deployComplete} ${mcpRecommendedActions}`, connectMcpServer).then(async result => {
-            await callWithTelemetryAndErrorHandling('postMcpDeploy', async (postDeployContext: IActionContext) => {
-                postDeployContext.valuesToMask.push(...context.valuesToMask);
-                context.telemetry.eventVersion = 2;
-                await node.initSite(context);
+    // Don't wait
+    void window.showInformationMessage(deployComplete, ...messageItems).then(async result => {
+        await callWithTelemetryAndErrorHandling('postDeploy', async (postDeployContext: IActionContext) => {
+            postDeployContext.telemetry.properties.dialogResult = result && result.title;
+            postDeployContext.valuesToMask.push(...context.valuesToMask);
+            context.telemetry.eventVersion = 2;
+            await node.initSite(context);
+
+            if (result === viewOutput) {
+                ext.outputChannel.show();
+            } else if (result === streamLogs) {
+                await startStreamingLogs(postDeployContext, node);
+            } else if (result === uploadSettings) {
+                const subContext = {
+                    ...postDeployContext,
+                    ...node.site.subscription
+                }
+                await uploadAppSettings(subContext, node.appSettingsTreeItem, undefined, workspaceFolder);
+            } else if (result === connectMcpServer) {
                 const mcpProjectType = getWorkspaceSetting(mcpProjectTypeSetting, workspaceFolder.uri.fsPath);
                 if (mcpProjectType === McpProjectType.McpExtensionServer) {
                     postDeployContext.telemetry.properties.projectType = 'McpExtensionServer';
                 } else if (mcpProjectType === McpProjectType.SelfHostedMcpServer) {
                     postDeployContext.telemetry.properties.projectType = 'SelfHostedMcpServer';
-                } else {
-                    // not sure how we got here so just return;
-                    return;
                 }
-
-                const mcpJson = await getOrCreateMcpJson(workspaceFolder.uri.fsPath);
-                const serverName = getRemoteServerName(node);
-                // only add if it doesn't already exist
-                if (!checkIfMcpServerExists(mcpJson, serverName)) {
-                    const newMcpJson = await addRemoteMcpServer(mcpJson, node, mcpProjectType);
-                    await saveMcpJson(workspaceFolder.uri.fsPath, newMcpJson);
-                }
-
-                if (result === connectMcpServer) {
-                    const mcpJsonFilePath: string = path.join(workspaceFolder.uri.fsPath, '.vscode', 'mcp.json');
-                    await window.showTextDocument(Uri.file(mcpJsonFilePath));
-                }
-            });
-        });
-
-    } else {
-
-        const viewOutput: MessageItem = { title: localize('viewOutput', 'View output') };
-        const streamLogs: MessageItem = { title: localize('streamLogs', 'Stream logs') };
-        const uploadSettings: MessageItem = { title: localize('uploadAppSettings', 'Upload settings') };
-
-        try {
-            const shouldCheckEventSystemTopics = isFlexConsumption && await hasRemoteEventGridBlobTrigger(context, node);
-            if (shouldCheckEventSystemTopics) {
-                await promptForEventGrid(context, workspaceFolder);
+                const mcpJsonFilePath: string = path.join(context.workspaceFolder.uri.fsPath, '.vscode', 'mcp.json');
+                await window.showTextDocument(Uri.file(mcpJsonFilePath));
             }
-        } catch (err) {
-            // ignore this error, don't block deploy for this check
-        }
-
-        // Don't wait
-        void window.showInformationMessage(deployComplete, streamLogs, uploadSettings, viewOutput).then(async result => {
-            await callWithTelemetryAndErrorHandling('postDeploy', async (postDeployContext: IActionContext) => {
-                postDeployContext.telemetry.properties.dialogResult = result && result.title;
-                postDeployContext.valuesToMask.push(...context.valuesToMask);
-                context.telemetry.eventVersion = 2;
-                await node.initSite(context);
-
-                if (result === viewOutput) {
-                    ext.outputChannel.show();
-                } else if (result === streamLogs) {
-                    await startStreamingLogs(postDeployContext, node);
-                } else if (result === uploadSettings) {
-                    const subContext = {
-                        ...postDeployContext,
-                        ...node.site.subscription
-                    }
-                    await uploadAppSettings(subContext, node.appSettingsTreeItem, undefined, workspaceFolder);
-                }
-            });
         });
+    });
 
-        try {
-            if (deployedWithFuncCli) {
-                // don't query triggers if we used the func cli to deploy
-                return;
-            }
-            const retries: number = 4;
-            await retry(
-                async (currentAttempt: number) => {
-                    context.telemetry.properties.queryTriggersAttempt = currentAttempt.toString();
-                    const message: string = currentAttempt === 1 ?
-                        localize('queryingTriggers', 'Querying triggers...') :
-                        localize('queryingTriggersAttempt', 'Querying triggers (Attempt {0}/{1})...', currentAttempt, retries + 1);
-                    ext.outputChannel.appendLog(message, { resourceName: node.site.fullName });
-                    await listHttpTriggerUrls(context, node);
-                },
-                { retries, minTimeout: 2 * 1000 }
-            );
-        } catch (error) {
-            // suppress error notification and instead display a warning in the output. We don't want it to seem like the deployment failed.
-            context.errorHandling.suppressDisplay = true;
-            ext.outputChannel.appendLog(localize('failedToList', 'WARNING: Deployment succeeded, but failed to list http trigger urls.'));
-            throw error;
+    try {
+        if (deployedWithFuncCli || context.isMcpProject) {
+            // don't query triggers if we used the func cli to deploy or if it's a self-hosted MCP project
+            return;
         }
+        const retries: number = 4;
+        await retry(
+            async (currentAttempt: number) => {
+                context.telemetry.properties.queryTriggersAttempt = currentAttempt.toString();
+                const message: string = currentAttempt === 1 ?
+                    localize('queryingTriggers', 'Querying triggers...') :
+                    localize('queryingTriggersAttempt', 'Querying triggers (Attempt {0}/{1})...', currentAttempt, retries + 1);
+                ext.outputChannel.appendLog(message, { resourceName: node.site.fullName });
+                await listHttpTriggerUrls(context, node);
+            },
+            { retries, minTimeout: 2 * 1000 }
+        );
+    } catch (error) {
+        // suppress error notification and instead display a warning in the output. We don't want it to seem like the deployment failed.
+        context.errorHandling.suppressDisplay = true;
+        ext.outputChannel.appendLog(localize('failedToList', 'WARNING: Deployment succeeded, but failed to list http trigger urls.'));
+        throw error;
     }
 }
 

--- a/src/commands/getMcpHostKey.ts
+++ b/src/commands/getMcpHostKey.ts
@@ -34,7 +34,6 @@ export async function getMcpHostKey(context: IActionContext & { subscription?: A
     }
 
     if (args.projectType === McpProjectType.SelfHostedMcpServer && keys.functionKeys?.['default']) {
-        // if the system key isn't there, just default to the default function key
         return keys.functionKeys['default'];
     }
 


### PR DESCRIPTION
For mcp extension function apps, the runtime will create a `mcp_extension` host key that is required to authenticate the remote server. It will fail with the default key (which was the old fallback behavior.)

It's better to throw an error because if the system key isn't there, it means that something went wrong. More than likely, the build failed and the runtime didn't actually start.