### PR TITLE
Update @microsoft/vscode-azext-azureutils to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@azure/storage-blob": "^12.5.0",
                 "@microsoft/vscode-azext-azureappservice": "^4.2.3",
                 "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
-                "@microsoft/vscode-azext-azureutils": "^4.0.1",
+                "@microsoft/vscode-azext-azureutils": "^4.1.1",
                 "@microsoft/vscode-azext-utils": "^4.0.5",
                 "@microsoft/vscode-azureresources-api": "^2.6.2",
                 "@microsoft/vscode-container-client": "^0.3.0",
@@ -207,18 +207,19 @@
             }
         },
         "node_modules/@azure/arm-msi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-msi/-/arm-msi-2.1.0.tgz",
-            "integrity": "sha512-qP2BXpXkZ/I5gO479Dj6HFVkgSrAlYOG2AGVTqxTu0YIVdZdmrlZLH7SNl1Um9id+p7uNGNRdVKIBO5rcQgeJw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-msi/-/arm-msi-2.2.0.tgz",
+            "integrity": "sha512-Wqg9j9qR+k1IxZXwKtegZWj6k1d6UUGOz4uHPmhyJOeiQrtZHXBcaWSZhtqJo5sy888TD6jVIQV/4znhbKYL9g==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/core-auth": "^1.3.0",
-                "@azure/core-client": "^1.6.1",
-                "@azure/core-paging": "^1.2.0",
-                "@azure/core-rest-pipeline": "^1.8.0",
-                "tslib": "^2.2.0"
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.2",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.0",
+                "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/arm-operationalinsights": {
@@ -338,20 +339,21 @@
             }
         },
         "node_modules/@azure/arm-storage": {
-            "version": "18.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.4.0.tgz",
-            "integrity": "sha512-3FOjh1FAL0FTWlNjmwOZFOiNJbu68cFRU4x7sKmSx+kze8/mkqAlJ+TLyYHv7+W/UigHOjrmn7DGKpDWyXkWgQ==",
+            "version": "18.6.0",
+            "resolved": "https://registry.npmjs.org/@azure/arm-storage/-/arm-storage-18.6.0.tgz",
+            "integrity": "sha512-dyN50fxts2xClCLIQY8qoDepYx2ql/eW5cVOy8XP+5zt9wIr1cgN2Mmv9/so2HDg6M/zOz8LhrvY+bS2blbhDQ==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
                 "@azure/core-auth": "^1.9.0",
-                "@azure/core-client": "^1.9.2",
+                "@azure/core-client": "^1.9.3",
                 "@azure/core-lro": "^2.5.4",
                 "@azure/core-paging": "^1.6.2",
-                "@azure/core-rest-pipeline": "^1.19.0",
+                "@azure/core-rest-pipeline": "^1.19.1",
                 "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/arm-storage-profile-2020-09-01-hybrid": {
@@ -384,16 +386,17 @@
             }
         },
         "node_modules/@azure/core-auth": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
-            "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+            "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-util": "^1.11.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-util": "^1.13.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
@@ -408,20 +411,21 @@
             }
         },
         "node_modules/@azure/core-client": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.3.tgz",
-            "integrity": "sha512-/wGw8fJ4mdpJ1Cum7s1S+VQyXt1ihwKLzfabS1O/RDADnmzVc01dHn44qD0BvGH6KlZNzOMW95tEpKqhkCChPA==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+            "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.4.0",
-                "@azure/core-rest-pipeline": "^1.9.1",
-                "@azure/core-tracing": "^1.0.0",
-                "@azure/core-util": "^1.6.1",
-                "@azure/logger": "^1.0.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
@@ -485,21 +489,21 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.1.tgz",
-            "integrity": "sha512-zHeoI3NCs53lLBbWNzQycjnYKsA1CVKlnzSNuSFcUDwBp8HHVObePxrM7HaX+Ha5Ks639H7chNC9HOaIhNS03w==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+            "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
-                "@azure/core-auth": "^1.8.0",
-                "@azure/core-tracing": "^1.0.1",
-                "@azure/core-util": "^1.11.0",
-                "@azure/logger": "^1.0.0",
-                "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
+                "@typespec/ts-http-runtime": "^0.3.4",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
@@ -514,26 +518,29 @@
             }
         },
         "node_modules/@azure/core-tracing": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
-            "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+            "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-util": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
-            "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+            "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/abort-controller": "^2.0.0",
+                "@azure/abort-controller": "^2.1.2",
+                "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
@@ -560,10 +567,10 @@
             }
         },
         "node_modules/@azure/identity": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.8.0.tgz",
-            "integrity": "sha512-l9ALUGHtFB/JfsqmA+9iYAp2a+cCwdNO/cyIr2y7nJLJsz1aae6qVP8XxT7Kbudg0IQRSIMXj0+iivFdbD1xPA==",
-            "dev": true,
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+            "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+            "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.0.0",
                 "@azure/core-auth": "^1.9.0",
