### PR TITLE
Stop filtering Java version picker by locally installed JDK

### DIFF
--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -45,11 +45,15 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
     }
 
     async getPicks(context: IJavaProjectWizardContext): Promise<IAzureQuickPickItem<string>[]> {
-        const javaVersion: number = await getJavaVersion();
+        const detectedVersion: number | undefined = await getJavaVersion();
         const result: IAzureQuickPickItem<string>[] = [];
         for (const version of versionInfo) {
-            if (await hasMinFuncCliVersion(context, version.miniFunc, context.version) && javaVersion >= Number(version.data)) {
-                result.push(version);
+            if (await hasMinFuncCliVersion(context, version.miniFunc, context.version)) {
+                const pick: IAzureQuickPickItem<string> = { ...version };
+                if (detectedVersion !== undefined && Number(version.data) === detectedVersion) {
+                    pick.description = localize('detected', '(Detected)');
+                }
+                result.push(pick);
             }
         }
         return result;

--- a/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersionStep.ts
@@ -46,12 +46,15 @@ export class JavaVersionStep extends AzureWizardPromptStep<IJavaProjectWizardCon
 
     async getPicks(context: IJavaProjectWizardContext): Promise<IAzureQuickPickItem<string>[]> {
         const detectedVersion: number | undefined = await getJavaVersion();
+        if (!detectedVersion || detectedVersion < 8) {
+            throw new Error(localize('javaVersionRequired', 'JDK 8 or higher is required to create a Java project. Please install a JDK and ensure JAVA_HOME is set or java is available on PATH.'));
+        }
         const result: IAzureQuickPickItem<string>[] = [];
         for (const version of versionInfo) {
             if (await hasMinFuncCliVersion(context, version.miniFunc, context.version)) {
                 const pick: IAzureQuickPickItem<string> = { ...version };
-                if (detectedVersion !== undefined && Number(version.data) === detectedVersion) {
-                    pick.description = localize('detected', '(Detected)');
+                if (Number(version.data) === detectedVersion) {
+                    pick.description = localize('javaVersionDetected', '(Detected)');
                 }
                 result.push(pick);
             }

--- a/src/commands/createNewProject/javaSteps/JavaVersions.ts
+++ b/src/commands/createNewProject/javaSteps/JavaVersions.ts
@@ -5,22 +5,17 @@
 
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
 import { composeArgs, withArg } from '@microsoft/vscode-processutils';
-import { localize } from '../../../localize';
 import { cpUtils } from "../../../utils/cpUtils";
 
 import * as path from 'path';
 
-export async function getJavaVersion(): Promise<number> {
+export async function getJavaVersion(): Promise<number | undefined> {
     const javaHome: string | undefined = process.env['JAVA_HOME'];
     let javaVersion = javaHome ? await checkVersionInReleaseFile(javaHome) : undefined;
     if (!javaVersion) {
         javaVersion = await checkVersionByCLI(javaHome ? path.join(javaHome, 'bin', 'java') : 'java');
     }
-    if (!javaVersion) {
-        const message: string = localize('javaNotFound', 'Failed to get Java version. Please ensure that Java is installed and JAVA_HOME environment variable is set.');
-        throw new Error(message);
-    }
-    return javaVersion;
+    return javaVersion || undefined;
 }
 
 async function checkVersionInReleaseFile(javaHome: string): Promise<number | undefined> {


### PR DESCRIPTION
Fixes #4998

The Java version quick pick was hiding versions higher than the locally detected JDK. Users who manage JDKs outside JAVA_HOME or plan to install a different version could not select their target.

**Changes:**
- Remove the local JDK version filter from getPicks(). All versions supported by the selected Functions runtime are now shown.
- Validate that a JDK >= 8 is detected at the start of getPicks(), before the user fills out the rest of the wizard. This gives a clear, actionable error early rather than a confusing Maven failure after completing all steps.
- getJavaVersion() returns undefined instead of throwing when no JDK is found. Its role is now detection (for labeling and validation), not gatekeeping the version list.
- Add a (Detected) label on the pick matching the locally installed JDK version as a convenience.