### PR TITLE
Revert "Group templates by filter rather than filtering it out (#4773)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1083,7 +1083,6 @@
                 "title": "Azure Functions",
                 "properties": {
                     "azureFunctions.templateFilter": {
-                        "deprecationMessage": "This setting is no longer used to filter templates, but is being left to explain what the filter enumerations mean.",
                         "scope": "resource",
                         "type": "string",
                         "default": "Verified",

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzureWizardPromptStep, type IAzureQuickPickItem, type IWizardOptions } from '@microsoft/vscode-azext-utils';
+import { AzureWizardPromptStep, type IActionContext, type IAzureQuickPickItem, type IAzureQuickPickOptions, type IWizardOptions } from '@microsoft/vscode-azext-utils';
 import * as escape from 'escape-string-regexp';
 import { type FuncVersion } from '../../FuncVersion';
-import { JavaBuildTool, ProjectLanguage } from '../../constants';
+import { JavaBuildTool, ProjectLanguage, TemplateFilter, templateFilterSetting } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { localize } from '../../localize';
 import { type FunctionTemplateBase, type IFunctionTemplate } from '../../templates/IFunctionTemplate';
@@ -14,7 +14,7 @@ import { TemplateSchemaVersion } from '../../templates/TemplateProviderBase';
 import { durableUtils } from '../../utils/durableUtils';
 import { nonNullProp } from '../../utils/nonNull';
 import { isNodeV4Plus, isPythonV2Plus, nodeV4Suffix } from '../../utils/programmingModelUtils';
-import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
+import { getWorkspaceSetting, updateWorkspaceSetting } from '../../vsCodeConfig/settings';
 import { FunctionSubWizard } from './FunctionSubWizard';
 import { type IFunctionWizardContext } from './IFunctionWizardContext';
 import { JobsListStep } from './JobsListStep';
@@ -39,7 +39,7 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             const language: ProjectLanguage = nonNullProp(context, 'language');
             const version: FuncVersion = nonNullProp(context, 'version');
             const templateProvider = ext.templateProvider.get(context);
-            const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, context.languageModel, version, context.projectTemplateKey);
+            const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, context.languageModel, version, TemplateFilter.All, context.projectTemplateKey);
             const foundTemplate: FunctionTemplateBase | undefined = templates.find((t: FunctionTemplateBase) => {
                 if (this._options.templateId) {
                     const actualId: string = t.id.toLowerCase();
@@ -83,6 +83,10 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     }
 
     public async prompt(context: IFunctionWizardContext): Promise<void> {
+        /* v2 schema doesn't have a template filter setting */
+        let templateFilter: TemplateFilter = context.templateSchemaVersion === TemplateSchemaVersion.v2 ? TemplateFilter.All :
+            getWorkspaceSetting<TemplateFilter>(templateFilterSetting, context.projectPath) || TemplateFilter.Verified;
+
         const templateProvider = ext.templateProvider.get(context);
         while (!context.functionTemplate) {
             let placeHolder: string = this._isProjectWizard ?
@@ -93,13 +97,17 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                 placeHolder += localize('templateSource', ' (Template source: "{0}")', templateProvider.templateSource)
             }
 
-            const result: FunctionTemplateBase | TemplatePromptResult =
-                (await context.ui.showQuickPick(this.getPicks(context),
-                    { placeHolder, enableGrouping: true })).data;
-
+            const result: FunctionTemplateBase | TemplatePromptResult = (await context.ui.showQuickPick(this.getPicks(context, templateFilter), { placeHolder })).data;
             if (result === 'skipForNow') {
                 context.telemetry.properties.templateId = 'skipForNow';
                 break;
+            } else if (result === 'changeFilter') {
+                templateFilter = await promptForTemplateFilter(context);
+                // can only update setting if it's open in a workspace
+                if (!this._isProjectWizard || context.openBehavior === 'AlreadyOpen') {
+                    await updateWorkspaceSetting(templateFilterSetting, templateFilter, context.projectPath);
+                }
+                context.telemetry.properties.changedFilter = 'true';
             } else if (result === 'openAPI') {
                 context.generateFromOpenAPI = true;
                 break;
@@ -109,6 +117,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             } else {
                 context.functionTemplate = result;
             }
+
+            context.telemetry.properties.templateFilter = templateFilter;
         }
     }
 
@@ -118,18 +128,18 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
             context.language !== ProjectLanguage.SelfHostedMCPServer;
     }
 
