### PR TITLE
Bump version after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.21.2 - 2026-05-28
+
+### Engineering
+* [[5057](https://github.com/microsoft/vscode-azurefunctions/pull/5057), [5058](https://github.com/microsoft/vscode-azurefunctions/pull/5058)] Bump runtime dependencies (`tmp`, `@microsoft/vscode-azext-utils`, `@microsoft/vscode-azext-azureappservice`)
+
 ## 1.21.1 - 2026-05-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-azurefunctions",
-    "version": "1.21.1",
+    "version": "1.21.3-alpha.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-azurefunctions",
-            "version": "1.21.1",
+            "version": "1.21.3-alpha.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@azure/arm-appinsights": "^5.0.0-alpha.20230530.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.21.2",
+    "version": "1.21.3-alpha.0",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-azurefunctions",
     "displayName": "Azure Functions",
     "description": "%azureFunctions.description%",
-    "version": "1.21.1",
+    "version": "1.21.2",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-functions.png",
     "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",


### PR DESCRIPTION
## Bump version after release

Bumps version in preparation for the next development cycle.

> ⚠️ **Do not merge until the upstream release PR has been merged and the extension has been published.**
> This PR depends on https://github.com/microsoft/vscode-azurefunctions/pull/5059 — merge that first.

> 🤖 This PR was generated by GitHub Copilot. Please review all changes before merging.