### PR TITLE
Relax test timeout for some slow tests

### DIFF
--- a/test/createFunction/createFunction.CSharp.test.ts
+++ b/test/createFunction/createFunction.CSharp.test.ts
@@ -190,7 +190,7 @@ function addSuite(version: FuncVersion, targetFramework: string, source: Templat
 
     tester.addParallelSuite(testCases, {
         title,
-        timeoutMS: 60 * 1000,
+        timeoutMS: 120 * 1000,
         isLongRunning: isLongRunningVersion(version),
     });
 }


### PR DESCRIPTION
Since parallelizing the tests in #5038, the C# tests are timing out more often. Because the tests are now executed in parallel, the wall-clock time of individual cases is longer, increasing the chances of timeout.