-    private async getPicks(context: IFunctionWizardContext): Promise<IAzureQuickPickItem<FunctionTemplateBase | TemplatePromptResult>[]> {
+    private async getPicks(context: IFunctionWizardContext, templateFilter: TemplateFilter): Promise<IAzureQuickPickItem<FunctionTemplateBase | TemplatePromptResult>[]> {
         const language: ProjectLanguage = nonNullProp(context, 'language');
         const languageModel = context.languageModel;
         const version: FuncVersion = nonNullProp(context, 'version');
         const templateProvider = ext.templateProvider.get(context);
 
-        const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, context.languageModel, version, context.projectTemplateKey);
+        const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, context.projectPath, language, context.languageModel, version, templateFilter, context.projectTemplateKey);
         context.telemetry.measurements.templateCount = templates.length;
         const picks: IAzureQuickPickItem<FunctionTemplateBase | TemplatePromptResult>[] = templates
             .filter((t) => !(doesTemplateRequireExistingStorageSetup(t.id, language) && !context.hasDurableStorage))
-            .sort((a, b) => sortTemplates(a, b))
-            .map(t => { return { label: t.name, data: t, group: t.templateFilter }; });
+            .sort((a, b) => sortTemplates(a, b, templateFilter))
+            .map(t => { return { label: t.name, data: t }; });
 
         if (this._isProjectWizard) {
             picks.unshift({
@@ -157,6 +167,15 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
                 suppressPersistence: true
             });
         }
