### PR TITLE
 Fixes Template Gallery bugs

### DIFF
--- a/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
+++ b/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
@@ -57,7 +57,7 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
             // wizard's folder picker) and it differs from what the existing panel was
             // created with, the old defaultLocation is stale. Dispose so we recreate
             // with the new location instead of silently ignoring it.
-            if (initialLocation !== undefined && existing.initialLocation !== initialLocation) {
+            if (initialLocation !== undefined && (existing.initialLocation === undefined || !isPathEqual(existing.initialLocation, initialLocation))) {
                 existing.dispose();
             } else {
                 existing.revealToForeground();

--- a/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
+++ b/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtFsExtra, UserCancelledError, callWithTelemetryAndErrorHandling, parseError, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { AzExtFsExtra, AzureWizard, UserCancelledError, callWithTelemetryAndErrorHandling, parseError, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { TemplateGalleryController, registerWebviewExtensionVariables, type IProjectTemplate as ISharedProjectTemplate, type TemplateGalleryConfig } from '@microsoft/vscode-azext-webview';
 import extract from 'extract-zip';
 import * as fs from 'fs';
@@ -15,7 +15,13 @@ import { localize } from '../../localize';
 import { type IProjectTemplate } from '../../templates/projectTemplates/IProjectTemplate';
 import { ProjectTemplateProvider } from '../../templates/projectTemplates/ProjectTemplateProvider';
 import { cpUtils } from '../../utils/cpUtils';
+import { isPathEqual } from '../../utils/fs';
 import { requestUtils } from '../../utils/requestUtils';
+import { getWorkspaceSetting } from '../../vsCodeConfig/settings';
+import { projectOpenBehaviorSetting } from '../../constants';
+import { type IProjectWizardContext, type OpenBehavior } from './IProjectWizardContext';
+import { OpenBehaviorStep } from './OpenBehaviorStep';
+import { OpenFolderStep } from './OpenFolderStep';
 
 /**
  * Azure Functions implementation of the shared TemplateGalleryController.
@@ -29,10 +35,12 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
 
     private readonly templateProvider: ProjectTemplateProvider;
     private isPanelDisposed = false;
+    private readonly initialLocation: string | undefined;
 
-    private constructor(context: vscode.ExtensionContext, config: TemplateGalleryConfig) {
+    private constructor(context: vscode.ExtensionContext, config: TemplateGalleryConfig, initialLocation?: string) {
         super(context, config);
         this.templateProvider = new ProjectTemplateProvider();
+        this.initialLocation = initialLocation;
 
         this.registerDisposable(
             this.onDisposed(() => {
@@ -42,10 +50,19 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
         );
     }
 
-    public static createOrShow(context: vscode.ExtensionContext): FunctionsTemplateGalleryController {
-        if (FunctionsTemplateGalleryController.currentController) {
-            FunctionsTemplateGalleryController.currentController.revealToForeground();
-            return FunctionsTemplateGalleryController.currentController;
+    public static createOrShow(context: vscode.ExtensionContext, initialLocation?: string): FunctionsTemplateGalleryController {
+        const existing = FunctionsTemplateGalleryController.currentController;
+        if (existing) {
+            // If the caller supplied a fresh initialLocation (typically from the classic
+            // wizard's folder picker) and it differs from what the existing panel was
+            // created with, the old defaultLocation is stale. Dispose so we recreate
+            // with the new location instead of silently ignoring it.
+            if (initialLocation !== undefined && existing.initialLocation !== initialLocation) {
+                existing.dispose();
+            } else {
+                existing.revealToForeground();
+                return existing;
+            }
         }
 
         if (!FunctionsTemplateGalleryController.webviewVariablesRegistered) {
@@ -63,7 +80,7 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
             supportsAiGeneration: true,
         };
 
-        FunctionsTemplateGalleryController.currentController = new FunctionsTemplateGalleryController(context, config);
+        FunctionsTemplateGalleryController.currentController = new FunctionsTemplateGalleryController(context, config, initialLocation);
         return FunctionsTemplateGalleryController.currentController;
     }
 
@@ -73,7 +90,12 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
         return await callWithTelemetryAndErrorHandling('azureFunctions.templateGallery.getTemplates', async (actionContext: IActionContext) => {
             const templates = await this.templateProvider.getTemplates(actionContext);
             let defaultLocation = '';
-            if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+            if (this.initialLocation) {
+                // Prefer the folder the user already picked in the classic wizard before
+                // switching into the gallery — otherwise we'd fall back to the open
+                // workspace folder, which is almost always the wrong target.
+                defaultLocation = this.initialLocation;
+            } else if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
                 defaultLocation = vscode.workspace.workspaceFolders[0].uri.fsPath;
             }
             return { templates: templates as unknown as ISharedProjectTemplate[], defaultLocation };
@@ -200,10 +222,50 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
                 void vscode.window.showInformationMessage(
                     localize('projectCreated', 'Project created successfully at {0}', projectPath),
                 );
+
+                // Match the classic wizard's post-create behavior: prompt the user how to
+                // open the newly created project (Open in current/new window, or Add to
+                // workspace) and then act on it via the shared OpenFolderStep. This keeps
+                // both flows consistent and reuses the same telemetry / activity output.
+                await this.promptAndOpenProject(actionContext, projectPath);
             } finally {
                 try { await AzExtFsExtra.deleteResource(tempDir, { recursive: true }); } catch { /* ignore */ }
             }
         });