@@ -572,23 +579,19 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^4.2.0",
-                "@azure/msal-node": "^3.2.3",
-                "events": "^3.0.0",
-                "jws": "^4.0.0",
+                "@azure/msal-browser": "^5.5.0",
+                "@azure/msal-node": "^5.1.0",
                 "open": "^10.1.0",
-                "stoppable": "^1.1.0",
                 "tslib": "^2.2.0"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
             "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.6.2"
             },
@@ -600,7 +603,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "dev": true,
             "engines": {
                 "node": ">=12"
             },
@@ -612,7 +614,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
             "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-            "dev": true,
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -627,7 +628,6 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
             "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
-            "dev": true,
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
@@ -642,64 +642,56 @@
             }
         },
         "node_modules/@azure/logger": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
-            "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+            "license": "MIT",
             "dependencies": {
+                "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@azure/ms-rest-azure-env": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
-            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
-            "peer": true
+            "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.7.0.tgz",
-            "integrity": "sha512-H4AIPhIQVe1qW4+BJaitqod6UGQiXE3juj7q2ZBsOPjuZicQaqcbnBp2gCroF/icS0+TJ9rGuyCBJbjlAqVOGA==",
-            "dev": true,
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.2.tgz",
+            "integrity": "sha512-ZgcN9ToRJ80f+wNPBBKYJ+DG0jlW7ktEjYtSNkNsTrlHVMhKB8tKMdI1yIG1I9BJtykkXtqnuOjlJaEMC7J6aw==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.2.1"
+                "@azure/msal-common": "16.4.0"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "15.2.1",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.2.1.tgz",
-            "integrity": "sha512-eZHtYE5OHDN0o2NahCENkczQ6ffGc0MoUSAI3hpwGpZBHJXaEQMMZPWtIx86da2L9w7uT+Tr/xgJbGwIkvTZTQ==",
-            "dev": true,
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
+            "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.3.0.tgz",
-            "integrity": "sha512-ulsT3EHF1RQ29X55cxBLgKsIKWni9JdbUqG7sipGVP4uhWcBpmm/vhKOMH340+27Acm9+kHGnN/5XmQ5LrIDgA==",
-            "dev": true,
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.1.tgz",
+            "integrity": "sha512-71grXU6+5hl+3CL3joOxlj/AW6rmhthuTlG0fRqsTrhPArQBpZuUFzCIlKOGdcafLUa/i1hBdV78ZxJdlvRA+g==",
+            "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.2.1",
+                "@azure/msal-common": "16.4.0",
                 "jsonwebtoken": "^9.0.0",
                 "uuid": "^8.3.0"
             },
             "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/@azure/msal-node/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "bin": {
-                "uuid": "dist/bin/uuid"
+                "node": ">=20"
             }
         },
         "node_modules/@azure/storage-blob": {
@@ -1799,26 +1791,42 @@
                 "vscode": "^1.105.0"
             }
         },
+        "node_modules/@microsoft/vscode-azext-azureauth": {
+            "version": "6.0.0-alpha.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureauth/-/vscode-azext-azureauth-6.0.0-alpha.8.tgz",
+            "integrity": "sha512-oOZpeTe4tOupKzQpeKxyHOSG10Bxsyp8YhCeyadQMsz1wICR/JZEdSMKPR0GnXpXYlYSsEDFbSzJWqZUZ/3+Yw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/core-rest-pipeline": "^1.22.2",
+                "@azure/identity": "^4.13.0",
+                "@azure/ms-rest-azure-env": "^2.0.0"
+            },
+            "engines": {
+                "vscode": "^1.106.0"
+            }
+        },
         "node_modules/@microsoft/vscode-azext-azureutils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-4.0.1.tgz",
