### PR TITLE
Stop using utils that are not available in node 24

### DIFF
--- a/src/templates/script/parseScriptTemplates.ts
+++ b/src/templates/script/parseScriptTemplates.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isString } from 'util';
 import { ProjectLanguage, sqlBindingTemplateRegex } from '../../constants';
 import { ParsedFunctionJson, type IFunctionBinding } from '../../funcConfig/function';
 import { localize } from '../../localize';
@@ -82,7 +81,7 @@ export interface IResources {
 }
 
 function getVariableValue(resources: IResources, variables: IVariables, data: string): string {
-    if (!isString(data)) {
+    if (typeof data !== 'string') {
         // This evaluates to a non-string value in rare cases, in which case we just return the value as-is
         return data;
     }

--- a/src/utils/azure.ts
+++ b/src/utils/azure.ts
@@ -6,7 +6,6 @@
 import { AppKind, type IAppServiceWizardContext } from '@microsoft/vscode-azext-azureappservice';
 import { VerifyProvidersStep } from '@microsoft/vscode-azext-azureutils';
 import { AzureWizard, type AzureWizardExecuteStep, type IActionContext, type IAzureQuickPickItem } from '@microsoft/vscode-azext-utils';
-import { isArray } from 'util';
 import { webProvider } from '../constants';
 import { localize } from '../localize';
 import { type ICreateFunctionAppContext, type SubscriptionTreeItem } from '../tree/SubscriptionTreeItem';
@@ -18,7 +17,7 @@ export interface IBaseResourceWithName {
 
 export async function promptForResource<T extends IBaseResourceWithName>(context: IActionContext, placeHolder: string, resourcesTask: Promise<T[]>): Promise<T | undefined> {
     const picksTask: Promise<IAzureQuickPickItem<T | undefined>[]> = resourcesTask.then((resources: T[]) => {
-        const picks: IAzureQuickPickItem<T | undefined>[] = !isArray(resources) ? [] : <IAzureQuickPickItem<T>[]>(resources
+        const picks: IAzureQuickPickItem<T | undefined>[] = !Array.isArray(resources) ? [] : <IAzureQuickPickItem<T>[]>(resources
             .map((r: T) => r.name ? { data: r, label: r.name, description: r._description } : undefined)
             .filter((p: IAzureQuickPickItem<T> | undefined) => p));
         picks.push({


### PR DESCRIPTION
I think the tests suddenly started breaking because VS Code stable must have updated to node 24. Let's see this fixes it.