### PR TITLE
Add error message when deploying to flex apps with python 3.14

### DIFF
--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -144,6 +144,16 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
 
     const isFlexConsumption: boolean = await client.getIsConsumptionV2(actionContext);
     actionContext.telemetry.properties.isFlexConsumption = String(isFlexConsumption);
+
+    if (language === ProjectLanguage.Python && isFlexConsumption) {
+        const runtimeVersion = site.rawSite.functionAppConfig?.runtime?.version;
+        if (runtimeVersion === '3.14') {
+            const errorMessage = localize('python314FlexError', 'Remote build for Python 3.14 is not supported for flex. Please refer to https://aka.ms/py314-remote-build-flex.');
+            ext.outputChannel.appendLog(errorMessage);
+            throw new Error(errorMessage);
+        }
+    }
+
     // don't use remote build setting for consumption v2
     const doRemoteBuild: boolean | undefined = getWorkspaceSetting<boolean>(remoteBuildSetting, deployPaths.effectiveDeployFsPath) && !isFlexConsumption;
     actionContext.telemetry.properties.scmDoBuildDuringDeployment = String(doRemoteBuild);


### PR DESCRIPTION
This PR adds validation to prevent deploying Python 3.14 function apps to Flex Consumption plans, as remote build is not currently supported for this configuration.

Changes

- Added a check in the deployment flow to detect when a Python 3.14 app is being deployed to a Flex Consumption function app
- The validation reads the [functionAppConfig.runtime.version](vscode-file://vscode-app/c:/Users/gaaguiar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) property from the remote site configuration
- When Python 3.14 on Flex is detected, the deployment is blocked with a clear error message
- The error message includes a reference link ([https://aka.ms/py314-remote-build-flex](vscode-file://vscode-app/c:/Users/gaaguiar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) for more information