### PR TITLE
Release prep for 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This release brings DTS consumption plan support, a new Function Host Debugger V
 
 ### Added
 * [[4951](https://github.com/microsoft/vscode-azurefunctions/pull/4951)] Support **DTS consumption plan** and remove preview flag
-* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add **Function Host Debugger View** — captures `func` CLI output in a dedicated section of the Debug panel and lets you ask Copilot for help directly from the view
+* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add **Function Host Debugger View** — captures `func` CLI errors in a dedicated section of the Debug panel and lets you ask Copilot for help directly from the view
 * [[4909](https://github.com/microsoft/vscode-azurefunctions/pull/4909)] Support **domain name label scopes**
 
 ### Changed
@@ -21,9 +21,7 @@ This release brings DTS consumption plan support, a new Function Host Debugger V
 * [[4954](https://github.com/microsoft/vscode-azurefunctions/pull/4954)] Update aka.ms link for Remote Debugging
 
 ### Fixed
-* [[4971](https://github.com/microsoft/vscode-azurefunctions/pull/4971)] Fix **DTS** resource group default name and auto-refresh after deletion
 * [[4963](https://github.com/microsoft/vscode-azurefunctions/pull/4963)] Fix and improve scheduler creation with **consumption SKU**
-* [[4956](https://github.com/microsoft/vscode-azurefunctions/pull/4956)] Fix containerized **.NET** project creation failing with exit code 73
 * [[4929](https://github.com/microsoft/vscode-azurefunctions/pull/4929)] Fix fallback to storage suffix endpoint when not available
 * [[4915](https://github.com/microsoft/vscode-azurefunctions/pull/4915)] Fix not being able to get **.NET** latest templates
 * [[4914](https://github.com/microsoft/vscode-azurefunctions/pull/4914)] Fix no response when executing **Create New Project** command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This release brings DTS consumption plan support, a new Function Host Debugger V
 
 ### Added
 * [[4951](https://github.com/microsoft/vscode-azurefunctions/pull/4951)] Support **DTS consumption plan** and remove preview flag
-* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add **Function Host Debugger View** — captures `func` CLI output (errors and issues) in a dedicated section of the Debug panel and lets you ask Copilot for help directly from the view
+* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add **Function Host Debugger View** — captures `func` CLI output in a dedicated section of the Debug panel and lets you ask Copilot for help directly from the view
 * [[4909](https://github.com/microsoft/vscode-azurefunctions/pull/4909)] Support **domain name label scopes**
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,41 @@
 # Change Log
 
-## 1.21.0 - 2026-04-03
+## 1.21.0 - 2026-04-14
+
+### Overview
+This release brings DTS consumption plan support, a new Function Host Debugger View with Copilot support, domain name label scope support, and includes several bug fixes for scheduler creation, .NET templates, and containerized deployments.
 
 ### Added
-* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add a **Function Host Debug** view in the Run and Debug panel that lists running Function Host tasks, displays recent error output, and send errors to Copilot or provides commands to view logs
-* [[4909](https://github.com/microsoft/vscode-azurefunctions/pull/4909)] Support for domain name label scopes
+* [[4951](https://github.com/microsoft/vscode-azurefunctions/pull/4951)] Support **DTS consumption plan** and remove preview flag
+* [[4883](https://github.com/microsoft/vscode-azurefunctions/pull/4883)] Add **Function Host Debugger View** — captures `func` CLI output (errors and issues) in a dedicated section of the Debug panel and lets you ask Copilot for help directly from the view
+* [[4909](https://github.com/microsoft/vscode-azurefunctions/pull/4909)] Support **domain name label scopes**
 
 ### Changed
+* [[4946](https://github.com/microsoft/vscode-azurefunctions/pull/4946)] Open sample file and `mcp.json` in split editor when creating **Self-Hosted MCP Server** projects
+* [[4902](https://github.com/microsoft/vscode-azurefunctions/pull/4902)] Auto-open `mcp.json` after **Self-Hosted MCP Server** project creation
+* [[4944](https://github.com/microsoft/vscode-azurefunctions/pull/4944)] Remove `proxies.json` JSON schema contribution
 * [[4826](https://github.com/microsoft/vscode-azurefunctions/pull/4826)] Group templates by filter rather than filtering them out
-* [[4892](https://github.com/microsoft/vscode-azurefunctions/pull/4892)] Use StorageV2 for storage account creation
-* [[4902](https://github.com/microsoft/vscode-azurefunctions/pull/4902)] Auto-open `mcp.json` after Self-Hosted MCP Server project creation
+* [[4892](https://github.com/microsoft/vscode-azurefunctions/pull/4892)] Use **StorageV2** for storage account creation
+* [[4901](https://github.com/microsoft/vscode-azurefunctions/pull/4901)] Respect **Java remote debugging** setting precedence when both debug modes are enabled
+* [[4923](https://github.com/microsoft/vscode-azurefunctions/pull/4923)] Improve extension responsiveness in common Azure Functions workflows
+* [[4954](https://github.com/microsoft/vscode-azurefunctions/pull/4954)] Update aka.ms link for Remote Debugging
 
 ### Fixed
+* [[4971](https://github.com/microsoft/vscode-azurefunctions/pull/4971)] Fix **DTS** resource group default name and auto-refresh after deletion
+* [[4963](https://github.com/microsoft/vscode-azurefunctions/pull/4963)] Fix and improve scheduler creation with **consumption SKU**
+* [[4956](https://github.com/microsoft/vscode-azurefunctions/pull/4956)] Fix containerized **.NET** project creation failing with exit code 73
+* [[4929](https://github.com/microsoft/vscode-azurefunctions/pull/4929)] Fix fallback to storage suffix endpoint when not available
+* [[4915](https://github.com/microsoft/vscode-azurefunctions/pull/4915)] Fix not being able to get **.NET** latest templates
+* [[4914](https://github.com/microsoft/vscode-azurefunctions/pull/4914)] Fix no response when executing **Create New Project** command
 * [[4880](https://github.com/microsoft/vscode-azurefunctions/pull/4880)] Fix refresh error on collapsed function app nodes
-* [[4901](https://github.com/microsoft/vscode-azurefunctions/pull/4901)] Respect Java remote debugging setting precedence when both debug modes are enabled
-* [[4914](https://github.com/microsoft/vscode-azurefunctions/pull/4914)] Fix no response when executing "Create New Project" command
-* [[4915](https://github.com/microsoft/vscode-azurefunctions/pull/4915)] Fix not being able to get .NET latest templates
-* [[4923](https://github.com/microsoft/vscode-azurefunctions/pull/4923)] Performance improvements
-* [[4929](https://github.com/microsoft/vscode-azurefunctions/pull/4929)] Don't call for `storageConnectionString` if it's not needed
-* [[4944](https://github.com/microsoft/vscode-azurefunctions/pull/4944)] Remove `proxies.json` from JSON schema contribution
+* [[4770](https://github.com/microsoft/vscode-azurefunctions/pull/4770)] Pin EventGrid sample files URL to specific commit SHA
+
+### Engineering
+* [[4947](https://github.com/microsoft/vscode-azurefunctions/pull/4947)] Replace **JsonCli** tool with direct nupkg parsing and native `dotnet new`
+* [[4894](https://github.com/microsoft/vscode-azurefunctions/pull/4894)] Migrate to **esbuild**
+* [[4906](https://github.com/microsoft/vscode-azurefunctions/pull/4906)] Refactor **cpUtils** to use `vscode-processutils`
+* [[4920](https://github.com/microsoft/vscode-azurefunctions/pull/4920)] Migrate tests to use testApi with esbuild
+* Bump 15 dependencies across build, test, and tooling infrastructure
 
 ## 1.20.3 - 2025-12-16
 

--- a/NOTICE.html
+++ b/NOTICE.html
@@ -3120,6 +3120,44 @@ SOFTWARE.
 <li>
     <details>
         <summary>
+            @nevware21/ts-utils 0.13.0 - MIT
+        </summary>
+        <p><a href="https://github.com/nevware21/ts-utils">https://github.com/nevware21/ts-utils</a></p>
+        <ul><li>Copyright (c) 2022 NevWare21 Solutions LLC</li>
+<li>Copyright (c) 2023 NevWare21 Solutions LLC</li>
+<li>Copyright (c) 2024 NevWare21 Solutions LLC</li>
+<li>Copyright (c) 2025 NevWare21 Solutions LLC</li>
+<li>Copyright (c) 2022-2025 NevWare21 Solutions LLC</li>
+<li>Copyright (c) NevWare21 Solutions LLC and contributors</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) 2022 NevWare21 Solutions LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             @nodelib/fs.scandir 2.1.5 - MIT
         </summary>
         
@@ -3654,27 +3692,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            ansi-regex 3.0.1 - MIT
-        </summary>
-        <p><a href="https://github.com/chalk/ansi-regex#readme">https://github.com/chalk/ansi-regex#readme</a></p>
-        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             ansi-regex 6.2.2 - MIT
         </summary>
         <p><a href="https://github.com/chalk/ansi-regex#readme">https://github.com/chalk/ansi-regex#readme</a></p>
@@ -3717,40 +3734,6 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
 <li>
     <details>
         <summary>
-            array-union 1.0.2 - MIT
-        </summary>
-        <p><a href="https://github.com/sindresorhus/array-union#readme">https://github.com/sindresorhus/array-union#readme</a></p>
-        <ul><li>(c) Sindre Sorhus (https://sindresorhus.com)</li>
-<li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             array-union 2.1.0 - MIT
         </summary>
         <p><a href="https://github.com/sindresorhus/array-union#readme">https://github.com/sindresorhus/array-union#readme</a></p>
@@ -3766,40 +3749,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            array-uniq 1.0.3 - MIT
-        </summary>
-        <p><a href="https://github.com/sindresorhus/array-uniq#readme">https://github.com/sindresorhus/array-uniq#readme</a></p>
-        <ul><li>(c) Sindre Sorhus (https://sindresorhus.com)</li>
-<li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
-        <pre>
-        The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
         </pre>
     </details>
@@ -3843,40 +3792,7 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            brace-expansion 2.0.2 - MIT
-        </summary>
-        <p><a href="https://github.com/juliangruber/brace-expansion">https://github.com/juliangruber/brace-expansion</a></p>
-        <ul><li>Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            brace-expansion 5.0.3 - MIT
+            brace-expansion 5.0.5 - MIT
         </summary>
         <p><a href="https://github.com/juliangruber/brace-expansion#readme">https://github.com/juliangruber/brace-expansion#readme</a></p>
         <ul><li>Copyright Isaac Z. Schlueter &lt;i@izs.me&gt;</li>
@@ -5577,69 +5493,6 @@ THE SOFTWARE.
 <li>
     <details>
         <summary>
-            minimist 1.2.8 - MIT
-        </summary>
-        <p><a href="https://github.com/minimistjs/minimist">https://github.com/minimistjs/minimist</a></p>
-        
-        <pre>
-        This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            mkdirp 0.5.6 - MIT
-        </summary>
-        <p><a href="https://github.com/substack/node-mkdirp#readme">https://github.com/substack/node-mkdirp#readme</a></p>
-        <ul><li>Copyright 2010 James Halliday (mail@substack.net)</li></ul>
-        <pre>
-        Copyright 2010 James Halliday (mail@substack.net)
-
-This project is free software released under the MIT/X11 license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             ms 2.0.0 - MIT
         </summary>
         <p><a href="https://github.com/zeit/ms#readme">https://github.com/zeit/ms#readme</a></p>
@@ -5831,6 +5684,39 @@ SOFTWARE.
 <li>
     <details>
         <summary>
+            path-expression-matcher 1.1.3 - MIT
+        </summary>
+        <p><a href="https://github.com/NaturalIntelligence/path-expression-matcher#readme">https://github.com/NaturalIntelligence/path-expression-matcher#readme</a></p>
+        <ul><li>Copyright (c) 2024</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             path-type 4.0.0 - MIT
         </summary>
         <p><a href="https://github.com/sindresorhus/path-type#readme">https://github.com/sindresorhus/path-type#readme</a></p>
@@ -5942,15 +5828,15 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            pify 2.3.0 - MIT
+            picomatch 2.3.2 - MIT
         </summary>
-        <p><a href="https://github.com/sindresorhus/pify">https://github.com/sindresorhus/pify</a></p>
-        <ul><li>(c) Sindre Sorhus (http://sindresorhus.com)</li>
-<li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
+        <p><a href="https://github.com/micromatch/picomatch">https://github.com/micromatch/picomatch</a></p>
+        <ul><li>Copyright (c) 2017-present, Jon Schlinkert</li>
+<li>Copyright (c) 2017-present, Jon Schlinkert (https://github.com/jonschlinkert)</li></ul>
         <pre>
         The MIT License (MIT)
 
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
+Copyright (c) 2017-present, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -6502,27 +6388,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            strip-ansi 4.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/chalk/strip-ansi#readme">https://github.com/chalk/strip-ansi#readme</a></p>
-        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             strnum 2.2.1 - MIT
         </summary>
         <p><a href="https://github.com/NaturalIntelligence/strnum#readme">https://github.com/NaturalIntelligence/strnum#readme</a></p>
@@ -6893,6 +6758,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
+            wrap-ansi 7.0.0 - MIT
+        </summary>
+        <p><a href="https://github.com/chalk/wrap-ansi#readme">https://github.com/chalk/wrap-ansi#readme</a></p>
+        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)</li></ul>
+        <pre>
+        MIT License
+
+Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         </pre>
     </details>


### PR DESCRIPTION
## Release prep for 1.21.0

> 🤖 This PR was generated by GitHub Copilot. Please review all changes before merging.

### Changes
- Bumped version to `1.21.0` in `package.json`
- Updated `CHANGELOG.md`

Updated via a new skill I'm working on - I'll share it soon.