### PR TITLE
Don't call for storageConnetionString if it's not needed

### DIFF
--- a/src/commands/createFunctionApp/FunctionAppCreateStep.ts
+++ b/src/commands/createFunctionApp/FunctionAppCreateStep.ts
@@ -147,7 +147,16 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStepWithActivityOut
     private async getNewSiteConfig(context: IFunctionAppWizardContext, stack?: FullFunctionAppStack): Promise<SiteConfig> {
         let newSiteConfig: SiteConfig = {};
 
-        const storageConnectionString: string = (await getStorageConnectionString(context)).connectionString;
+        const isElasticPremium: boolean = context.plan?.sku?.family?.toLowerCase() === 'ep';
+        const isConsumption: boolean = context.plan?.sku?.family?.toLowerCase() === 'y';
+        // no stack means it's a flex app
+        const isFlex: boolean = !stack;
+
+        // Only fetch the storage connection string when it's actually needed.
+        // It's not needed for flex + managed identity since all storage settings use service URIs.
+        const needsConnectionString: boolean = !(isFlex && context.managedIdentity);
+        const storageConnectionString: string | undefined = needsConnectionString ?
+            (await getStorageConnectionString(context)).connectionString : undefined;
 
         let appSettings: NameValuePair[] = [];
         if (context.managedIdentity) {
@@ -155,7 +164,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStepWithActivityOut
         } else {
             appSettings.push({
                 name: ConnectionKey.Storage,
-                value: storageConnectionString
+                value: nonNullProp({ storageConnectionString }, 'storageConnectionString')
             });
         }
 
@@ -176,20 +185,16 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStepWithActivityOut
         if (context.version === FuncVersion.v1) {
             appSettings.push({
                 name: 'AzureWebJobsDashboard',
-                value: storageConnectionString
+                value: nonNullProp({ storageConnectionString }, 'storageConnectionString')
             });
         }
 
-        const isElasticPremium: boolean = context.plan?.sku?.family?.toLowerCase() === 'ep';
-        const isConsumption: boolean = context.plan?.sku?.family?.toLowerCase() === 'y';
-        // no stack means it's a flex app
-        const isFlex: boolean = !stack;
         if (isConsumption || isElasticPremium) {
             // WEBSITE_CONTENT* settings are added for consumption/premium plans, but not dedicated
             // https://github.com/microsoft/vscode-azurefunctions/issues/1702
             appSettings.push({
                 name: contentConnectionStringKey,
-                value: storageConnectionString
+                value: nonNullProp({ storageConnectionString }, 'storageConnectionString')
             });
             appSettings.push({
                 name: contentShareKey,
@@ -199,7 +204,7 @@ export class FunctionAppCreateStep extends AzureWizardExecuteStepWithActivityOut
         } else if (isFlex && !context.managedIdentity) {
             appSettings.push({
                 name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING',
-                value: storageConnectionString
+                value: nonNullProp({ storageConnectionString }, 'storageConnectionString')
             });
         }
 

--- a/src/utils/managedIdentityUtils.ts
+++ b/src/utils/managedIdentityUtils.ts
@@ -8,21 +8,37 @@ import { nonNullValueAndProp } from "@microsoft/vscode-azext-utils";
 import { type IFunctionAppWizardContext } from "../commands/createFunctionApp/IFunctionAppWizardContext";
 import { ConnectionKey } from "../constants";
 
+const defaultStorageEndpointSuffix = 'core.windows.net';
+
+/**
+ * Gets the storage endpoint suffix from the Azure environment, stripping any leading dot.
+ * Falls back to 'core.windows.net' if the environment doesn't provide one.
+ */
+function getStorageEndpointSuffix(context: IFunctionAppWizardContext): string {
+    let suffix: string = context.environment?.storageEndpointSuffix ?? defaultStorageEndpointSuffix;
+    // https://github.com/Azure/azure-sdk-for-node/issues/4706
+    if (suffix.startsWith('.')) {
+        suffix = suffix.substring(1);
+    }
+    return suffix;
+}
+
 export function createAzureWebJobsStorageManagedIdentitySettings(context: IFunctionAppWizardContext): NameValuePair[] {
     const appSettings: NameValuePair[] = [];
     const storageAccountName = context.newStorageAccountName ?? context.storageAccount?.name;
     if (context.managedIdentity) {
+        const endpointSuffix = getStorageEndpointSuffix(context);
         appSettings.push({
             name: `${ConnectionKey.Storage}__blobServiceUri`,
-            value: `https://${storageAccountName}.blob.core.windows.net`
+            value: `https://${storageAccountName}.blob.${endpointSuffix}`
         });
         appSettings.push({
             name: `${ConnectionKey.Storage}__queueServiceUri`,
-            value: `https://${storageAccountName}.queue.core.windows.net`
+            value: `https://${storageAccountName}.queue.${endpointSuffix}`
         });
         appSettings.push({
             name: `${ConnectionKey.Storage}__tableServiceUri`,
-            value: `https://${storageAccountName}.table.core.windows.net`
+            value: `https://${storageAccountName}.table.${endpointSuffix}`
         });
         appSettings.push({
             name: `${ConnectionKey.Storage}__clientId`,


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-azurefunctions/issues/4900

For creating flex + managed identity, `storageConnectionString` is never used but still computed. That's the unnecessary call that triggers the error since it's not available with storage accounts that have SAS turned off.

Also have a fallback for storage endpoint suffix, but it was previously hard-coded before, so it probably didn't work for other clouds.