+        if (context.templateSchemaVersion !== TemplateSchemaVersion.v2) {
+            // don't offer template filter for v2 schema
+            picks.push({
+                label: localize('selectFilter', '$(gear) Change template filter'),
+                description: localize('currentFilter', 'Current: {0}', templateFilter),
+                data: 'changeFilter',
+                suppressPersistence: true
+            });
+        }
 
         if (getWorkspaceSetting<boolean>('showReloadTemplates')) {
             picks.push({
@@ -176,7 +195,18 @@ interface IFunctionListStepOptions {
     functionSettings: { [key: string]: string | undefined } | undefined;
 }
 
-type TemplatePromptResult = 'skipForNow' | 'openAPI' | 'reloadTemplates';
+type TemplatePromptResult = 'changeFilter' | 'skipForNow' | 'openAPI' | 'reloadTemplates';
+
+async function promptForTemplateFilter(context: IActionContext): Promise<TemplateFilter> {
+    const picks: IAzureQuickPickItem<TemplateFilter>[] = [
+        { label: TemplateFilter.Verified, description: localize('verifiedDescription', '(Subset of "Core" that has been verified in VS Code)'), data: TemplateFilter.Verified },
+        { label: TemplateFilter.Core, data: TemplateFilter.Core },
+        { label: TemplateFilter.All, data: TemplateFilter.All }
+    ];
+
+    const options: IAzureQuickPickOptions = { suppressPersistence: true, placeHolder: localize('selectFilter', 'Select a template filter') };
+    return (await context.ui.showQuickPick(picks, options)).data;
+}
 
 // Todo: https://github.com/microsoft/vscode-azurefunctions/issues/3529
 // Identify and filter out Durable Function templates requiring a pre-existing storage setup
@@ -198,17 +228,21 @@ function doesTemplateRequireExistingStorageSetup(templateId: string, language?: 
  * If templateFilter is verified, puts HttpTrigger/TimerTrigger at the top since they're the most popular
  * Otherwise sort alphabetically
  */
-function sortTemplates(a: FunctionTemplateBase, b: FunctionTemplateBase): number {
-    function getPriority(id: string): number {
-        if (/\bhttptrigger\b/i.test(id)) { // Plain http trigger
-            return 1;
-        } else if (/\bhttptrigger/i.test(id)) { // Http trigger with any extra pizazz
-            return 2;
-        } else if (/\btimertrigger\b/i.test(id)) {
-            return 3;
-        } else {
-            return a.name.localeCompare(b.name) === -1 ? 4 : 5;
+function sortTemplates(a: FunctionTemplateBase, b: FunctionTemplateBase, templateFilter: TemplateFilter): number {
+    if (templateFilter === TemplateFilter.Verified) {
+        function getPriority(id: string): number {
+            if (/\bhttptrigger\b/i.test(id)) { // Plain http trigger
+                return 1;
+            } else if (/\bhttptrigger/i.test(id)) { // Http trigger with any extra pizazz
+                return 2;
+            } else if (/\btimertrigger\b/i.test(id)) {
+                return 3;
+            } else {
+                return 4;
+            }
         }
+        return getPriority(a.id) - getPriority(b.id);
     }
-    return getPriority(a.id) - getPriority(b.id);
+
+    return a.name.localeCompare(b.name);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const projectLanguageSetting: string = 'projectLanguage';
 export const projectLanguageModelSetting: string = 'projectLanguageModel';
 export const funcVersionSetting: string = 'projectRuntime'; // Using this name for the sake of backwards compatability even though it's not the most accurate
 export const projectSubpathSetting: string = 'projectSubpath';
+export const templateFilterSetting: string = 'templateFilter';
 export const deploySubpathSetting: string = 'deploySubpath';
 export const templateVersionSetting: string = 'templateVersion';
 export const preDeployTaskSetting: string = 'preDeployTask';

--- a/src/funcConfig/function.ts
+++ b/src/funcConfig/function.ts
@@ -40,7 +40,7 @@ export class ParsedFunctionJson {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
     public constructor(data: any) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (typeof data === 'object' && data !== null && (data.functions?.bindings !== undefined || data.functions?.bindings instanceof Array)) {
+        if (typeof data === 'object' && data !== null && (data.bindings === undefined || data.bindings instanceof Array)) {
             // this is to preserve the old template structure where function.json was nested under 'functions'
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             this.data = <IFunctionJson>data.functions;

--- a/src/templates/CentralTemplateProvider.ts
+++ b/src/templates/CentralTemplateProvider.ts
@@ -83,20 +83,18 @@ export class CentralTemplateProvider implements Disposable {
     }
 
     /* Ignored by the v2 schema */
-    public async getFunctionTemplates(context: IActionContext, projectPath: string | undefined, language: ProjectLanguage, languageModel: number | undefined, version: FuncVersion, projectTemplateKey: string | undefined): Promise<FunctionTemplateBase[]> {
+    public async getFunctionTemplates(context: IActionContext, projectPath: string | undefined, language: ProjectLanguage, languageModel: number | undefined, version: FuncVersion, templateFilter: TemplateFilter, projectTemplateKey: string | undefined): Promise<FunctionTemplateBase[]> {
         const templates: ITemplates = await this.getTemplates(context, projectPath, language, languageModel, version, projectTemplateKey);
-        for (const template of templates.functionTemplates) {
-            // by default, all templates will be categorized as 'All'
-            template.templateFilter = TemplateFilter.All;
-            const verifiedTemplateIds = getScriptVerifiedTemplateIds(version).concat(getDotnetVerifiedTemplateIds(version)).concat(getJavaVerifiedTemplateIds().concat(getBallerinaVerifiedTemplateIds()));
-            if (verifiedTemplateIds.find(vt => typeof vt === 'string' ? vt === template.id : vt.test(template.id))) {
-                template.templateFilter = TemplateFilter.Verified;
-            } else if ((template as IFunctionTemplate).categories.find((c: TemplateCategory) => c === TemplateCategory.Core) !== undefined) {
-                template.templateFilter = TemplateFilter.Core;
-            }
+        switch (templateFilter) {
+            case TemplateFilter.All:
+                return templates.functionTemplates;
+            case TemplateFilter.Core:
+                return templates.functionTemplates.filter((t: IFunctionTemplate) => t.categories.find((c: TemplateCategory) => c === TemplateCategory.Core) !== undefined);
+            case TemplateFilter.Verified:
+            default:
+                const verifiedTemplateIds = getScriptVerifiedTemplateIds(version).concat(getDotnetVerifiedTemplateIds(version)).concat(getJavaVerifiedTemplateIds().concat(getBallerinaVerifiedTemplateIds()));
+                return templates.functionTemplates.filter((t: IFunctionTemplate) => verifiedTemplateIds.find(vt => typeof vt === 'string' ? vt === t.id : vt.test(t.id)));
         }
-
-        return templates.functionTemplates;
     }
 
     public async clearTemplateCache(context: IActionContext, projectPath: string | undefined, language: ProjectLanguage, languageModel: number | undefined, version: FuncVersion): Promise<void> {
@@ -119,7 +117,7 @@ export class CentralTemplateProvider implements Disposable {
 
     public async tryGetSampleData(context: IActionContext, version: FuncVersion, triggerBindingType: string): Promise<string | undefined> {
         try {
-            const templates: IScriptFunctionTemplate[] = <IScriptFunctionTemplate[]>await this.getFunctionTemplates(context, undefined, ProjectLanguage.JavaScript, undefined, version, undefined);
+            const templates: IScriptFunctionTemplate[] = <IScriptFunctionTemplate[]>await this.getFunctionTemplates(context, undefined, ProjectLanguage.JavaScript, undefined, version, TemplateFilter.All, undefined);
             const template: IScriptFunctionTemplate | undefined = templates.find(t => t.functionJson.triggerBinding?.type?.toLowerCase() === triggerBindingType.toLowerCase());
             return template?.templateFiles['sample.dat'];
         } catch {

--- a/src/templates/IFunctionTemplate.ts
+++ b/src/templates/IFunctionTemplate.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { type ProjectLanguage, type TemplateFilter } from '../constants';
+import { type ProjectLanguage } from '../constants';
 import { type IBindingSetting } from './IBindingTemplate';
 import { type TemplateSchemaVersion } from './TemplateProviderBase';
 import { type ParsedJob, type RawTemplateV2 } from './script/parseScriptTemplatesV2';
@@ -46,5 +46,4 @@ export interface FunctionTemplateBase {
     isTimerTrigger: boolean;
     isMcpTrigger: boolean;
     templateSchemaVersion: TemplateSchemaVersion
-    templateFilter?: TemplateFilter; // defaults to All
 }

--- a/src/templates/dotnet/parseDotnetTemplates.ts
+++ b/src/templates/dotnet/parseDotnetTemplates.ts
@@ -86,8 +86,7 @@ function parseDotnetTemplate(rawTemplate: IRawTemplate): IFunctionTemplate {
         userPromptedSettings: userPromptedSettings,
         categories: [TemplateCategory.Core], // Dotnet templates do not have category information, so display all templates as if they are in the 'core' category
         isDynamicConcurrent: (rawTemplate.Identity.includes('ServiceBusQueueTrigger') || rawTemplate.Identity.includes('BlobTrigger') || rawTemplate.Identity.includes('QueueTrigger')) ? true : false,
-        templateSchemaVersion: TemplateSchemaVersion.v1,
-        templateFilter: TemplateFilter.All
+        templateSchemaVersion: TemplateSchemaVersion.v1
     };
 }
 
@@ -124,7 +123,7 @@ async function copyCSharpSettingsFromJS(csharpTemplates: IFunctionTemplate[], ve
         jsContext.telemetry.properties.isActivationEvent = 'true';
 
         const templateProvider = ext.templateProvider.get(jsContext);
-        const jsTemplates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(jsContext, undefined, ProjectLanguage.JavaScript, undefined, version, undefined);
+        const jsTemplates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(jsContext, undefined, ProjectLanguage.JavaScript, undefined, version, TemplateFilter.All, undefined);
         for (const csharpTemplate of csharpTemplates) {
             assertTemplateIsV1(csharpTemplate);
             csharpTemplate.templateSchemaVersion = TemplateSchemaVersion.v1;

--- a/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
+++ b/src/vsCodeConfig/verifyVSCodeConfigOnActivate.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import type * as vscode from 'vscode';
 import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIsProject';
 import { initProjectForVSCode } from '../commands/initProjectForVSCode/initProjectForVSCode';
-import { funcVersionSetting, ProjectLanguage, projectLanguageModelSetting, projectLanguageSetting } from '../constants';
+import { funcVersionSetting, ProjectLanguage, projectLanguageModelSetting, projectLanguageSetting, TemplateFilter } from '../constants';
 import { ext } from '../extensionVariables';
 import { tryParseFuncVersion, type FuncVersion } from '../FuncVersion';
 import { localize } from '../localize';
@@ -38,7 +38,7 @@ export async function verifyVSCodeConfigOnActivate(context: IActionContext, fold
                         templatesContext.telemetry.properties.isActivationEvent = 'true';
                         templatesContext.errorHandling.suppressDisplay = true;
                         const templateProvider = ext.templateProvider.get(templatesContext);
-                        await templateProvider.getFunctionTemplates(templatesContext, projectPath, language, languageModel, version, undefined);
+                        await templateProvider.getFunctionTemplates(templatesContext, projectPath, language, languageModel, version, TemplateFilter.Verified, undefined);
                     });
 
                     let isDotnet: boolean = false;

--- a/test/createFunction/FunctionTesterBase.ts
+++ b/test/createFunction/FunctionTesterBase.ts
@@ -8,7 +8,7 @@ import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import * as assert from 'assert';
 import * as path from 'path';
 import { type Disposable } from 'vscode';
-import { createFunctionInternal, getRandomHexString, type FunctionTemplateBase, type FuncVersion, type ProjectLanguage, type TemplateSource } from '../../extension.bundle';
+import { createFunctionInternal, getRandomHexString, TemplateFilter, type FunctionTemplateBase, type FuncVersion, type ProjectLanguage, type TemplateSource } from '../../extension.bundle';
 import { addParallelSuite, type ParallelSuiteOptions, type ParallelTest } from '../addParallelSuite';
 import { runForTemplateSource, testFolderPath } from '../global.test';
 
@@ -47,7 +47,7 @@ export abstract class FunctionTesterBase implements Disposable {
                 await this.initializeTestFolder(this.projectPath);
 
                 // This will initialize and cache the templatesTask for this project. Better to do it here than during the first test
-                await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, undefined, this.version, undefined);
+                await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, undefined, this.version, TemplateFilter.Verified, undefined);
             });
         });
     }
@@ -55,7 +55,7 @@ export abstract class FunctionTesterBase implements Disposable {
     public async dispose(): Promise<void> {
         await runWithTestActionContext('testCreateFunctionDispose', async context => {
             await runForTemplateSource(context, this.source, async (templateProvider) => {
-                const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, undefined, this.version, undefined);
+                const templates: FunctionTemplateBase[] = await templateProvider.getFunctionTemplates(context, this.projectPath, this.language, undefined, this.version, TemplateFilter.Verified, undefined);
                 assert.deepEqual(this.testedFunctions.sort(), templates.map(t => t.name).sort(), 'Not all "Verified" templates were tested');
             });
         });

--- a/test/global.test.ts
+++ b/test/global.test.ts
@@ -9,7 +9,7 @@ import * as assert from 'assert';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { CentralTemplateProvider, deploySubpathSetting, envUtils, ext, FuncVersion, funcVersionSetting, getGlobalSetting, getRandomHexString, parseError, preDeployTaskSetting, ProjectLanguage, projectLanguageSetting, pythonVenvSetting, registerOnActionStartHandler, TemplateSource, updateGlobalSetting, updateWorkspaceSetting, type IActionContext } from '../extension.bundle';
+import { CentralTemplateProvider, deploySubpathSetting, envUtils, ext, FuncVersion, funcVersionSetting, getGlobalSetting, getRandomHexString, parseError, preDeployTaskSetting, ProjectLanguage, projectLanguageSetting, pythonVenvSetting, registerOnActionStartHandler, TemplateFilter, templateFilterSetting, TemplateSource, updateGlobalSetting, updateWorkspaceSetting, type IActionContext } from '../extension.bundle';
 
 /**
  * Folder for most tests that do not need a workspace open
@@ -106,7 +106,7 @@ async function preLoadTemplates(): Promise<void> {
                 }
 
                 for (const language of [ProjectLanguage.JavaScript, ProjectLanguage.CSharp]) {
-                    tasks.push(provider.getFunctionTemplates(context, testWorkspaceFolders[0], language, undefined, version, undefined));
+                    tasks.push(provider.getFunctionTemplates(context, testWorkspaceFolders[0], language, undefined, version, TemplateFilter.Verified, undefined));
                 }
             }
         });
@@ -147,6 +147,7 @@ export async function cleanTestWorkspace(): Promise<void> {
         const settings: string[] = [
             projectLanguageSetting,
             funcVersionSetting,
+            templateFilterSetting,
             deploySubpathSetting,
             preDeployTaskSetting,
             pythonVenvSetting

--- a/test/templateCount.test.ts
+++ b/test/templateCount.test.ts
@@ -5,7 +5,7 @@
 
 import { runWithTestActionContext } from '@microsoft/vscode-azext-dev';
 import * as assert from 'assert';
-import { FuncVersion, ProjectLanguage, TemplateSource, type CentralTemplateProvider, type FunctionTemplateBase } from '../extension.bundle';
+import { FuncVersion, ProjectLanguage, TemplateFilter, TemplateSource, type CentralTemplateProvider, type FunctionTemplateBase } from '../extension.bundle';
 import { getTestWorkspaceFolder, longRunningTestsEnabled, runForTemplateSource, shouldSkipVersion } from './global.test';
 import { javaUtils } from './utils/javaUtils';
 
@@ -57,7 +57,7 @@ function addSuite(source: TemplateSource | undefined): void {
 
                 await runWithTestActionContext('getFunctionTemplates', async context => {
                     await runForTemplateSource(context, source, async (provider: CentralTemplateProvider) => {
-                        const templates: FunctionTemplateBase[] = await provider.getFunctionTemplates(context, testWorkspacePath, language, undefined, version, projectTemplateKey);
+                        const templates: FunctionTemplateBase[] = await provider.getFunctionTemplates(context, testWorkspacePath, language, undefined, version, TemplateFilter.Verified, projectTemplateKey);
                         assert.equal(templates.length, expectedCount);
                     });
                 });


### PR DESCRIPTION
This was causing a bug with Python V2 templates. I'm pretty sure that I know how to fix it, but I don't want to risk it with the release, so will fix it afterwards.