### PR TITLE
Fix a `Netherite` connection setting boolean

### DIFF
--- a/src/commands/deploy/verifyAppSettings.ts
+++ b/src/commands/deploy/verifyAppSettings.ts
@@ -83,7 +83,7 @@ export async function verifyAndUpdateAppConnectionStrings(context: IActionContex
     let didUpdate: boolean = false;
     switch (durableStorageType) {
         case DurableBackend.Netherite:
-            if (context.newEventHubsNamespaceConnectionSettingKey && context.newEventHubConnectionSettingValue) {
+            if (context.newEventHubsNamespaceConnectionSettingKey && context.newEventHubsNamespaceConnectionSettingValue) {
                 const updatedNamespaceConnection: boolean = updateConnectionStringIfNeeded(context, remoteProperties, context.newEventHubsNamespaceConnectionSettingKey, context.newEventHubsNamespaceConnectionSettingValue);
                 didUpdate ||= updatedNamespaceConnection;
             }


### PR DESCRIPTION
Found a small bug where we are checking the wrong boolean value.  That said, impact is likely pretty low anyway because Netherite was deprecated / removed from the list of available new projects for users to create.