-            "integrity": "sha512-lJq5PxwKZagJkqjBfyac7YCSjb2K3UVwj8CJLm16ejrrnFop/q2qoLC52Sfi0ahA0Y0uqAPWzM4ToAZwbBrk0A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureutils/-/vscode-azext-azureutils-4.1.1.tgz",
+            "integrity": "sha512-IVY7TqYNcwIUQqaOfkNJyLz7lrYG/UfLqG2OXuWB8HO1RQbwfvrxPncPXGw/zl8w1eDhBdZwf5YXbKzDDb8nqQ==",
             "license": "MIT",
             "dependencies": {
                 "@azure/arm-authorization": "^9.0.0",
                 "@azure/arm-authorization-profile-2020-09-01-hybrid": "^2.1.0",
-                "@azure/arm-msi": "^2.1.0",
+                "@azure/arm-msi": "^2.2.0",
                 "@azure/arm-resources": "^5.0.0",
-                "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.0.0",
-                "@azure/arm-resources-subscriptions": "^2.0.0",
-                "@azure/arm-storage": "^18.2.0",
-                "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.0.0",
-                "@azure/core-client": "^1.6.0",
-                "@azure/core-rest-pipeline": "^1.9.0",
-                "@azure/logger": "^1.0.4",
-                "@microsoft/vscode-azext-utils": "^4.0.3",
-                "@microsoft/vscode-azureresources-api": "^3.0.0",
-                "semver": "^7.3.7"
+                "@azure/arm-resources-profile-2020-09-01-hybrid": "^2.1.0",
+                "@azure/arm-resources-subscriptions": "^2.1.0",
+                "@azure/arm-storage": "^18.6.0",
+                "@azure/arm-storage-profile-2020-09-01-hybrid": "^2.1.0",
+                "@azure/core-client": "^1.10.1",
+                "@azure/core-rest-pipeline": "^1.22.2",
+                "@azure/logger": "^1.3.0",
+                "@microsoft/vscode-azext-azureauth": "^6.0.0-alpha.6",
+                "@microsoft/vscode-azext-utils": "^4.0.4",
+                "@microsoft/vscode-azureresources-api": "^3.1.0",
+                "semver": "^7.7.4"
             },
             "engines": {
                 "vscode": "^1.105.0"
@@ -1828,9 +1836,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureutils/node_modules/@microsoft/vscode-azureresources-api": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.0.0.tgz",
-            "integrity": "sha512-IfivhAfLjUQtIJa3kqfZPJanb9m3XVBgRmYrFQtnRp6GWeKGKhkyMC44MunodtX0k4C7A1LmG3lM4z38sxCcpQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azureresources-api/-/vscode-azureresources-api-3.1.0.tgz",
+            "integrity": "sha512-jcx5VdDiOftjkjQ+ZXuGQ7xpy7WSKnB7oRLdmGuW3ykaB/PrBSHwStkItSg8l8ycJ0t1kaPOz3eDJP0Ol309jg==",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.105.0"
@@ -3119,6 +3127,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typespec/ts-http-runtime": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
+            "integrity": "sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==",
+            "license": "MIT",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@vscode/extension-telemetry": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
@@ -3936,7 +3958,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/bufferutil": {
@@ -3955,7 +3976,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-            "dev": true,
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -4465,7 +4485,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
             "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-            "dev": true,
             "dependencies": {
                 "bundle-name": "^4.1.0",
                 "default-browser-id": "^5.0.0"
@@ -4481,7 +4500,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
             "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-            "dev": true,
             "engines": {
                 "node": ">=18"
             },
@@ -4614,7 +4632,6 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
@@ -5921,7 +5938,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-            "dev": true,
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -5939,7 +5955,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-            "dev": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -6183,12 +6198,12 @@
             }
         },
         "node_modules/jsonwebtoken": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-            "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-            "dev": true,
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+            "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+            "license": "MIT",
             "dependencies": {
-                "jws": "^3.2.2",
+                "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
                 "lodash.isboolean": "^3.0.3",
                 "lodash.isinteger": "^4.0.4",
@@ -6202,29 +6217,6 @@
             "engines": {
                 "node": ">=12",
                 "npm": ">=6"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer-equal-constant-time": "^1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/jsonwebtoken/node_modules/jws": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "jwa": "^1.4.2",
-                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/jszip": {
@@ -6243,7 +6235,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
@@ -6255,7 +6246,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jwa": "^2.0.1",
@@ -6361,43 +6351,43 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
             "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-            "dev": true
+            "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
@@ -7623,7 +7613,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
             "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-            "dev": true,
             "engines": {
                 "node": ">=18"
             },
@@ -7657,7 +7646,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8055,16 +8043,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/stoppable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-            "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4",
-                "npm": ">=6"
             }
         },
         "node_modules/stream-combiner": {
@@ -8778,6 +8756,15 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -1591,7 +1591,7 @@
         "@azure/storage-blob": "^12.5.0",
         "@microsoft/vscode-azext-azureappservice": "^4.2.3",
         "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
-        "@microsoft/vscode-azext-azureutils": "^4.0.1",
+        "@microsoft/vscode-azext-azureutils": "^4.1.1",
         "@microsoft/vscode-azext-utils": "^4.0.5",
         "@microsoft/vscode-azureresources-api": "^2.6.2",
         "@microsoft/vscode-container-client": "^0.3.0",


### PR DESCRIPTION
Updates `@microsoft/vscode-azext-azureutils` from `4.0.1` to `4.1.1`.

## Bug fixes included in this upgrade

- **Fallback to default name when resource group is unavailable** ([vscode-azuretools#2219](https://github.com/microsoft/vscode-azuretools/pull/2219)) — The managed identity name step now falls back to a default name when the resource group name is not available, preventing a crash during creation wizards. Fixes [#4905](https://github.com/microsoft/vscode-azurefunctions/issues/4905).

## Other changes

- **In-memory cache for Azure location/provider API calls** ([vscode-azuretools#2239](https://github.com/microsoft/vscode-azuretools/pull/2239)) — Location and provider queries are now deduplicated and cached across wizard instances within a single extension activation, improving performance.

- **Use BearerChallengePolicy from auth package** ([vscode-azuretools#2232](https://github.com/microsoft/vscode-azuretools/pull/2232)) — Consolidated the bearer challenge policy logic into the shared auth package, removing a local duplicate and adding more robust telemetry.

- **Security: bump picomatch** ([vscode-azuretools#2241](https://github.com/microsoft/vscode-azuretools/pull/2241)) — Fixes CVE-2026-33671 and CVE-2026-33672 in the picomatch transitive dependency.