### PR TITLE
Hide getMcpHostKey from cmd pal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1048,6 +1048,10 @@
                 {
                     "command": "azureFunctions.funcHostDebug.askCopilot",
                     "when": "never"
+                },
+                {
+                    "command": "azureFunctions.getMcpHostKey",
+                    "when": "never"
                 }
             ],
             "editor/context": [


### PR DESCRIPTION
Fixes #4872 

This command should only be called the mcp.json, never from the cmd palette. It has a way to get the resource id when invoked in this way.