### PR TITLE
Fix DTS resource group default name and auto-refresh after deletion

### DIFF
--- a/src/commands/durableTaskScheduler/createScheduler.ts
+++ b/src/commands/durableTaskScheduler/createScheduler.ts
@@ -28,6 +28,7 @@ class SchedulerNamingStep extends AzureWizardPromptStep<ICreateSchedulerContext>
         wizardContext.schedulerName = await wizardContext.ui.showInputBox({
             prompt: localize('schedulerNamingStepPrompt', 'Enter a name for the new scheduler')
         });
+        wizardContext.relatedNameTask = Promise.resolve(wizardContext.schedulerName);
     }
 
     shouldPrompt(wizardContext: ICreateSchedulerContext): boolean {

--- a/src/commands/durableTaskScheduler/deleteScheduler.ts
+++ b/src/commands/durableTaskScheduler/deleteScheduler.ts
@@ -6,7 +6,7 @@
 import {type IActionContext } from "@microsoft/vscode-azext-utils";
 import { type DurableTaskSchedulerClient } from "../../tree/durableTaskScheduler/DurableTaskSchedulerClient";
 import { localize } from "../../localize";
-import { type MessageItem } from "vscode";
+import { commands, type MessageItem } from "vscode";
 import { type DurableTaskSchedulerResourceModel } from "../../tree/durableTaskScheduler/DurableTaskSchedulerResourceModel";
 import { type DurableTaskSchedulerDataBranchProvider } from "../../tree/durableTaskScheduler/DurableTaskSchedulerDataBranchProvider";
 import { withCancellation } from "../../utils/cancellation";
@@ -55,6 +55,7 @@ export function deleteSchedulerCommandFactory(
         }
         finally {
             dataBranchProvider.refresh();
+            await commands.executeCommand('azureResourceGroups.refresh');
         }
     };
 }

--- a/src/commands/durableTaskScheduler/deleteTaskHub.ts
+++ b/src/commands/durableTaskScheduler/deleteTaskHub.ts
@@ -7,7 +7,7 @@ import {type IActionContext } from "@microsoft/vscode-azext-utils";
 import { type DurableTaskSchedulerClient } from "../../tree/durableTaskScheduler/DurableTaskSchedulerClient";
 import { localize } from "../../localize";
 import { type DurableTaskHubResourceModel } from "../../tree/durableTaskScheduler/DurableTaskHubResourceModel";
-import { type MessageItem } from "vscode";
+import { commands, type MessageItem } from "vscode";
 import { withAzureActivity } from "../../utils/AzureActivity";
 import { withCancellation } from "../../utils/cancellation";
 
@@ -52,6 +52,7 @@ export function deleteTaskHubCommandFactory(schedulerClient: DurableTaskSchedule
         }
         finally {
             taskHub.scheduler.refresh();
+            await commands.executeCommand('azureResourceGroups.refresh');
         }
     };
 }


### PR DESCRIPTION
## Summary

Fixes two Durable Task Scheduler UX issues:

### Resource group name not pre-populated (#4967)

When creating a DTS and selecting "+ Create new resource group", the resource group name input was empty. This sets `relatedNameTask` on the wizard context after the scheduler name is entered, so `ResourceGroupListStep` can use it to pre-populate the default resource group name.

### Deleted items remain visible until manual refresh (#4968)

After deleting a DTS scheduler or task hub, the item remained visible in the Azure Resources view (marked as "(Deleted)") until the user manually clicked Refresh. This adds `azureResourceGroups.refresh` command execution after deletion completes, triggering the Azure Resources extension to re-enumerate resources and remove the deleted item automatically.

## Changes

- **`src/commands/durableTaskScheduler/createScheduler.ts`**: Set `wizardContext.relatedNameTask` in `SchedulerNamingStep.prompt()` so `ResourceGroupListStep` pre-populates the default name
- **`src/commands/durableTaskScheduler/deleteScheduler.ts`**: Call `commands.executeCommand('azureResourceGroups.refresh')` after deletion to auto-remove the scheduler from the tree
- **`src/commands/durableTaskScheduler/deleteTaskHub.ts`**: Call `commands.executeCommand('azureResourceGroups.refresh')` after deletion to auto-remove the task hub from the tree

Fixes #4967, #4968