+    }
+
+    private async promptAndOpenProject(actionContext: IActionContext, projectPath: string): Promise<void> {
+        // If the freshly-created project is already part of the open workspace,
+        // there's nothing to open.
+        const alreadyOpen = (vscode.workspace.workspaceFolders ?? []).some(f => isPathEqual(f.uri.fsPath, projectPath));
+        if (alreadyOpen) {
+            return;
+        }
+
+        const wizardContext = Object.assign({}, actionContext, {
+            projectPath,
+            workspacePath: projectPath,
+            workspaceFolder: undefined,
+            openBehavior: getWorkspaceSetting<OpenBehavior>(projectOpenBehaviorSetting),
+        }) as Partial<IProjectWizardContext> & IActionContext;
+
+        const wizard = new AzureWizard<IProjectWizardContext>(wizardContext as IProjectWizardContext, {
+            title: localize('openProject', 'Open new project'),
+            promptSteps: [new OpenBehaviorStep()],
+            executeSteps: [new OpenFolderStep()],
+        });
+
+        try {
+            await wizard.prompt();
+            await wizard.execute();
+        } catch (err) {
+            if (err instanceof UserCancelledError) {
+                // User dismissed the open-behavior picker — files are already on disk,
+                // so just leave them in place. No need to surface an error.
+                return;
+            }
+            throw err;
+        }
     }
 
     // ── Optional overrides ──

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -86,7 +86,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
         const result = (await context.ui.showQuickPick(languagePicks, options)).data;
 
         if (result.language === templateGalleryLanguage) {
-            FunctionsTemplateGalleryController.createOrShow(ext.context);
+            FunctionsTemplateGalleryController.createOrShow(ext.context, context.projectPath);
             context.telemetry.properties.flow = 'templateGalleryFromWizard';
             throw new UserCancelledError('templateGallery');
         }


### PR DESCRIPTION
 Fixes two Template Gallery bugs reported by the testing team.
 
 ## Fixes #5068 — Non-empty folder warning fires against the wrong folder
 
 **Repro:** Open Folder A as a workspace → `F1 → Create New Project` → pick empty **Folder B** in the folder picker → choose "Browse Template Gallery (Preview)…" → pick a template → "Use this template".
 
 **Before:** The gallery validates against the open workspace (Folder A), so the user sees a "folder is not empty" modal warning about Folder A. The folder they picked seconds earlier (Folder B) is silently dropped.
 
 **Root cause:** `NewProjectLanguageStep.ts:89` calls `FunctionsTemplateGalleryController.createOrShow(ext.context)` and drops `context.projectPath`. The gallery then falls back to `vscode.workspace.workspaceFolders[0]` in `fetchTemplates`.
 
 **Fix:**
 - Added an optional `initialLocation?: string` to `FunctionsTemplateGalleryController` constructor and `createOrShow`.
 - `fetchTemplates` now prefers `this.initialLocation` over the workspace fallback.
 - `NewProjectLanguageStep` passes `context.projectPath` through on the hand-off.
 - `createOrShow` also disposes an existing panel if it was created with a different `initialLocation`, so the second run with a fresh folder doesn't reveal a stale panel.
 
 ## Fixes #5065 — Newly-created project from gallery is not opened in VS Code
 
 **Repro:** `F1 → Browse New Templates` → pick a template → "Use this template" → choose an empty folder outside the current workspace → wait for success toast.
 
 **Before:** Project files are written to disk and a README opens, but VS Code never prompts to open the new folder or add it to the workspace. The user is left in their previous workspace with an orphaned README tab.
 
 **Root cause:** After scaffolding, `createProject` only called `tryOpenReadme` + `disposePanelIfOpen` + `showInformationMessage`. The classic wizard handles this with `OpenBehaviorStep` (prompt) and `OpenFolderStep` (execute), but the gallery never wired them up.
 
 **Fix:** Added `promptAndOpenProject` which:
 - No-ops if the target folder is already a workspace folder (uses `isPathEqual` from `utils/fs.ts`).
 - Builds a minimal `IProjectWizardContext`, pre-seeded from the existing `azureFunctions.projectOpenBehavior` setting (same precedence as the classic wizard).
 - Runs a 2-step `AzureWizard` with `OpenBehaviorStep` → `OpenFolderStep`, reusing the shared steps verbatim so behavior and telemetry stay consistent.
 - Silently swallows `UserCancelledError` if the user dismisses the open-behavior picker — files stay on disk where they were just created.
 