### PR TITLE
Bump version after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 1.21.1 - 2026-05-20
+
+### Added
+* [[4765](https://github.com/microsoft/vscode-azurefunctions/pull/4765)] Support **debug-isolated** flag and stream `func` CLI output during debugging
+* [[5002](https://github.com/microsoft/vscode-azurefunctions/pull/5002)] Add **MCP Prompt** template
+* [[4966](https://github.com/microsoft/vscode-azurefunctions/pull/4966)] Add **MCP Resource trigger** templates for JavaScript and TypeScript
+* [[4959](https://github.com/microsoft/vscode-azurefunctions/pull/4959)] Add a setting to bypass **emulator validation**
+
+### Changed
+* [[5008](https://github.com/microsoft/vscode-azurefunctions/pull/5008)] Hide `Get MCP Host Key` from the command palette
+* [[4999](https://github.com/microsoft/vscode-azurefunctions/pull/4999)] Stop filtering the **Java version** picker by locally installed JDKs
+
+### Fixed
+* [[5020](https://github.com/microsoft/vscode-azurefunctions/pull/5020)] Fix missing icons for **role assignment scope** nodes under User Assigned Identities
+* [[5005](https://github.com/microsoft/vscode-azurefunctions/pull/5005)] Fix invalid CLI args when creating **C# functions** with templates that lack namespace support
+* [[4993](https://github.com/microsoft/vscode-azurefunctions/pull/4993)] Fix **SignalR Trigger** C# template showing `"null"` as the default hub name
+
 ## 1.21.0 - 2026-04-14
 
 ### Overview

--- a/NOTICE.html
+++ b/NOTICE.html
@@ -1821,6 +1821,39 @@ SOFTWARE.
 <li>
     <details>
         <summary>
+            xmlbuilder 11.0.1 - LicenseRef-scancode-unicode AND MIT
+        </summary>
+        <p><a href="http://github.com/oozcitak/xmlbuilder-js">http://github.com/oozcitak/xmlbuilder-js</a></p>
+        <ul><li>Copyright (c) 2013 Ozgur Ozcitak</li></ul>
+        <pre>
+        The MIT License (MIT)
+
+Copyright (c) 2013 Ozgur Ozcitak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             @azure/abort-controller 2.1.2 - MIT
         </summary>
         <p><a href="https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller/README.md">https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/abort-controller/README.md</a></p>
@@ -3792,6 +3825,42 @@ SOFTWARE.
 <li>
     <details>
         <summary>
+            benchmark 1.0.0 - MIT
+        </summary>
+        <p><a href="http://benchmarkjs.com/">http://benchmarkjs.com/</a></p>
+        <ul><li>copyright Robert Kieffer &lt;http://broofa.com/&gt;</li>
+<li>Copyright 2010-2012 Mathias Bynens &lt;http://mths.be/&gt;</li>
+<li>Copyright 2010-2012 Mathias Bynens &lt;http://mathiasbynens.be/&gt;</li></ul>
+        <pre>
+        Copyright 2010-2012 Mathias Bynens &lt;http://mathiasbynens.be/&gt;
+Based on JSLitmus.js, copyright Robert Kieffer &lt;http://broofa.com/&gt;
+Modified by John-David Dalton &lt;http://allyoucanleet.com/&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&quot;Software&quot;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+        </pre>
+    </details>
+</li>
+<li>
+    <details>
+        <summary>
             brace-expansion 5.0.5 - MIT
         </summary>
         <p><a href="https://github.com/juliangruber/brace-expansion#readme">https://github.com/juliangruber/brace-expansion#readme</a></p>
@@ -4526,7 +4595,7 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            fast-xml-builder 1.1.4 - MIT
+            fast-xml-builder 1.2.0 - MIT
         </summary>
         <p><a href="https://github.com/NaturalIntelligence/fast-xml-builder#readme">https://github.com/NaturalIntelligence/fast-xml-builder#readme</a></p>
         <ul><li>Copyright (c) 2026 Natural Intelligence</li></ul>
@@ -4559,7 +4628,7 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            fast-xml-parser 5.5.7 - MIT
+            fast-xml-parser 5.7.1 - MIT
         </summary>
         <p><a href="https://github.com/NaturalIntelligence/fast-xml-parser#readme">https://github.com/NaturalIntelligence/fast-xml-parser#readme</a></p>
         <ul><li>Copyright (c) 2017 Amit Kumar Gupta</li></ul>
@@ -5330,35 +5399,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            jwa 1.4.2 - MIT
-        </summary>
-        <p><a href="https://github.com/brianloveswords/node-jwa#readme">https://github.com/brianloveswords/node-jwa#readme</a></p>
-        <ul><li>Copyright (c) 2013 Brian J. Brennan</li></ul>
-        <pre>
-        Copyright (c) 2013 Brian J. Brennan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy 
-of this software and associated documentation files (the &quot;Software&quot;), to deal in 
-the Software without restriction, including without limitation the rights to use, 
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the 
-Software, and to permit persons to whom the Software is furnished to do so, 
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all 
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
-PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
-FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             leac 0.6.0 - MIT
         </summary>
         <p><a href="https://github.com/mxxii/leac">https://github.com/mxxii/leac</a></p>
@@ -5659,39 +5699,6 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
         MIT License
 
 Copyright (c) 2021-2022 KillyMXI &lt;killy@mxii.eu.org&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            path-expression-matcher 1.1.3 - MIT
-        </summary>
-        <p><a href="https://github.com/NaturalIntelligence/path-expression-matcher#readme">https://github.com/NaturalIntelligence/path-expression-matcher#readme</a></p>
-        <ul><li>Copyright (c) 2024</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) 2024
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -6258,26 +6265,6 @@ SOFTWARE.
 <li>
     <details>
         <summary>
-            simple-git 3.33.0 - MIT
-        </summary>
-        <p><a href="https://github.com/steveukx/git-js#readme">https://github.com/steveukx/git-js#readme</a></p>
-        
-        <pre>
-        MIT License
-
-Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             slash 3.0.0 - MIT
         </summary>
         <p><a href="https://github.com/sindresorhus/slash#readme">https://github.com/sindresorhus/slash#readme</a></p>
@@ -6388,7 +6375,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            strnum 2.2.1 - MIT
+            strnum 2.2.3 - MIT
         </summary>
         <p><a href="https://github.com/NaturalIntelligence/strnum#readme">https://github.com/NaturalIntelligence/strnum#readme</a></p>
         <ul><li>Copyright (c) 2021 Natural Intelligence</li></ul>
@@ -6765,61 +6752,6 @@ THE SOFTWARE.
 <li>
     <details>
         <summary>
-            wrap-ansi 7.0.0 - MIT
-        </summary>
-        <p><a href="https://github.com/chalk/wrap-ansi#readme">https://github.com/chalk/wrap-ansi#readme</a></p>
-        <ul><li>Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)</li></ul>
-        <pre>
-        MIT License
-
-Copyright (c) Sindre Sorhus &lt;sindresorhus@gmail.com&gt; (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
-            ws 8.18.1 - MIT
-        </summary>
-        <p><a href="https://github.com/websockets/ws">https://github.com/websockets/ws</a></p>
-        <ul><li>Copyright (c) 2016 Luigi Pinca and contributors</li>
-<li>Copyright (c) 2013 Arnout Kazemier and contributors</li>
-<li>Copyright (c) 2011 Einar Otto Stangvik &lt;einaros@gmail.com&gt;</li></ul>
-        <pre>
-        Copyright (c) 2011 Einar Otto Stangvik &lt;einaros@gmail.com&gt;
-Copyright (c) 2013 Arnout Kazemier and contributors
-Copyright (c) 2016 Luigi Pinca and contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-        </pre>
-    </details>
-</li>
-<li>
-    <details>
-        <summary>
             xml2js 0.5.0 - MIT
         </summary>
         <p><a href="https://github.com/Leonidas-from-XIV/node-xml2js">https://github.com/Leonidas-from-XIV/node-xml2js</a></p>
@@ -6851,33 +6783,20 @@ IN THE SOFTWARE.
 <li>
     <details>
         <summary>
-            xmlbuilder 11.0.1 - MIT
+            xml-naming 0.1.0 - MIT
         </summary>
-        <p><a href="http://github.com/oozcitak/xmlbuilder-js">http://github.com/oozcitak/xmlbuilder-js</a></p>
-        <ul><li>Copyright (c) 2013 Ozgur Ozcitak</li></ul>
+        <p><a href="https://github.com/NaturalIntelligence/xml-naming#readme">https://github.com/NaturalIntelligence/xml-naming#readme</a></p>
+        
         <pre>
-        The MIT License (MIT)
+        MIT License
 
-Copyright (c) 2013 Ozgur Ozcitak
+Copyright (c) &lt;year&gt; &lt;copyright holders&gt;
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         </pre>
     </details>
 </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.21.1-alpha.0",
+    "version": "1.21.2-alpha.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.21.1-alpha.0",
+            "version": "1.21.2-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-alpha.20230530.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.21.1",
+    "version": "1.21.2-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.21.1-alpha.0",
+    "version": "1.21.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
## Bump version after release

Bumps version in preparation for the next development cycle.

> Do not merge until the upstream release PR has been merged and the extension has been published.
> This PR depends on https://github.com/microsoft/vscode-azurefunctions/pull/5041 — merge that first.

> Generated by GitHub Copilot. Please review all changes before merging.