### PR TITLE
Add Go language support: project creation and local run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1158,6 +1158,11 @@
                 "name": "func-python-watch",
                 "label": "%azureFunctions.problemMatchers.funcPythonWatch%",
                 "base": "$func-watch"
+            },
+            {
+                "name": "func-golang-watch",
+                "label": "%azureFunctions.problemMatchers.funcGolangWatch%",
+                "base": "$func-watch"
             }
         ],
         "configuration": [
@@ -1226,6 +1231,7 @@
                             "PowerShell",
                             "Python",
                             "TypeScript",
+                            "Go",
                             "Custom"
                         ],
                         "description": "%azureFunctions.projectLanguage%",
@@ -1239,6 +1245,7 @@
                             "",
                             "",
                             "",
+                            "%azureFunctions.projectLanguage.preview%",
                             "",
                             ""
                         ]

--- a/package.nls.json
+++ b/package.nls.json
@@ -60,6 +60,7 @@
     "azureFunctions.problemMatchers.funcNodeWatch": "Azure Functions Node.js problems (watch mode)",
     "azureFunctions.problemMatchers.funcPowerShellWatch": "Azure Functions PowerShell problems (watch mode)",
     "azureFunctions.problemMatchers.funcPythonWatch": "Azure Functions Python problems (watch mode)",
+    "azureFunctions.problemMatchers.funcGolangWatch": "Azure Functions Go problems (watch mode)",
     "azureFunctions.problemMatchers.funcWatch": "Azure Functions problems (watch mode)",
     "azureFunctions.projectLanguage": "The default language to use when performing operations like \"Create New Function\".",
     "azureFunctions.projectLanguage.preview": "(Preview)",

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -115,7 +115,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     public shouldPrompt(context: IFunctionWizardContext): boolean {
         return !context.functionTemplate &&
             context['buildTool'] !== JavaBuildTool.maven &&
-            context.language !== ProjectLanguage.SelfHostedMCPServer;
+            context.language !== ProjectLanguage.SelfHostedMCPServer &&
+            context.language !== ProjectLanguage.Go;
     }
 
     private async getPicks(context: IFunctionWizardContext): Promise<IAzureQuickPickItem<FunctionTemplateBase | TemplatePromptResult>[]> {

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, type IActionContext } from '@microsoft/vscode-azext-utils';
-import * as vscode from 'vscode';
+import { type WorkspaceFolder } from 'vscode';
 import { type FuncVersion } from '../../FuncVersion';
 import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
