### PR TITLE
Loosen requirements on the func host start task more

### DIFF
--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -83,7 +83,7 @@ const defaultFuncPort: string = '7071';
 
 export function isFuncHostTask(task: vscode.Task): boolean {
     const commandLine: string | undefined = task.execution && (<vscode.ShellExecution>task.execution).commandLine;
-    return /(?:^|[\\/])(func(?:\.exe)?)\s+host\s+start$/i.test(commandLine || '');
+    return /(func(?:\.exe)?)\s+host\s+start/i.test(commandLine || '');
 }
 
 export function registerFuncHostTaskEvents(): void {


### PR DESCRIPTION
The original regex was `/func (host )?start/i`

There was a change in Insiders that added the file path and .exe in the task when I was testing, so I tried to account for that, but I think by adding the $, it made anything that had flags fail. 

Anyway, this is still more strict than what we had originally.