### PR TITLE
Add Go support for Create Function App

### DIFF
--- a/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
+++ b/src/commands/createFunctionApp/createCreateFunctionAppComponents.ts
@@ -7,7 +7,7 @@ import { AppInsightsCreateStep, AppInsightsListStep, AppKind, AppServicePlanCrea
 import { CommonRoleDefinitions, createRoleId, LocationListStep, ResourceGroupCreateStep, ResourceGroupListStep, RoleAssignmentExecuteStep, StorageAccountCreateStep, StorageAccountKind, StorageAccountListStep, StorageAccountPerformance, StorageAccountReplication, type INewStorageAccountDefaults, type Role } from "@microsoft/vscode-azext-azureutils";
 import { type AzureWizardExecuteStep, type AzureWizardPromptStep, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 import { FuncVersion, latestGAVersion, tryParseFuncVersion } from "../../FuncVersion";
-import { DurableBackend, funcVersionSetting } from "../../constants";
+import { DurableBackend, funcVersionSetting, ProjectLanguage } from "../../constants";
 import { tryGetLocalFuncVersion } from "../../funcCoreTools/tryGetLocalFuncVersion";
 import { type ICreateFunctionAppContext } from "../../tree/SubscriptionTreeItem";
 import { createActivityContext } from "../../utils/activityUtils";
@@ -91,7 +91,12 @@ export async function createCreateFunctionAppComponents(context: ICreateFunction
     if (!wizardContext.advancedCreation) {
         // if the user is deploying to a container app, do not use a flex consumption plan
         wizardContext.useFlexConsumptionPlan = !wizardContext.dockerfilePath;
-        wizardContext.stackFilter = getRootFunctionsWorkerRuntime(wizardContext.language);
+        // Some languages (e.g. Go) use a different worker runtime ('native') than their stacks API value ('go')
+        const stackFilterOverrides: Partial<Record<ProjectLanguage, string>> = {
+            [ProjectLanguage.Go]: 'go',
+        };
+        wizardContext.stackFilter = stackFilterOverrides[wizardContext.language as ProjectLanguage]
+            ?? getRootFunctionsWorkerRuntime(wizardContext.language);
         promptSteps.push(new ConfigureCommonNamesStep());
         executeSteps.push(new ResourceGroupCreateStep());
         executeSteps.push(new StorageAccountCreateStep(storageAccountCreateOptions));

--- a/src/commands/createFunctionApp/stacks/getStackPicks.ts
+++ b/src/commands/createFunctionApp/stacks/getStackPicks.ts
@@ -187,7 +187,7 @@ async function getFlexStacks(context: ISubscriptionActionContext & { _stacks?: F
     const client: ServiceClient = await createGenericClient(context, context);
     location = location ?? (await LocationListStep.getLocation(context)).name;
     const flexFunctionAppStacks: FunctionAppStack[] = [];
-    const stacks = ['dotnet', 'java', 'node', 'powershell', 'python', 'custom'];
+    const stacks = ['dotnet', 'java', 'node', 'powershell', 'python', 'custom', 'go'];
     if (!context._stacks) {
         const getFlexStack = async (stack: string) => {
             const result: AzExtPipelineResponse = await client.sendRequest(createPipelineRequest({

--- a/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
@@ -29,7 +29,7 @@ export class GoProjectCreateStep extends ScriptProjectCreateStep {
 
         // local.settings.json was written by super; add the Go preview flag
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.localSettingsJson.Values!['FUNCTIONS_CLI_NATIVE_LANGUAGE'] = 'true';
+        this.localSettingsJson.Values!['FUNCTIONS_CLI_NATIVE_LANGUAGE'] = 'go';
         await AzExtFsExtra.writeJSON(path.join(context.projectPath, 'local.settings.json'), this.localSettingsJson);
 
         const moduleName: string = path.basename(context.projectPath);


### PR DESCRIPTION
Description:

Enables "Create Function App" to work with Go projects. Go uses native as its worker runtime but the Azure stacks API lists it as go. This adds a stack filter override map so the extension correctly queries for the Go runtime stack. Also adds go to the Flex Consumption stacks list.

Changes:

 - Added stackFilterOverrides map in createCreateFunctionAppComponents.ts to resolve worker runtime vs stacks API value mismatch
 - Added 'go' to the Flex Consumption stacks query list in getStackPicks.ts