### PR TITLE
Change the aka.ms link for Remote Debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@azure/core-client": "^1.7.3",
                 "@azure/core-rest-pipeline": "^1.11.0",
                 "@azure/storage-blob": "^12.5.0",
-                "@microsoft/vscode-azext-azureappservice": "^4.2.3",
+                "@microsoft/vscode-azext-azureappservice": "^4.2.4",
                 "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^4.0.1",
                 "@microsoft/vscode-azext-utils": "^4.0.5",
@@ -1705,9 +1705,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-azureappservice": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-4.2.3.tgz",
-            "integrity": "sha512-tk8zvfUv58LhoOXjB4CHwaM/KBBG15hO174A2ECMPYJsP5Jk3Rjx1avIQtS0XvbpEHuyTJp08oJqfAO45KWxww==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-azureappservice/-/vscode-azext-azureappservice-4.2.4.tgz",
+            "integrity": "sha512-pfZBKcj3c3GsSAGSnCmyc4bx/9gtbwOok/XgjhDR70f1ACfJrZwhUwNrkUqBjumEa7o/kz1VQ7O/nWr9b4okRQ==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1583,7 +1583,7 @@
         "@azure/core-client": "^1.7.3",
         "@azure/core-rest-pipeline": "^1.11.0",
         "@azure/storage-blob": "^12.5.0",
-        "@microsoft/vscode-azext-azureappservice": "^4.2.3",
+        "@microsoft/vscode-azext-azureappservice": "^4.2.4",
         "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^4.0.1",
         "@microsoft/vscode-azext-utils": "^4.0.5",

--- a/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
+++ b/src/commands/remoteDebugJava/remoteDebugJavaFunctionApp.ts
@@ -42,7 +42,7 @@ export async function remoteDebugJavaFunctionApp(context: IActionContext, node?:
                     const confirmMsg: string = localize('confirmRemoteDebug', 'The configurations of the selected app will be changed before debugging. Would you like to continue?');
                     const result: vscode.MessageItem = await context.ui.showWarningMessage(confirmMsg, { modal: true }, DialogResponses.yes, DialogResponses.learnMore);
                     if (result === DialogResponses.learnMore) {
-                        await openUrl('https://aka.ms/azfunc-remotedebug');
+                        await openUrl('https://aka.ms/azfunctions-remotedebugging');
                         return;
                     } else {
                         await updateSiteConfig(client, p, siteConfig);


### PR DESCRIPTION
Updates the "Learn more" URL used during Azure Functions remote debugging to point to Azure Functions–specific documentation.

## Changes Made

- Updated the aka.ms URL opened from the Java remote debugging confirmation dialog (`remoteDebugJavaFunctionApp`).
- Upgraded `@microsoft/vscode-azext-azureappservice` to v4.2.4, which includes the updated "Learn more" link for the non-Java remote debug path (e.g., Linux Node.js apps).