### PR TITLE
Add a setting that allows users to bypass emulator validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1373,6 +1373,11 @@
                         "description": "%azureFunctions.validateFuncCoreTools%",
                         "default": true
                     },
+                    "azureFunctions.validateEmulators": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.validateEmulators%",
+                        "default": true
+                    },
                     "azureFunctions.requestTimeout": {
                         "type": "number",
                         "description": "%azureFunctions.requestTimeout%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -111,6 +111,7 @@
     "azureFunctions.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
     "azureFunctions.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
     "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
+    "azureFunctions.validateEmulators": "Validate that service emulators and connections are properly configured before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",
     "azureFunctions.viewProperties": "View Properties",

--- a/src/debug/validatePreDebug.ts
+++ b/src/debug/validatePreDebug.ts
@@ -38,6 +38,9 @@ export async function preDebugValidate(actionContext: IActionContext, debugConfi
     let shouldContinue: boolean;
     context.telemetry.properties.debugType = debugConfig.type;
 
+    const validateEmulators: boolean = !!getWorkspaceSetting<boolean>('validateEmulators', workspace.uri.fsPath);
+    context.telemetry.properties.validateEmulators = String(validateEmulators);
+
     try {
         context.telemetry.properties.lastValidateStep = 'funcInstalled';
         const message: string = localize('installFuncTools', 'You must have the Azure Functions Core Tools installed to debug your local functions.');
@@ -62,28 +65,30 @@ export async function preDebugValidate(actionContext: IActionContext, debugConfi
                 context.telemetry.properties.lastValidateStep = 'workerRuntime';
                 await validateWorkerRuntime(context, projectLanguage, context.projectPath);
 
-                switch (durableStorageType) {
-                    case DurableBackend.DTS:
-                        context.telemetry.properties.lastValidateStep = 'dtsConnection';
-                        await validateDTSConnectionPreDebug(context, context.projectPath);
-                        break;
-                    case DurableBackend.Netherite:
-                        context.telemetry.properties.lastValidateStep = 'netheriteConnection';
-                        await validateNetheriteConnectionPreDebug(context, context.projectPath);
-                        break;
-                    case DurableBackend.SQL:
-                        context.telemetry.properties.lastValidateStep = 'sqlDbConnection';
-                        await validateSQLConnectionPreDebug(context, context.projectPath);
-                        break;
-                    case DurableBackend.Storage:
-                    default:
+                if (validateEmulators) {
+                    switch (durableStorageType) {
+                        case DurableBackend.DTS:
+                            context.telemetry.properties.lastValidateStep = 'dtsConnection';
+                            await validateDTSConnectionPreDebug(context, context.projectPath);
+                            break;
+                        case DurableBackend.Netherite:
+                            context.telemetry.properties.lastValidateStep = 'netheriteConnection';
+                            await validateNetheriteConnectionPreDebug(context, context.projectPath);
+                            break;
+                        case DurableBackend.SQL:
+                            context.telemetry.properties.lastValidateStep = 'sqlDbConnection';
+                            await validateSQLConnectionPreDebug(context, context.projectPath);
+                            break;
+                        case DurableBackend.Storage:
+                        default:
+                    }
+
+                    context.telemetry.properties.lastValidateStep = 'azureWebJobsStorage';
+                    await validateAzureWebJobsStorage(context, context.projectPath);
+
+                    context.telemetry.properties.lastValidateStep = 'emulatorRunning';
+                    shouldContinue = await validateEmulatorIsRunning(context, context.projectPath);
                 }
-
-                context.telemetry.properties.lastValidateStep = 'azureWebJobsStorage';
-                await validateAzureWebJobsStorage(context, context.projectPath);
-
-                context.telemetry.properties.lastValidateStep = 'emulatorRunning';
-                shouldContinue = await validateEmulatorIsRunning(context, context.projectPath);
             }
         }
     } catch (error) {


### PR DESCRIPTION
Users may already have their own tasks set up to launch all required emulators. In those cases, our extension can still prompt them to start emulators manually, which is kind of annoying. I'm seeing this with Copilot on Rails local-dev testing, where the task chain eventually starts the emulators, but they aren’t running yet during pre-validation and so the extension's pre-validation check triggers unwanted modals to still appear.