@@ -50,7 +50,7 @@ export async function createFunctionFromCommand(
 }
 
 export async function createFunctionInternal(context: IActionContext, options: api.ICreateFunctionOptions): Promise<void> {
-    let workspaceFolder: vscode.WorkspaceFolder | undefined;
+    let workspaceFolder: WorkspaceFolder | undefined;
     let workspacePath: string | undefined = options.folderPath;
 
     if (workspacePath === undefined) {
@@ -77,11 +77,11 @@ export async function createFunctionInternal(context: IActionContext, options: a
         // Core tools does not yet support `func new --language Go`, so additional functions must be added by editing
         // the source files directly. Show a modal so the user can't miss it.
         context.telemetry.properties.goCreateFunctionUnsupported = 'true';
-        await vscode.window.showWarningMessage(
-            localize('goCreateFunctionUnsupportedTitle', 'Adding functions to a Go project is not yet supported.'),
+        await context.ui.showWarningMessage(
+            localize('goCreateFunctionUnsupported', 'Adding new functions is currently not supported for Go projects'),
             {
                 modal: true,
-                detail: localize('goCreateFunctionUnsupportedDetail', 'To add another function, edit the source files directly.'),
+                detail: localize('goCreateFunctionUnsupportedDetail', 'To add another function, edit the Go source files directly.'),
             },
         );
         return;

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzureWizard, type IActionContext } from '@microsoft/vscode-azext-utils';
-import { type WorkspaceFolder } from 'vscode';
+import * as vscode from 'vscode';
 import { type FuncVersion } from '../../FuncVersion';
-import { projectTemplateKeySetting, type ProjectLanguage } from '../../constants';
+import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
 import { type LocalProjectTreeItem } from '../../tree/localProject/LocalProjectTreeItem';
@@ -50,7 +50,7 @@ export async function createFunctionFromCommand(
 }
 
 export async function createFunctionInternal(context: IActionContext, options: api.ICreateFunctionOptions): Promise<void> {
-    let workspaceFolder: WorkspaceFolder | undefined;
+    let workspaceFolder: vscode.WorkspaceFolder | undefined;
     let workspacePath: string | undefined = options.folderPath;
 
     if (workspacePath === undefined) {
@@ -71,6 +71,22 @@ export async function createFunctionInternal(context: IActionContext, options: a
     }
 
     const { language, languageModel, version, templateSchemaVersion } = await verifyInitForVSCode(context, projectPath, options.language, options.languageModel, options.version);
+
+    if (language === ProjectLanguage.Go) {
+        // Go projects scaffold an initial function during "Create New Project" via `func init --worker-runtime go`.
+        // Core tools does not yet support `func new --language Go`, so additional functions must be added by editing
+        // the source files directly. Show a modal so the user can't miss it.
+        context.telemetry.properties.goCreateFunctionUnsupported = 'true';
+        await vscode.window.showWarningMessage(
+            localize('goCreateFunctionUnsupportedTitle', 'Adding functions to a Go project is not yet supported.'),
+            {
+                modal: true,
+                detail: localize('goCreateFunctionUnsupportedDetail', 'To add another function, edit the source files directly.'),
+            },
+        );
+        return;
+    }
+
     const durableStorageType = await durableUtils.getStorageTypeFromWorkspace(language, projectPath);
     context.telemetry.properties.hasDurableStorageProject = String(!!durableStorageType);
     context.telemetry.properties.durableStorageType = durableStorageType;

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -16,6 +16,7 @@ import { type IProjectWizardContext } from './IProjectWizardContext';
 import { ProgrammingModelStep } from './ProgrammingModelStep';
 import { CustomProjectCreateStep } from './ProjectCreateStep/CustomProjectCreateStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
+import { GoProjectCreateStep } from './ProjectCreateStep/GoProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
 import { PowerShellProjectCreateStep } from './ProjectCreateStep/PowerShellProjectCreateStep';
 import { PythonProjectCreateStep } from './ProjectCreateStep/PythonProjectCreateStep';
@@ -49,6 +50,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.TypeScript, data: { language: ProjectLanguage.TypeScript } },
             { label: ProjectLanguage.CSharp, data: { language: ProjectLanguage.CSharp } },
             { label: ProjectLanguage.Python, data: { language: ProjectLanguage.Python } },
+            { label: ProjectLanguage.Go, data: { language: ProjectLanguage.Go } },
             { label: ProjectLanguage.Java, data: { language: ProjectLanguage.Java } },
             { label: ProjectLanguage.PowerShell, data: { language: ProjectLanguage.PowerShell } },
             { label: localize('customHandler', 'Custom Handler'), data: { language: ProjectLanguage.Custom } },
@@ -116,6 +118,9 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 break;
             case ProjectLanguage.PowerShell:
                 executeSteps.push(new PowerShellProjectCreateStep());
+                break;
+            case ProjectLanguage.Go:
+                executeSteps.push(new GoProjectCreateStep());
                 break;
             case ProjectLanguage.Java:
                 await addJavaCreateProjectSteps(context, promptSteps, executeSteps);

--- a/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { composeArgs, withArg } from '@microsoft/vscode-processutils';
-import { workspace, type Progress } from 'vscode';
+import { type Progress } from 'vscode';
 import { ext } from '../../../extensionVariables';
 import { getFuncCliPath } from '../../../funcCoreTools/getFuncCliPath';
 import { localize } from '../../../localize';
@@ -16,11 +16,7 @@ export class GoProjectCreateStep extends ProjectCreateStepBase {
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         progress.report({ message: localize('initializingGoProject', 'Initializing Go Functions project...') });
 
-        // Prefer the currently-open workspace's azureFunctions.funcCliPath override.
-        // context.workspacePath is the freshly-picked new-project folder, which isn't part of any open
-        // workspace yet, so passing it to getFuncCliPath only resolves global/user settings.
-        const funcCliPathScope = context.workspaceFolder ?? workspace.workspaceFolders?.[0];
-        const funcCliPath = await getFuncCliPath(context, funcCliPathScope);
+        const funcCliPath = await getFuncCliPath(context, context.workspaceFolder);
         // Core tools accepts "go" as the worker-runtime CLI argument and maps it to the "native" worker runtime internally.
         const args = composeArgs(
             withArg('init'),

--- a/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import { workspace, type Progress } from 'vscode';
+import { ext } from '../../../extensionVariables';
+import { getFuncCliPath } from '../../../funcCoreTools/getFuncCliPath';
+import { localize } from '../../../localize';
+import { cpUtils } from '../../../utils/cpUtils';
+import { type IProjectWizardContext } from '../IProjectWizardContext';
+import { ProjectCreateStepBase } from './ProjectCreateStepBase';
+
+export class GoProjectCreateStep extends ProjectCreateStepBase {
+    public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        progress.report({ message: localize('initializingGoProject', 'Initializing Go Functions project...') });
+
+        // Prefer the currently-open workspace's azureFunctions.funcCliPath override.
+        // context.workspacePath is the freshly-picked new-project folder, which isn't part of any open
+        // workspace yet, so passing it to getFuncCliPath only resolves global/user settings.
+        const funcCliPathScope = context.workspaceFolder ?? workspace.workspaceFolders?.[0];
+        const funcCliPath = await getFuncCliPath(context, funcCliPathScope);
+        // Core tools accepts "go" as the worker-runtime CLI argument and maps it to the "native" worker runtime internally.
+        const args = composeArgs(
+            withArg('init'),
+            withArg('--worker-runtime', 'go'),
+            withArg('--no-source-control'),
+        )();
+
+        await cpUtils.executeCommand(ext.outputChannel, context.projectPath, funcCliPath, args);
+    }
+}

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -12,6 +12,7 @@ import { type IProjectWizardContext } from '../createNewProject/IProjectWizardCo
 import { BallerinaInitVSCodeStep } from './InitVSCodeStep/BallerinaInitVSCodeStep';
 import { DotnetInitVSCodeStep } from './InitVSCodeStep/DotnetInitVSCodeStep';
 import { DotnetScriptInitVSCodeStep } from './InitVSCodeStep/DotnetScriptInitVSCodeStep';
+import { GoInitVSCodeStep } from './InitVSCodeStep/GoInitVSCodeStep';
 import { JavaScriptInitVSCodeStep } from './InitVSCodeStep/JavaScriptInitVSCodeStep';
 import { MCPServerInitVSCodeStep } from './InitVSCodeStep/MCPServerInitVSCodeStep';
 import { PowerShellInitVSCodeStep } from './InitVSCodeStep/PowerShellInitVSCodeStep';
@@ -31,6 +32,7 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.CSharpScript, data: { language: ProjectLanguage.CSharpScript } },
             { label: ProjectLanguage.FSharp, data: { language: ProjectLanguage.FSharp } },
             { label: ProjectLanguage.FSharpScript, data: { language: ProjectLanguage.FSharpScript } },
+            { label: ProjectLanguage.Go, data: { language: ProjectLanguage.Go } },
             { label: ProjectLanguage.Java, data: { language: ProjectLanguage.Java } },
             { label: ProjectLanguage.JavaScript, data: { language: ProjectLanguage.JavaScript } },
             { label: ProjectLanguage.PowerShell, data: { language: ProjectLanguage.PowerShell } },
@@ -89,6 +91,9 @@ export async function addInitVSCodeSteps(
             break;
         case ProjectLanguage.Ballerina:
             executeSteps.push(new BallerinaInitVSCodeStep());
+            break;
+        case ProjectLanguage.Go:
+            executeSteps.push(new GoInitVSCodeStep());
             break;
         case ProjectLanguage.SelfHostedMCPServer:
             executeSteps.push(new MCPServerInitVSCodeStep());

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type DebugConfiguration, type TaskDefinition } from 'vscode';
+import { func, hostStartCommand, hostStartTaskName, type ProjectLanguage } from '../../../constants';
+import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
+import { type IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
+import { InitVSCodeStepBase } from './InitVSCodeStepBase';
+
+// Default Delve DAP port used by GoDebugProvider. Inlined here so PR 1 is self-contained;
+// PR 2 will introduce GoDebugProvider and may re-export this config.
+export const goDebugConfig: DebugConfiguration = {
+    name: 'Attach to Go Functions',
+    type: 'go',
+    request: 'attach',
+    mode: 'remote',
+    port: 2345,
+    host: '127.0.0.1',
+    preLaunchTask: hostStartTaskName,
+};
+
+export class GoInitVSCodeStep extends InitVSCodeStepBase {
+    stepName: string = 'GoInitVSCodeStep';
+
+    protected async executeCore(context: IProjectWizardContext): Promise<void> {
+        this.setDeploySubpath(context, '.');
+    }
+
+    protected getTasks(language: ProjectLanguage): TaskDefinition[] {
+        return [
+            {
+                type: func,
+                label: hostStartTaskName,
+                command: hostStartCommand,
+                problemMatcher: getFuncWatchProblemMatcher(language),
+                isBackground: true,
+            },
+        ];
+    }
+
+    protected getDebugConfiguration(): DebugConfiguration {
+        return goDebugConfig;
+    }
+
+    protected getRecommendedExtensions(): string[] {
+        return ['golang.go'];
+    }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export enum ProjectLanguage {
     JavaScript = 'JavaScript',
     PowerShell = 'PowerShell',
     Python = 'Python',
+    Go = 'Go',
     TypeScript = 'TypeScript',
     Ballerina = 'Ballerina',
     Custom = 'Custom',

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -90,6 +90,9 @@ export function getRootFunctionsWorkerRuntime(language: string | undefined): str
         case ProjectLanguage.PowerShell:
             return 'powershell';
         case ProjectLanguage.Go:
+            // Go compiles to a standalone binary, so the Functions host launches the binary directly.
+            // The host and core tools expect FUNCTIONS_WORKER_RUNTIME to be 'native' for Go apps
+            // (this is the value `func init --worker-runtime go` writes to local.settings.json).
             return 'native';
         case ProjectLanguage.Custom:
             return 'custom';
@@ -119,6 +122,7 @@ export async function tryGetFunctionsWorkerRuntimeForProject(context: IActionCon
 }
 
 export function isKnownWorkerRuntime(runtime: string | undefined): boolean {
+    // 'native' is the worker runtime used for Go (see getRootFunctionsWorkerRuntime).
     return !!runtime && ['node', 'dotnet', 'dotnet-isolated', 'java', 'python', 'powershell', 'native', 'custom'].includes(runtime.toLowerCase());
 }
 

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -89,6 +89,8 @@ export function getRootFunctionsWorkerRuntime(language: string | undefined): str
             return 'python';
         case ProjectLanguage.PowerShell:
             return 'powershell';
+        case ProjectLanguage.Go:
+            return 'native';
         case ProjectLanguage.Custom:
             return 'custom';
         default:
@@ -117,7 +119,7 @@ export async function tryGetFunctionsWorkerRuntimeForProject(context: IActionCon
 }
 
 export function isKnownWorkerRuntime(runtime: string | undefined): boolean {
-    return !!runtime && ['node', 'dotnet', 'dotnet-isolated', 'java', 'python', 'powershell', 'custom'].includes(runtime.toLowerCase());
+    return !!runtime && ['node', 'dotnet', 'dotnet-isolated', 'java', 'python', 'powershell', 'native', 'custom'].includes(runtime.toLowerCase());
 }
 
 export function promptToUpdateDotnetRuntime(azureRuntime: string | undefined, localRuntime: string | undefined): boolean {
@@ -126,6 +128,10 @@ export function promptToUpdateDotnetRuntime(azureRuntime: string | undefined, lo
 }
 
 export function getFuncWatchProblemMatcher(language: string | undefined): string {
+    // Go uses the user-friendly "$func-golang-watch" matcher name even though its worker runtime is "native".
+    if (language === ProjectLanguage.Go) {
+        return '$func-golang-watch';
+    }
     const runtime: string | undefined = getRootFunctionsWorkerRuntime(language);
     return runtime && runtime !== 'custom' ? `$func-${runtime}-watch` : '$func-watch';
 }

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ProjectLanguage } from '../src/constants';
+import { getFuncWatchProblemMatcher, getRootFunctionsWorkerRuntime, isKnownWorkerRuntime } from '../src/vsCodeConfig/settings';
+
+suite('vsCodeConfig/settings — Go support', () => {
+    test('getRootFunctionsWorkerRuntime: Go maps to native (not golang)', () => {
+        assert.strictEqual(getRootFunctionsWorkerRuntime(ProjectLanguage.Go), 'native');
+    });
+
+    test('isKnownWorkerRuntime: accepts native', () => {
+        assert.strictEqual(isKnownWorkerRuntime('native'), true);
+    });
+
+    test('getFuncWatchProblemMatcher: Go uses $func-golang-watch (user-friendly name, despite native worker runtime)', () => {
+        assert.strictEqual(getFuncWatchProblemMatcher(ProjectLanguage.Go), '$func-golang-watch');
+    });
+});


### PR DESCRIPTION
First of three PRs adding Go support to the Azure Functions extension. After this PR, users can create a Go Functions project and run it locally with F5 / Ctrl+F5. Debug and deploy follow in subsequent PRs.

Highlights:
- Add `Go` to ProjectLanguage enum, Create New Project picker (after Python), Initialize Project for VS Code picker, and the package.json projectLanguage enum (marked Preview).
- Map Go to the `native` worker runtime (what core tools and Azure expect for FUNCTIONS_WORKER_RUNTIME). Add `native` to isKnownWorkerRuntime() so deploy verification doesn't reject Go apps.
- Register `$func-golang-watch` problem matcher and use it for Go's tasks.json. Matcher keeps the user-friendly `golang` name even though the underlying runtime value is `native`.
- New GoProjectCreateStep: thin wrapper around `func init --worker-runtime go --no-source-control`. Honors workspace funcCliPath setting via context.workspaceFolder fallback chain.
- New GoInitVSCodeStep: generates .vscode/{tasks,launch,settings, extensions}.json. Launch config is a Delve remote attach on port 2345 (the dlv lifecycle itself lands in a follow-up PR). Recommends the golang.go extension.
- Skip template selection for Go in FunctionListStep (mirrors SelfHostedMCPServer) -- `func init` already scaffolds an initial function.
- Show a modal warning when Create Function is invoked on a Go project -- `func new --language Go` isn't supported by core tools yet.
- Unit tests for the three Go-specific assertions in settings.ts (getRootFunctionsWorkerRuntime, isKnownWorkerRuntime, getFuncWatchProblemMatcher).