### PR TITLE
Add Go language support: debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1384,6 +1384,11 @@
                         "description": "%azureFunctions.validateFuncCoreTools%",
                         "default": true
                     },
+                    "azureFunctions.validateDelve": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.validateDelve%",
+                        "default": true
+                    },
                     "azureFunctions.validateEmulators": {
                         "type": "boolean",
                         "description": "%azureFunctions.validateEmulators%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,6 +112,7 @@
     "azureFunctions.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
     "azureFunctions.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
     "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
+    "azureFunctions.validateDelve": "Validate that Delve (dlv) is installed before debugging Go Functions.",
     "azureFunctions.validateEmulators": "Validate that service emulators and connections are properly configured before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
@@ -5,21 +5,10 @@
 
 import { type DebugConfiguration, type TaskDefinition } from 'vscode';
 import { func, hostStartCommand, hostStartTaskName, type ProjectLanguage } from '../../../constants';
+import { goDebugConfig } from '../../../debug/GoDebugProvider';
 import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
 import { type IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
 import { InitVSCodeStepBase } from './InitVSCodeStepBase';
-
-// Default Delve DAP port used by GoDebugProvider. Inlined here so PR 1 is self-contained;
-// PR 2 will introduce GoDebugProvider and may re-export this config.
-export const goDebugConfig: DebugConfiguration = {
-    name: 'Attach to Go Functions',
-    type: 'go',
-    request: 'attach',
-    mode: 'remote',
-    port: 2345,
-    host: '127.0.0.1',
-    preLaunchTask: hostStartTaskName,
-};
 
 export class GoInitVSCodeStep extends InitVSCodeStepBase {
     stepName: string = 'GoInitVSCodeStep';

--- a/src/debug/GoDebugProvider.ts
+++ b/src/debug/GoDebugProvider.ts
@@ -207,6 +207,11 @@ async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefine
             dlvProcess.on('error', (err) => {
                 ext.outputChannel.appendLog(localize('dlvSpawnFailed', 'Failed to spawn Delve: {0}', err.message));
             });
+            dlvProcess.on('exit', () => {
+                // remove dead entries from the tracking map so killTrackedDlv
+                // doesn't log spurious "Cleaned up" lines later.
+                activeDlvProcesses.delete(folder.uri.fsPath);
+            });
             dlvProcess.stdout?.on('data', (chunk: Buffer) => {
                 ext.outputChannel.append(`[dlv] ${chunk.toString()}`);
             });
@@ -226,6 +231,9 @@ async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefine
             context.telemetry.properties.dlvAttachResult = 'attached';
             ext.outputChannel.appendLog(localize('dlvAttached', 'Delve attached to Go worker (PID {0}) and listening on port {1}.', pid, port));
         } catch (err) {
+            // Clean up any dlv we already spawned before failing - killTrackedDlv is idempotent.
+            killTrackedDlv(folder.uri.fsPath);
+
             if (isUserCancelledError(err)) {
                 // callWithTelemetryAndErrorHandling marks the event as cancelled and stays silent.
                 throw err;

--- a/src/debug/GoDebugProvider.ts
+++ b/src/debug/GoDebugProvider.ts
@@ -4,14 +4,18 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import { createConnection } from 'net';
+import psTree, { type PS } from 'ps-tree';
+import * as vscode from 'vscode';
 import { type CancellationToken, type DebugConfiguration, type WorkspaceFolder } from 'vscode';
-import { hostStartTaskName, localhost } from '../constants';
+import { hostStartTaskName, hostStartTaskNameRegExp, localhost } from '../constants';
 import { ext } from '../extensionVariables';
+import { runningFuncTaskMap, type IRunningFuncTask } from '../funcCoreTools/funcHostTask';
 import { localize } from '../localize';
 import { cpUtils } from '../utils/cpUtils';
 import { delay } from '../utils/delay';
+import { getWindowsProcessTree, ProcessDataFlag, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
 import { FuncDebugProviderBase } from './FuncDebugProviderBase';
 import { validateDelveInstalled } from './validateDelveInstalled';
 
@@ -43,6 +47,50 @@ const dlvListenRetryIntervalMs: number = 500;
 // Brief pause to let a freed port settle after killing a stale dlv.
 const stalePortFreedDelayMs: number = 1_000;
 
+// Tracks the dlv child process we spawned per workspace folder so we can
+// terminate it proactively when the matching debug session ends. Keyed by
+// `WorkspaceFolder.uri.fsPath`. If a second debug session targets the same
+// folder before the first ends, the previous entry is killed and replaced.
+const activeDlvProcesses = new Map<string, ChildProcess>();
+
+/**
+ * Wires the dlv-cleanup-on-session-end behavior. Call once during extension
+ * activation; the returned disposable should be added to context.subscriptions.
+ */
+export function registerGoDebugSessionCleanup(): vscode.Disposable {
+    return vscode.debug.onDidTerminateDebugSession((session) => {
+        if (session.type !== 'go' || !session.workspaceFolder) {
+            return;
+        }
+        killTrackedDlv(session.workspaceFolder.uri.fsPath);
+    });
+}
+
+function killTrackedDlv(folderFsPath: string): void {
+    const dlv = activeDlvProcesses.get(folderFsPath);
+    if (!dlv) {
+        return;
+    }
+    activeDlvProcesses.delete(folderFsPath);
+    if (dlv.pid === undefined) {
+        return;
+    }
+    try {
+        if (process.platform === 'win32') {
+            // Windows has no process groups — just terminate dlv directly.
+            dlv.kill();
+        } else {
+            // dlv was spawned with `detached: true`, which makes it the leader of a
+            // new process group. Signal the whole group (negative pid) so any
+            // descendants dlv may have spawned are cleaned up too.
+            process.kill(-dlv.pid, 'SIGTERM');
+        }
+        ext.outputChannel.appendLog(localize('dlvCleanedUp', 'Cleaned up Delve process (PID {0}) for "{1}".', dlv.pid, folderFsPath));
+    } catch {
+        // Process already gone — fine.
+    }
+}
+
 export class GoDebugProvider extends FuncDebugProviderBase {
     // Delve attaches to the worker process out-of-band. These satisfy the
     // abstract members on FuncDebugProviderBase but are never read because
@@ -55,9 +103,18 @@ export class GoDebugProvider extends FuncDebugProviderBase {
         return '';
     }
 
+    // resolveDebugConfiguration is a hook VS Code calls every time a debug session is about to start
+    // GoDebugProvider overrides FuncDebugProviderBase.resolveDebugConfiguration
     public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration | undefined> {
         const result = await super.resolveDebugConfiguration(folder, debugConfiguration, token);
         if (!result || result.mode !== 'remote') {
+            return result;
+        }
+
+        // Mirror the gate in FuncDebugProviderBase: only run our Functions-specific
+        // dlv-attach lifecycle when the debug session is actually for a Functions
+        // project (signalled by the `func: host start` preLaunchTask).
+        if (!hostStartTaskNameRegExp.test(debugConfiguration.preLaunchTask as string)) {
             return result;
         }
 
@@ -77,21 +134,31 @@ export class GoDebugProvider extends FuncDebugProviderBase {
         // launches the Go worker concurrently with this. The poller watches
         // for that worker, then spawns `dlv attach` so VS Code's Go extension
         // can connect to dlv's DAP server on `port`.
-        void pollAndAttachDlv(port);
+        void pollAndAttachDlv(port, folder, token);
 
         return result;
     }
 }
 
-async function pollAndAttachDlv(port: number): Promise<void> {
+async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefined, token: CancellationToken | undefined): Promise<void> {
     await callWithTelemetryAndErrorHandling('azureFunctions.go.attachDlv', async (context: IActionContext) => {
         context.errorHandling.suppressDisplay = true;
         context.telemetry.properties.dlvPort = String(port);
 
         try {
+            // 1. Free the port if a prior session's dlv is still listening on it.
             await killStaleDlv(port);
+            if (token?.isCancellationRequested) {
+                context.telemetry.properties.dlvAttachResult = 'cancelled';
+                return;
+            }
 
-            const pid = await pollForGoWorkerPid(workerPollTimeoutMs);
+            // 2. Wait for `func host start` to build and launch the Go worker, then capture its PID.
+            const pid = await pollForGoWorkerPid(workerPollTimeoutMs, folder, token);
+            if (token?.isCancellationRequested) {
+                context.telemetry.properties.dlvAttachResult = 'cancelled';
+                return;
+            }
             if (pid === undefined) {
                 context.telemetry.properties.dlvAttachResult = 'workerNotFound';
                 ext.outputChannel.appendLog(localize('dlvWorkerNotFound', 'Could not find Go worker process "{0}" within {1}s. Skipping dlv auto-attach.', goWorkerProcessName, workerPollTimeoutMs / 1_000));
@@ -99,13 +166,17 @@ async function pollAndAttachDlv(port: number): Promise<void> {
             }
             context.telemetry.measurements.dlvWorkerPid = pid;
 
-            // Another dlv may have started in the meantime (very fast restart).
+            // 3. Bail if dlv is already listening on the port. The window between killStaleDlv
+            // (step 1) and our spawn is long, so a parallel poller (rapid restart, second window)
+            // may have already attached. Let VS Code connect to whatever's there rather than
+            // spawning a duplicate that would fail with EADDRINUSE.
             if (await isPortInUse(port)) {
                 context.telemetry.properties.dlvAttachResult = 'portTaken';
                 ext.outputChannel.appendLog(localize('dlvPortTaken', 'Port {0} is already in use; assuming dlv is already attached.', port));
                 return;
             }
 
+            // 4. Spawn dlv, attaching to the worker PID. Detached so it outlives this poller.
             const dlvProcess = spawn('dlv', [
                 'attach', String(pid),
                 '--headless',
@@ -117,11 +188,36 @@ async function pollAndAttachDlv(port: number): Promise<void> {
                 '--accept-multiclient',
             ], {
                 detached: true,
-                stdio: 'ignore',
+                // Pipe stdio so we can surface dlv errors. Without this the spawn
+                // is a black box on failure.
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+
+            // 5. Surface spawn errors and dlv's own output to the Azure Functions output channel.
+            dlvProcess.on('error', (err) => {
+                ext.outputChannel.appendLog(localize('dlvSpawnFailed', 'Failed to spawn Delve: {0}', err.message));
+            });
+            dlvProcess.stdout?.on('data', (chunk: Buffer) => {
+                ext.outputChannel.append(`[dlv] ${chunk.toString()}`);
+            });
+            dlvProcess.stderr?.on('data', (chunk: Buffer) => {
+                ext.outputChannel.append(`[dlv] ${chunk.toString()}`);
             });
             dlvProcess.unref();
 
-            await waitForPort(port, dlvListenTimeoutMs);
+            // 6. Track this dlv for proactive cleanup on session end. If a previous dlv was
+            // tracked for this folder (rapid restart), kill it first so it doesn't become orphaned.
+            if (folder) {
+                killTrackedDlv(folder.uri.fsPath);
+                activeDlvProcesses.set(folder.uri.fsPath, dlvProcess);
+            }
+
+            // 7. Block until dlv is actually listening, so VS Code's Go extension has a port to connect to.
+            await waitForPort(port, dlvListenTimeoutMs, token);
+            if (token?.isCancellationRequested) {
+                context.telemetry.properties.dlvAttachResult = 'cancelled';
+                return;
+            }
             context.telemetry.properties.dlvAttachResult = 'attached';
             ext.outputChannel.appendLog(localize('dlvAttached', 'Delve attached to Go worker (PID {0}) and listening on port {1}.', pid, port));
         } catch (err) {
@@ -173,10 +269,13 @@ async function killStaleDlv(port: number): Promise<void> {
     await delay(stalePortFreedDelayMs);
 }
 
-async function pollForGoWorkerPid(timeoutMs: number): Promise<number | undefined> {
+async function pollForGoWorkerPid(timeoutMs: number, folder: WorkspaceFolder | undefined, token: CancellationToken | undefined): Promise<number | undefined> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        const pid = await findGoWorkerPid();
+        if (token?.isCancellationRequested) {
+            return undefined;
+        }
+        const pid = await findGoWorkerPid(folder);
         if (pid !== undefined) {
             return pid;
         }
@@ -185,23 +284,58 @@ async function pollForGoWorkerPid(timeoutMs: number): Promise<number | undefined
     return undefined;
 }
 
-async function findGoWorkerPid(): Promise<number | undefined> {
-    if (process.platform === 'win32') {
-        const imageName = `${goWorkerProcessName}.exe`;
-        const result = await cpUtils.tryExecuteCommandLine(undefined, undefined, `tasklist /FI "IMAGENAME eq ${imageName}" /FO CSV /NH`);
-        if (result.code !== 0) {
-            return undefined;
-        }
-        const match = result.cmdOutput.match(new RegExp(`"${imageName.replace('.', '\\.')}","(\\d+)"`));
-        return match ? parseInt(match[1], 10) : undefined;
-    }
-
-    const result = await cpUtils.tryExecuteCommandLine(undefined, undefined, `pgrep -x ${goWorkerProcessName}`);
-    if (result.code !== 0) {
+/**
+ * Resolves the PID of *this* debug session's Go worker by walking the children
+ * of the func host process tracked in `runningFuncTaskMap`. Scoping by parent
+ * avoids attaching to an unrelated `app.exe` that happens to be running on the
+ * machine, and naturally distinguishes between concurrent Functions debug
+ * sessions in different VS Code windows (each window has its own func host).
+ */
+async function findGoWorkerPid(folder: WorkspaceFolder | undefined): Promise<number | undefined> {
+    if (!folder) {
         return undefined;
     }
-    const pid = parseInt(result.cmdOutput.trim().split('\n')[0], 10);
-    return Number.isNaN(pid) ? undefined : pid;
+    // Use getAll instead of get(folder) because get() filters by cwd, which we
+    // don't have at debug-resolve time. getAll returns every task tracked for
+    // this folder; for our use case there's at most one func host per folder.
+    const hostTask = runningFuncTaskMap.getAll(folder).find((t): t is IRunningFuncTask => t !== undefined);
+    if (hostTask === undefined) {
+        return undefined;
+    }
+    const children = await listDescendantProcesses(hostTask.processId);
+    const goWorker = children.find(c => isGoWorkerProcess(c.name));
+    return goWorker?.pid;
+}
+
+interface DescendantProcess {
+    pid: number;
+    name: string | undefined;
+}
+
+async function listDescendantProcesses(rootPid: number): Promise<DescendantProcess[]> {
+    if (process.platform === 'win32') {
+        const tree: IWindowsProcessTree = getWindowsProcessTree();
+        const procs: IProcessInfo[] | undefined = await new Promise((resolve) => {
+            tree.getProcessList(rootPid, resolve, ProcessDataFlag.None);
+        });
+        return (procs ?? []).map(p => ({ pid: p.pid, name: p.name }));
+    }
+
+    // ps-tree typings omit COMM but it's the actual field on some platforms.
+    // See pickFuncProcess.ts for the same workaround.
+    type ActualUnixPS = PS & { COMM?: string };
+    const procs: ActualUnixPS[] = await new Promise((resolve, reject) => {
+        psTree(rootPid, (err: Error | null, result: PS[]) => err ? reject(err) : resolve(result as ActualUnixPS[]));
+    });
+    return procs.map(p => ({ pid: parseInt(p.PID, 10), name: p.COMMAND ?? p.COMM }));
+}
+
+function isGoWorkerProcess(name: string | undefined): boolean {
+    if (!name) {
+        return false;
+    }
+    const lower = name.toLowerCase();
+    return lower === goWorkerProcessName || lower === `${goWorkerProcessName}.exe`;
 }
 
 async function isPortInUse(port: number): Promise<boolean> {
@@ -218,9 +352,12 @@ async function isPortInUse(port: number): Promise<boolean> {
     });
 }
 
-async function waitForPort(port: number, timeoutMs: number): Promise<void> {
+async function waitForPort(port: number, timeoutMs: number, token: CancellationToken | undefined): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
+        if (token?.isCancellationRequested) {
+            return;
+        }
         if (await isPortInUse(port)) {
             return;
         }

--- a/src/debug/GoDebugProvider.ts
+++ b/src/debug/GoDebugProvider.ts
@@ -1,0 +1,230 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { spawn } from 'child_process';
+import { createConnection } from 'net';
+import { type CancellationToken, type DebugConfiguration, type WorkspaceFolder } from 'vscode';
+import { hostStartTaskName, localhost } from '../constants';
+import { ext } from '../extensionVariables';
+import { localize } from '../localize';
+import { cpUtils } from '../utils/cpUtils';
+import { delay } from '../utils/delay';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+import { validateDelveInstalled } from './validateDelveInstalled';
+
+export const defaultGoDebugPort: number = 2345;
+
+export const goDebugConfig: DebugConfiguration = {
+    name: localize('attachGo', 'Attach to Go Functions'),
+    type: 'go',
+    request: 'attach',
+    mode: 'remote',
+    port: defaultGoDebugPort,
+    host: localhost,
+    preLaunchTask: hostStartTaskName,
+};
+
+// The Go worker binary is always named `app` (or `app.exe` on Windows) by the
+// Functions core tools. If core tools changes that convention, this needs to
+// change too.
+const goWorkerProcessName: string = 'app';
+
+// How long to wait for the Go worker process to appear after `func host start`
+// kicks off. The build step is part of `func host start`, so this needs to
+// cover compile time as well.
+const workerPollTimeoutMs: number = 120_000;
+const workerPollIntervalMs: number = 1_000;
+// How long to wait for dlv to start listening on the debug port after we spawn it.
+const dlvListenTimeoutMs: number = 10_000;
+const dlvListenRetryIntervalMs: number = 500;
+// Brief pause to let a freed port settle after killing a stale dlv.
+const stalePortFreedDelayMs: number = 1_000;
+
+export class GoDebugProvider extends FuncDebugProviderBase {
+    // Delve attaches to the worker process out-of-band. These satisfy the
+    // abstract members on FuncDebugProviderBase but are never read because
+    // FuncTaskProvider has no `case ProjectLanguage.Go` branch.
+    public readonly workerArgKey: string = 'GOLANG_WORKER_DEBUG_FLAGS';
+    protected readonly defaultPortOrPipeName: number = defaultGoDebugPort;
+    protected readonly debugConfig: DebugConfiguration = goDebugConfig;
+
+    public async getWorkerArgValue(_folder: WorkspaceFolder): Promise<string> {
+        return '';
+    }
+
+    public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration | undefined> {
+        const result = await super.resolveDebugConfiguration(folder, debugConfiguration, token);
+        if (!result || result.mode !== 'remote') {
+            return result;
+        }
+
+        const port: number = (typeof result.port === 'number' ? result.port : defaultGoDebugPort);
+
+        const delveAvailable = await callWithTelemetryAndErrorHandling('azureFunctions.go.validateDelveBeforeDebug', async (context: IActionContext) => {
+            context.errorHandling.suppressDisplay = true;
+            const message = localize('installDelve', 'Delve (dlv) is required to debug Go Functions. Install Delve and try again.');
+            return await validateDelveInstalled(context, message, folder?.uri.fsPath);
+        });
+
+        if (!delveAvailable) {
+            return undefined;
+        }
+
+        // Fire-and-forget: the preLaunchTask (`func host start`) builds and
+        // launches the Go worker concurrently with this. The poller watches
+        // for that worker, then spawns `dlv attach` so VS Code's Go extension
+        // can connect to dlv's DAP server on `port`.
+        void pollAndAttachDlv(port);
+
+        return result;
+    }
+}
+
+async function pollAndAttachDlv(port: number): Promise<void> {
+    await callWithTelemetryAndErrorHandling('azureFunctions.go.attachDlv', async (context: IActionContext) => {
+        context.errorHandling.suppressDisplay = true;
+        context.telemetry.properties.dlvPort = String(port);
+
+        try {
+            await killStaleDlv(port);
+
+            const pid = await pollForGoWorkerPid(workerPollTimeoutMs);
+            if (pid === undefined) {
+                context.telemetry.properties.dlvAttachResult = 'workerNotFound';
+                ext.outputChannel.appendLog(localize('dlvWorkerNotFound', 'Could not find Go worker process "{0}" within {1}s. Skipping dlv auto-attach.', goWorkerProcessName, workerPollTimeoutMs / 1_000));
+                return;
+            }
+            context.telemetry.measurements.dlvWorkerPid = pid;
+
+            // Another dlv may have started in the meantime (very fast restart).
+            if (await isPortInUse(port)) {
+                context.telemetry.properties.dlvAttachResult = 'portTaken';
+                ext.outputChannel.appendLog(localize('dlvPortTaken', 'Port {0} is already in use; assuming dlv is already attached.', port));
+                return;
+            }
+
+            const dlvProcess = spawn('dlv', [
+                'attach', String(pid),
+                '--headless',
+                // --continue is required: without it, dlv pauses the worker and the
+                // Functions host kills the worker for being unresponsive.
+                '--continue',
+                `--listen=:${port}`,
+                '--api-version=2',
+                '--accept-multiclient',
+            ], {
+                detached: true,
+                stdio: 'ignore',
+            });
+            dlvProcess.unref();
+
+            await waitForPort(port, dlvListenTimeoutMs);
+            context.telemetry.properties.dlvAttachResult = 'attached';
+            ext.outputChannel.appendLog(localize('dlvAttached', 'Delve attached to Go worker (PID {0}) and listening on port {1}.', pid, port));
+        } catch (err) {
+            context.telemetry.properties.dlvAttachResult = 'failed';
+            const message = err instanceof Error ? err.message : String(err);
+            ext.outputChannel.appendLog(localize('dlvAttachFailed', 'Failed to auto-attach Delve: {0}', message));
+            throw err;
+        }
+    });
+}
+
+async function killStaleDlv(port: number): Promise<void> {
+    if (!await isPortInUse(port)) {
+        return;
+    }
+
+    if (process.platform === 'win32') {
+        // netstat → find PID listening on port → tasklist → confirm it's dlv.exe → taskkill.
+        const netstat = await cpUtils.tryExecuteCommandLine(undefined, undefined, `netstat -ano | findstr ":${port}" | findstr "LISTENING"`);
+        if (netstat.code !== 0) {
+            return;
+        }
+        const match = netstat.cmdOutput.match(/LISTENING\s+(\d+)/);
+        if (!match) {
+            return;
+        }
+        const pid = match[1];
+        const taskInfo = await cpUtils.tryExecuteCommandLine(undefined, undefined, `tasklist /FI "PID eq ${pid}" /FO CSV /NH`);
+        if (taskInfo.code !== 0 || !taskInfo.cmdOutput.toLowerCase().includes('dlv.exe')) {
+            return;
+        }
+        await cpUtils.tryExecuteCommandLine(undefined, undefined, `taskkill /PID ${pid} /F`);
+    } else {
+        const lsof = await cpUtils.tryExecuteCommandLine(undefined, undefined, `lsof -ti :${port}`);
+        if (lsof.code !== 0) {
+            return;
+        }
+        const pid = lsof.cmdOutput.trim().split('\n')[0];
+        if (!pid) {
+            return;
+        }
+        const psInfo = await cpUtils.tryExecuteCommandLine(undefined, undefined, `ps -p ${pid} -o comm=`);
+        if (psInfo.code !== 0 || psInfo.cmdOutput.trim() !== 'dlv') {
+            return;
+        }
+        await cpUtils.tryExecuteCommandLine(undefined, undefined, `kill -9 ${pid}`);
+    }
+
+    await delay(stalePortFreedDelayMs);
+}
+
+async function pollForGoWorkerPid(timeoutMs: number): Promise<number | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const pid = await findGoWorkerPid();
+        if (pid !== undefined) {
+            return pid;
+        }
+        await delay(workerPollIntervalMs);
+    }
+    return undefined;
+}
+
+async function findGoWorkerPid(): Promise<number | undefined> {
+    if (process.platform === 'win32') {
+        const imageName = `${goWorkerProcessName}.exe`;
+        const result = await cpUtils.tryExecuteCommandLine(undefined, undefined, `tasklist /FI "IMAGENAME eq ${imageName}" /FO CSV /NH`);
+        if (result.code !== 0) {
+            return undefined;
+        }
+        const match = result.cmdOutput.match(new RegExp(`"${imageName.replace('.', '\\.')}","(\\d+)"`));
+        return match ? parseInt(match[1], 10) : undefined;
+    }
+
+    const result = await cpUtils.tryExecuteCommandLine(undefined, undefined, `pgrep -x ${goWorkerProcessName}`);
+    if (result.code !== 0) {
+        return undefined;
+    }
+    const pid = parseInt(result.cmdOutput.trim().split('\n')[0], 10);
+    return Number.isNaN(pid) ? undefined : pid;
+}
+
+async function isPortInUse(port: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const socket = createConnection({ port, host: localhost });
+        socket.once('connect', () => {
+            socket.destroy();
+            resolve(true);
+        });
+        socket.once('error', () => {
+            socket.destroy();
+            resolve(false);
+        });
+    });
+}
+
+async function waitForPort(port: number, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (await isPortInUse(port)) {
+            return;
+        }
+        await delay(dlvListenRetryIntervalMs);
+    }
+    throw new Error(localize('dlvListenTimeout', 'Timed out waiting for Delve to start listening on port {0} within {1}s.', port, timeoutMs / 1_000));
+}

--- a/src/debug/GoDebugProvider.ts
+++ b/src/debug/GoDebugProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { callWithTelemetryAndErrorHandling, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { callWithTelemetryAndErrorHandling, isUserCancelledError, UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { spawn, type ChildProcess } from 'child_process';
 import { createConnection } from 'net';
 import psTree, { type PS } from 'ps-tree';
@@ -60,6 +60,14 @@ const activeDlvProcesses = new Map<string, ChildProcess>();
 export function registerGoDebugSessionCleanup(): vscode.Disposable {
     return vscode.debug.onDidTerminateDebugSession((session) => {
         if (session.type !== 'go' || !session.workspaceFolder) {
+            return;
+        }
+        // Only act on Functions debug sessions. A user may have a non-Functions Go debug
+        // session open in the same folder; the `func: host start` preLaunchTask is the same
+        // discriminator we use in resolveDebugConfiguration to decide whether to spawn dlv,
+        // so checking it here keeps the spawn and cleanup gates symmetric.
+        const preLaunchTask = session.configuration.preLaunchTask as string | undefined;
+        if (!preLaunchTask || !hostStartTaskNameRegExp.test(preLaunchTask)) {
             return;
         }
         killTrackedDlv(session.workspaceFolder.uri.fsPath);
@@ -145,20 +153,22 @@ async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefine
         context.errorHandling.suppressDisplay = true;
         context.telemetry.properties.dlvPort = String(port);
 
+        if (!folder) {
+            // findGoWorkerPid keys off runningFuncTaskMap[folder]; with no folder there is
+            // nothing to look up and the 120s poll would spin without ever finding a worker.
+            context.telemetry.properties.dlvAttachResult = 'noWorkspaceFolder';
+            ext.outputChannel.appendLog(localize('dlvNoFolder', 'No workspace folder for the Go debug session; skipping dlv auto-attach.'));
+            return;
+        }
+
         try {
             // 1. Free the port if a prior session's dlv is still listening on it.
             await killStaleDlv(port);
-            if (token?.isCancellationRequested) {
-                context.telemetry.properties.dlvAttachResult = 'cancelled';
-                return;
-            }
+            throwIfCancelled(token);
 
             // 2. Wait for `func host start` to build and launch the Go worker, then capture its PID.
             const pid = await pollForGoWorkerPid(workerPollTimeoutMs, folder, token);
-            if (token?.isCancellationRequested) {
-                context.telemetry.properties.dlvAttachResult = 'cancelled';
-                return;
-            }
+            throwIfCancelled(token);
             if (pid === undefined) {
                 context.telemetry.properties.dlvAttachResult = 'workerNotFound';
                 ext.outputChannel.appendLog(localize('dlvWorkerNotFound', 'Could not find Go worker process "{0}" within {1}s. Skipping dlv auto-attach.', goWorkerProcessName, workerPollTimeoutMs / 1_000));
@@ -207,20 +217,19 @@ async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefine
 
             // 6. Track this dlv for proactive cleanup on session end. If a previous dlv was
             // tracked for this folder (rapid restart), kill it first so it doesn't become orphaned.
-            if (folder) {
-                killTrackedDlv(folder.uri.fsPath);
-                activeDlvProcesses.set(folder.uri.fsPath, dlvProcess);
-            }
+            killTrackedDlv(folder.uri.fsPath);
+            activeDlvProcesses.set(folder.uri.fsPath, dlvProcess);
 
             // 7. Block until dlv is actually listening, so VS Code's Go extension has a port to connect to.
             await waitForPort(port, dlvListenTimeoutMs, token);
-            if (token?.isCancellationRequested) {
-                context.telemetry.properties.dlvAttachResult = 'cancelled';
-                return;
-            }
+            throwIfCancelled(token);
             context.telemetry.properties.dlvAttachResult = 'attached';
             ext.outputChannel.appendLog(localize('dlvAttached', 'Delve attached to Go worker (PID {0}) and listening on port {1}.', pid, port));
         } catch (err) {
+            if (isUserCancelledError(err)) {
+                // callWithTelemetryAndErrorHandling marks the event as cancelled and stays silent.
+                throw err;
+            }
             context.telemetry.properties.dlvAttachResult = 'failed';
             const message = err instanceof Error ? err.message : String(err);
             ext.outputChannel.appendLog(localize('dlvAttachFailed', 'Failed to auto-attach Delve: {0}', message));
@@ -272,9 +281,7 @@ async function killStaleDlv(port: number): Promise<void> {
 async function pollForGoWorkerPid(timeoutMs: number, folder: WorkspaceFolder | undefined, token: CancellationToken | undefined): Promise<number | undefined> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        if (token?.isCancellationRequested) {
-            return undefined;
-        }
+        throwIfCancelled(token);
         const pid = await findGoWorkerPid(folder);
         if (pid !== undefined) {
             return pid;
@@ -355,13 +362,17 @@ async function isPortInUse(port: number): Promise<boolean> {
 async function waitForPort(port: number, timeoutMs: number, token: CancellationToken | undefined): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-        if (token?.isCancellationRequested) {
-            return;
-        }
+        throwIfCancelled(token);
         if (await isPortInUse(port)) {
             return;
         }
         await delay(dlvListenRetryIntervalMs);
     }
     throw new Error(localize('dlvListenTimeout', 'Timed out waiting for Delve to start listening on port {0} within {1}s.', port, timeoutMs / 1_000));
+}
+
+function throwIfCancelled(token: CancellationToken | undefined): void {
+    if (token?.isCancellationRequested) {
+        throw new UserCancelledError('go.dlv.attach');
+    }
 }

--- a/src/debug/validateDelveInstalled.ts
+++ b/src/debug/validateDelveInstalled.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import { type MessageItem } from 'vscode';
+import { cpUtils } from '../utils/cpUtils';
+import { openUrl } from '../utils/openUrl';
+import { getWorkspaceSetting } from '../vsCodeConfig/settings';
+
+const dlvCommand: string = 'dlv';
+const dlvInstallUrl: string = 'https://github.com/go-delve/delve/tree/master/Documentation/installation';
+
+/**
+ * Verifies that Delve (`dlv`) is available on PATH before starting a Go debug
+ * session. If missing, prompts the user with a "Learn more" button that opens
+ * the Delve install docs.
+ *
+ * Honors the `azureFunctions.validateDelve` workspace setting (default true).
+ *
+ * @returns true if Delve is installed (or validation is disabled), false otherwise.
+ */
+export async function validateDelveInstalled(_context: IActionContext, message: string, workspacePath?: string): Promise<boolean> {
+    let installed: boolean = false;
+
+    await callWithTelemetryAndErrorHandling('azureFunctions.validateDelveInstalled', async (innerContext: IActionContext) => {
+        innerContext.errorHandling.suppressDisplay = true;
+
+        if (getWorkspaceSetting<boolean>('validateDelve', workspacePath) === false) {
+            innerContext.telemetry.properties.validateDelve = 'false';
+            installed = true;
+            return;
+        }
+
+        if (await delveInstalled(workspacePath)) {
+            installed = true;
+            return;
+        }
+
+        const result: MessageItem = await innerContext.ui.showWarningMessage(message, { modal: true, stepName: 'delveNotInstalled' }, DialogResponses.learnMore);
+        innerContext.telemetry.properties.dialogResult = result.title;
+        if (result === DialogResponses.learnMore) {
+            await openUrl(dlvInstallUrl);
+        }
+    });
+
+    return installed;
+}
+
+async function delveInstalled(workspacePath: string | undefined): Promise<boolean> {
+    try {
+        // Delve uses `dlv version` (no leading dashes), unlike most CLIs.
+        const result = await cpUtils.tryExecuteCommand(undefined, workspacePath, dlvCommand, composeArgs(withArg('version'))());
+        return result.code === 0;
+    } catch {
+        return false;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { registerCommands } from './commands/registerCommands';
 import { func } from './constants';
 import { BallerinaDebugProvider } from './debug/BallerinaDebugProvider';
 import { FuncTaskProvider } from './debug/FuncTaskProvider';
+import { GoDebugProvider } from './debug/GoDebugProvider';
 import { JavaDebugProvider } from './debug/JavaDebugProvider';
 import { NodeDebugProvider } from './debug/NodeDebugProvider';
 import { PowerShellDebugProvider } from './debug/PowerShellDebugProvider';
@@ -109,6 +110,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         const javaDebugProvider: JavaDebugProvider = new JavaDebugProvider();
         const ballerinaDebugProvider: BallerinaDebugProvider = new BallerinaDebugProvider();
         const powershellDebugProvider: PowerShellDebugProvider = new PowerShellDebugProvider();
+        const goDebugProvider: GoDebugProvider = new GoDebugProvider();
 
         // These don't actually overwrite "node", "python", etc. - they just add to it
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('node', nodeDebugProvider));
@@ -117,6 +119,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', javaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('ballerina', ballerinaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('PowerShell', powershellDebugProvider));
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('go', goDebugProvider));
         context.subscriptions.push(vscode.workspace.registerTaskProvider(func, new FuncTaskProvider(nodeDebugProvider, pythonDebugProvider, javaDebugProvider, ballerinaDebugProvider, powershellDebugProvider)));
 
         context.subscriptions.push(vscode.window.registerUriHandler({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { registerCommands } from './commands/registerCommands';
 import { func } from './constants';
 import { BallerinaDebugProvider } from './debug/BallerinaDebugProvider';
 import { FuncTaskProvider } from './debug/FuncTaskProvider';
-import { GoDebugProvider } from './debug/GoDebugProvider';
+import { GoDebugProvider, registerGoDebugSessionCleanup } from './debug/GoDebugProvider';
 import { JavaDebugProvider } from './debug/JavaDebugProvider';
 import { NodeDebugProvider } from './debug/NodeDebugProvider';
 import { PowerShellDebugProvider } from './debug/PowerShellDebugProvider';
@@ -120,6 +120,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('ballerina', ballerinaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('PowerShell', powershellDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('go', goDebugProvider));
+        context.subscriptions.push(registerGoDebugSessionCleanup());
         context.subscriptions.push(vscode.workspace.registerTaskProvider(func, new FuncTaskProvider(nodeDebugProvider, pythonDebugProvider, javaDebugProvider, ballerinaDebugProvider, powershellDebugProvider)));
 
         context.subscriptions.push(vscode.window.registerUriHandler({

--- a/test/goDebugProvider.test.ts
+++ b/test/goDebugProvider.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { hostStartTaskName, localhost } from '../src/constants';
+import { defaultGoDebugPort, goDebugConfig } from '../src/debug/GoDebugProvider';
+
+suite('debug/GoDebugProvider — config shape', () => {
+    test('goDebugConfig matches what the Go extension expects for an external dlv attach', () => {
+        // These values are the contract between this extension and the golang.go extension.
+        // Changing any of them silently breaks F5 for every Go Functions user, so pin them down.
+        assert.strictEqual(goDebugConfig.type, 'go');
+        assert.strictEqual(goDebugConfig.request, 'attach');
+        // mode 'remote' tells golang.go to connect to an externally-started dlv (the one our poller spawns)
+        // rather than starting dlv itself.
+        assert.strictEqual(goDebugConfig.mode, 'remote');
+        assert.strictEqual(goDebugConfig.port, 2345);
+        assert.strictEqual(goDebugConfig.host, localhost);
+        assert.strictEqual(goDebugConfig.preLaunchTask, hostStartTaskName);
+    });
+
+    test('defaultGoDebugPort matches goDebugConfig.port', () => {
+        // GoDebugProvider falls back to defaultGoDebugPort if the resolved config is missing a port,
+        // so the two must stay aligned.
+        assert.strictEqual(defaultGoDebugPort, goDebugConfig.port);
+    });
+});


### PR DESCRIPTION
Second of three PRs adding Go support to the Azure Functions extension. Builds on #5019. After this PR, F5 attaches Delve to a Go Functions project and breakpoints work. Deploy follows in PR3.

Highlights:

 - New GoDebugProvider extends FuncDebugProviderBase. Owns the dlv lifecycle: kill stale dlv on the target port, poll up to 120s for the Go worker (app/app.exe), spawn 
dlv attach <pid> --headless --continue --listen=:2345 --api-version=2 --accept-multiclient detached, wait for it to listen. Each step logs to the Azure Functions output 
channel and emits telemetry.
 - goDebugConfig moves from GoInitVSCodeStep to GoDebugProvider as the canonical source (PR1 left a comment anticipating this).
 - New validateDelveInstalled runs dlv version before attaching; on miss, shows a modal with a Learn more link to the Delve install docs. Honors a new 
azureFunctions.validateDelve setting (default true), mirroring azureFunctions.validateFuncCoreTools.
 - extension.ts registers GoDebugProvider for the 'go' debug type. Not wired into FuncTaskProvider — Go uses external dlv attach instead of the worker-arg env-var 
pattern.
 - validatePreDebug.ts left unchanged. Shared pre-debug checks still run for Go via FuncDebugProviderBase; Go-specific validation lives only in GoDebugProvider.
 - Unit test pinning the goDebugConfig shape so silent regressions to type/mode/port surface in CI.

Known limitations:

 - Worker process name is hardcoded to app/app.exe (matches current core tools output).
 - Detached dlv is cleaned up lazily on next attach via killStaleDlv, not on session end.
 - dlv must be on PATH; no dlvPath setting in this PR.
 - Smoke tested on Windows. macOS/Linux paths use pgrep/lsof/kill — asking reviewers on those platforms to verify.
