### PR TITLE
Fix Go functions not appearing under Functions node in workspace view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1158,6 +1158,11 @@
                 "name": "func-python-watch",
                 "label": "%azureFunctions.problemMatchers.funcPythonWatch%",
                 "base": "$func-watch"
+            },
+            {
+                "name": "func-golang-watch",
+                "label": "%azureFunctions.problemMatchers.funcGolangWatch%",
+                "base": "$func-watch"
             }
         ],
         "configuration": [
@@ -1226,6 +1231,7 @@
                             "PowerShell",
                             "Python",
                             "TypeScript",
+                            "Go",
                             "Custom"
                         ],
                         "description": "%azureFunctions.projectLanguage%",
@@ -1239,6 +1245,7 @@
                             "",
                             "",
                             "",
+                            "%azureFunctions.projectLanguage.preview%",
                             "",
                             ""
                         ]

--- a/package.json
+++ b/package.json
@@ -1384,6 +1384,11 @@
                         "description": "%azureFunctions.validateFuncCoreTools%",
                         "default": true
                     },
+                    "azureFunctions.validateDelve": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.validateDelve%",
+                        "default": true
+                    },
                     "azureFunctions.validateEmulators": {
                         "type": "boolean",
                         "description": "%azureFunctions.validateEmulators%",

--- a/package.json
+++ b/package.json
@@ -1389,6 +1389,11 @@
                         "description": "%azureFunctions.validateDelve%",
                         "default": true
                     },
+                    "azureFunctions.validateGo": {
+                        "type": "boolean",
+                        "description": "%azureFunctions.validateGo%",
+                        "default": true
+                    },
                     "azureFunctions.validateEmulators": {
                         "type": "boolean",
                         "description": "%azureFunctions.validateEmulators%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -113,6 +113,7 @@
     "azureFunctions.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
     "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
     "azureFunctions.validateDelve": "Validate that Delve (dlv) is installed before debugging Go Functions.",
+    "azureFunctions.validateGo": "Validate that the Go toolchain is installed before packaging Go Functions for deployment.",
     "azureFunctions.validateEmulators": "Validate that service emulators and connections are properly configured before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",

--- a/package.nls.json
+++ b/package.nls.json
@@ -60,6 +60,7 @@
     "azureFunctions.problemMatchers.funcNodeWatch": "Azure Functions Node.js problems (watch mode)",
     "azureFunctions.problemMatchers.funcPowerShellWatch": "Azure Functions PowerShell problems (watch mode)",
     "azureFunctions.problemMatchers.funcPythonWatch": "Azure Functions Python problems (watch mode)",
+    "azureFunctions.problemMatchers.funcGolangWatch": "Azure Functions Go problems (watch mode)",
     "azureFunctions.problemMatchers.funcWatch": "Azure Functions problems (watch mode)",
     "azureFunctions.projectLanguage": "The default language to use when performing operations like \"Create New Function\".",
     "azureFunctions.projectLanguage.preview": "(Preview)",

--- a/package.nls.json
+++ b/package.nls.json
@@ -112,6 +112,7 @@
     "azureFunctions.toggleAppSettingVisibility": "Toggle App Setting Visibility.",
     "azureFunctions.uninstallFuncCoreTools": "Uninstall Azure Functions Core Tools",
     "azureFunctions.validateFuncCoreTools": "Validate the Azure Functions Core Tools is installed before debugging.",
+    "azureFunctions.validateDelve": "Validate that Delve (dlv) is installed before debugging Go Functions.",
     "azureFunctions.validateEmulators": "Validate that service emulators and connections are properly configured before debugging.",
     "azureFunctions.viewCommitInGitHub": "View Commit in GitHub",
     "azureFunctions.viewDeploymentLogs": "View Deployment Logs",

--- a/src/commands/createFunction/FunctionListStep.ts
+++ b/src/commands/createFunction/FunctionListStep.ts
@@ -115,7 +115,8 @@ export class FunctionListStep extends AzureWizardPromptStep<IFunctionWizardConte
     public shouldPrompt(context: IFunctionWizardContext): boolean {
         return !context.functionTemplate &&
             context['buildTool'] !== JavaBuildTool.maven &&
-            context.language !== ProjectLanguage.SelfHostedMCPServer;
+            context.language !== ProjectLanguage.SelfHostedMCPServer &&
+            context.language !== ProjectLanguage.Go;
     }
 
     private async getPicks(context: IFunctionWizardContext): Promise<IAzureQuickPickItem<FunctionTemplateBase | TemplatePromptResult>[]> {

--- a/src/commands/createFunction/createFunction.ts
+++ b/src/commands/createFunction/createFunction.ts
@@ -6,7 +6,7 @@
 import { AzureWizard, type IActionContext } from '@microsoft/vscode-azext-utils';
 import { type WorkspaceFolder } from 'vscode';
 import { type FuncVersion } from '../../FuncVersion';
-import { projectTemplateKeySetting, type ProjectLanguage } from '../../constants';
+import { ProjectLanguage, projectTemplateKeySetting } from '../../constants';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { localize } from '../../localize';
 import { type LocalProjectTreeItem } from '../../tree/localProject/LocalProjectTreeItem';
@@ -71,6 +71,22 @@ export async function createFunctionInternal(context: IActionContext, options: a
     }
 
     const { language, languageModel, version, templateSchemaVersion } = await verifyInitForVSCode(context, projectPath, options.language, options.languageModel, options.version);
+
+    if (language === ProjectLanguage.Go) {
+        // Go projects scaffold an initial function during "Create New Project" via `func init --worker-runtime go`.
+        // Core tools does not yet support `func new --language Go`, so additional functions must be added by editing
+        // the source files directly. Show a modal so the user can't miss it.
+        context.telemetry.properties.goCreateFunctionUnsupported = 'true';
+        await context.ui.showWarningMessage(
+            localize('goCreateFunctionUnsupported', 'Adding new functions is currently not supported for Go projects'),
+            {
+                modal: true,
+                detail: localize('goCreateFunctionUnsupportedDetail', 'To add another function, edit the Go source files directly.'),
+            },
+        );
+        return;
+    }
+
     const durableStorageType = await durableUtils.getStorageTypeFromWorkspace(language, projectPath);
     context.telemetry.properties.hasDurableStorageProject = String(!!durableStorageType);
     context.telemetry.properties.durableStorageType = durableStorageType;

--- a/src/commands/createNewProject/NewProjectLanguageStep.ts
+++ b/src/commands/createNewProject/NewProjectLanguageStep.ts
@@ -16,6 +16,7 @@ import { type IProjectWizardContext } from './IProjectWizardContext';
 import { ProgrammingModelStep } from './ProgrammingModelStep';
 import { CustomProjectCreateStep } from './ProjectCreateStep/CustomProjectCreateStep';
 import { DotnetProjectCreateStep } from './ProjectCreateStep/DotnetProjectCreateStep';
+import { GoProjectCreateStep } from './ProjectCreateStep/GoProjectCreateStep';
 import { JavaScriptProjectCreateStep } from './ProjectCreateStep/JavaScriptProjectCreateStep';
 import { PowerShellProjectCreateStep } from './ProjectCreateStep/PowerShellProjectCreateStep';
 import { PythonProjectCreateStep } from './ProjectCreateStep/PythonProjectCreateStep';
@@ -49,6 +50,7 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.TypeScript, data: { language: ProjectLanguage.TypeScript } },
             { label: ProjectLanguage.CSharp, data: { language: ProjectLanguage.CSharp } },
             { label: ProjectLanguage.Python, data: { language: ProjectLanguage.Python } },
+            { label: ProjectLanguage.Go, data: { language: ProjectLanguage.Go } },
             { label: ProjectLanguage.Java, data: { language: ProjectLanguage.Java } },
             { label: ProjectLanguage.PowerShell, data: { language: ProjectLanguage.PowerShell } },
             { label: localize('customHandler', 'Custom Handler'), data: { language: ProjectLanguage.Custom } },
@@ -116,6 +118,9 @@ export class NewProjectLanguageStep extends AzureWizardPromptStep<IProjectWizard
                 break;
             case ProjectLanguage.PowerShell:
                 executeSteps.push(new PowerShellProjectCreateStep());
+                break;
+            case ProjectLanguage.Go:
+                executeSteps.push(new GoProjectCreateStep());
                 break;
             case ProjectLanguage.Java:
                 await addJavaCreateProjectSteps(context, promptSteps, executeSteps);

--- a/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import { type Progress } from 'vscode';
+import { ext } from '../../../extensionVariables';
+import { getFuncCliPath } from '../../../funcCoreTools/getFuncCliPath';
+import { localize } from '../../../localize';
+import { cpUtils } from '../../../utils/cpUtils';
+import { type IProjectWizardContext } from '../IProjectWizardContext';
+import { ProjectCreateStepBase } from './ProjectCreateStepBase';
+
+export class GoProjectCreateStep extends ProjectCreateStepBase {
+    public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
+        progress.report({ message: localize('initializingGoProject', 'Initializing Go Functions project...') });
+
+        const funcCliPath = await getFuncCliPath(context, context.workspaceFolder);
+        // Core tools accepts "go" as the worker-runtime CLI argument and maps it to the "native" worker runtime internally.
+        const args = composeArgs(
+            withArg('init'),
+            withArg('--worker-runtime', 'go'),
+            withArg('--no-source-control'),
+        )();
+
+        await cpUtils.executeCommand(ext.outputChannel, context.projectPath, funcCliPath, args);
+    }
+}

--- a/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
+++ b/src/commands/createNewProject/ProjectCreateStep/GoProjectCreateStep.ts
@@ -3,27 +3,138 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { AzExtFsExtra, UserCancelledError } from '@microsoft/vscode-azext-utils';
 import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import * as path from 'path';
 import { type Progress } from 'vscode';
 import { ext } from '../../../extensionVariables';
-import { getFuncCliPath } from '../../../funcCoreTools/getFuncCliPath';
+import { validateGoInstalled } from '../../../funcCoreTools/validateGoInstalled';
 import { localize } from '../../../localize';
 import { cpUtils } from '../../../utils/cpUtils';
+import { confirmOverwriteFile } from '../../../utils/fs';
 import { type IProjectWizardContext } from '../IProjectWizardContext';
-import { ProjectCreateStepBase } from './ProjectCreateStepBase';
+import { ScriptProjectCreateStep } from './ScriptProjectCreateStep';
 
-export class GoProjectCreateStep extends ProjectCreateStepBase {
+export class GoProjectCreateStep extends ScriptProjectCreateStep {
+    protected gitignore: string = goGitignore;
+
     public async executeCore(context: IProjectWizardContext, progress: Progress<{ message?: string | undefined; increment?: number | undefined }>): Promise<void> {
         progress.report({ message: localize('initializingGoProject', 'Initializing Go Functions project...') });
 
-        const funcCliPath = await getFuncCliPath(context, context.workspaceFolder);
-        // Core tools accepts "go" as the worker-runtime CLI argument and maps it to the "native" worker runtime internally.
-        const args = composeArgs(
-            withArg('init'),
-            withArg('--worker-runtime', 'go'),
-            withArg('--no-source-control'),
-        )();
+        if (!await validateGoInstalled(context, context.projectPath)) {
+            throw new UserCancelledError('validateGoInstalled');
+        }
 
-        await cpUtils.executeCommand(ext.outputChannel, context.projectPath, funcCliPath, args);
+        await super.executeCore(context, progress);
+
+        // local.settings.json was written by super; add the Go preview flag
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.localSettingsJson.Values!['FUNCTIONS_CLI_NATIVE_LANGUAGE'] = 'true';
+        await AzExtFsExtra.writeJSON(path.join(context.projectPath, 'local.settings.json'), this.localSettingsJson);
+
+        const moduleName: string = path.basename(context.projectPath);
+
+        const mainGoPath: string = path.join(context.projectPath, 'main.go');
+        if (await confirmOverwriteFile(context, mainGoPath)) {
+            await AzExtFsExtra.writeFile(mainGoPath, goMainTemplate);
+        }
+
+        const goModPath: string = path.join(context.projectPath, 'go.mod');
+        if (await confirmOverwriteFile(context, goModPath)) {
+            await AzExtFsExtra.writeFile(goModPath, getGoModTemplate(moduleName));
+        }
+
+        // Generate go.sum so `func start` / `go build` can resolve dependencies immediately.
+        await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'go', composeArgs(withArg('mod', 'tidy'))());
     }
 }
+
+const goMainTemplate: string = `package main
+
+import (
+\t"log"
+\t"net/http"
+
+\t"github.com/azure/azure-functions-golang-worker/sdk"
+\t"github.com/azure/azure-functions-golang-worker/worker"
+)
+
+// HTTPTriggerHandler handles standard HTTP requests
+func HTTPTriggerHandler(w http.ResponseWriter, r *http.Request) {
+\tlog.Printf("Processing HTTP Trigger for %s", r.URL.Path)
+\tw.WriteHeader(http.StatusOK)
+\tw.Write([]byte("Hello from Go Worker!"))
+}
+
+func main() {
+\tapp := sdk.FunctionApp()
+\tapp.HTTP("hello", HTTPTriggerHandler,
+\t\tsdk.WithMethods("GET", "POST"),
+\t\tsdk.WithAuth("anonymous"),
+\t)
+\tworker.Start(app)
+}
+`;
+
+function getGoModTemplate(moduleName: string): string {
+    return `module ${moduleName}
+
+go 1.24.0
+
+require github.com/azure/azure-functions-golang-worker v0.6.0-preview
+`;
+}
+
+// Matches the .gitignore that func init --worker-runtime go produces.
+const goGitignore: string = `bin/
+**/bin/
+!Modules/**
+obj
+csx
+.vs
+edge
+Publish
+
+*.user
+*.suo
+*.cscfg
+*.Cache
+project.lock.json
+
+/packages
+/TestResults
+
+/tools/NuGet.exe
+/App_Data
+/secrets
+/data
+.secrets
+appsettings.json
+local.settings.json
+
+node_modules
+dist
+
+# Local python packages
+.python_packages/
+
+# Python Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Azurite artifacts
+__blobstorage__
+__queuestorage__
+__azurite_db*__.json
+`;
+

--- a/src/commands/deploy/deploy.ts
+++ b/src/commands/deploy/deploy.ts
@@ -6,13 +6,14 @@
 import { type Site, type SiteConfigResource } from '@azure/arm-appservice';
 import { getDeployFsPath, getDeployNode, deploy as innerDeploy, showDeployConfirmation, type IDeployContext, type IDeployPaths, type InnerDeployContext, type ParsedSite } from '@microsoft/vscode-azext-azureappservice';
 import { ResourceGroupListStep } from '@microsoft/vscode-azext-azureutils';
-import { AzureWizard, DialogResponses, subscriptionExperience, type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from '@microsoft/vscode-azext-utils';
+import { AzureWizard, DialogResponses, subscriptionExperience, UserCancelledError, type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from '@microsoft/vscode-azext-utils';
 import { type AzureSubscription } from '@microsoft/vscode-azureresources-api';
 import type * as vscode from 'vscode';
 import { CodeAction, deploySubpathSetting, DurableBackend, hostFileName, ProjectLanguage, remoteBuildSetting, ScmType, stackUpgradeLearnMoreLink } from '../../constants';
 import { ext } from '../../extensionVariables';
 import { addLocalFuncTelemetry } from '../../funcCoreTools/getLocalFuncCoreToolsVersion';
 import { validateFuncCoreToolsInstalled } from '../../funcCoreTools/validateFuncCoreToolsInstalled';
+import { validateGoInstalled } from '../../funcCoreTools/validateGoInstalled';
 import { localize } from '../../localize';
 import { ResolvedFunctionAppResource } from '../../tree/ResolvedFunctionAppResource';
 import { type SlotTreeItem } from '../../tree/SlotTreeItem';
@@ -129,6 +130,22 @@ async function deploy(actionContext: IActionContext, arg1: vscode.Uri | string |
     if (language === ProjectLanguage.Python && !site.isLinux) {
         context.errorHandling.suppressReportIssue = true;
         throw new Error(localize('pythonNotAvailableOnWindows', 'Python projects are not supported on Windows Function Apps. Deploy to a Linux Function App instead.'));
+    }
+
+    if (language === ProjectLanguage.Go) {
+        // func pack produces a linux/amd64 binary, so a zip will deploy successfully to a
+        // Windows app but the worker will fail to start at runtime. Catch this up front.
+        if (!site.isLinux) {
+            context.errorHandling.suppressReportIssue = true;
+            throw new Error(localize('goNotAvailableOnWindows', 'Go projects are not supported on Windows Function Apps. Deploy to a Linux Flex Function App instead.'));
+        }
+
+        // `func pack` builds the Go binary locally using the user's installed Go
+        // toolchain, so Go must be on PATH before any pre-deploy work runs.
+        if (!await validateGoInstalled(context, context.workspaceFolder.uri.fsPath)) {
+            context.errorHandling.suppressReportIssue = true;
+            throw new UserCancelledError('validateGoInstalled');
+        }
     }
 
     void showCoreToolsWarning(context, version, site.fullName);

--- a/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeLanguageStep.ts
@@ -12,6 +12,7 @@ import { type IProjectWizardContext } from '../createNewProject/IProjectWizardCo
 import { BallerinaInitVSCodeStep } from './InitVSCodeStep/BallerinaInitVSCodeStep';
 import { DotnetInitVSCodeStep } from './InitVSCodeStep/DotnetInitVSCodeStep';
 import { DotnetScriptInitVSCodeStep } from './InitVSCodeStep/DotnetScriptInitVSCodeStep';
+import { GoInitVSCodeStep } from './InitVSCodeStep/GoInitVSCodeStep';
 import { JavaScriptInitVSCodeStep } from './InitVSCodeStep/JavaScriptInitVSCodeStep';
 import { MCPServerInitVSCodeStep } from './InitVSCodeStep/MCPServerInitVSCodeStep';
 import { PowerShellInitVSCodeStep } from './InitVSCodeStep/PowerShellInitVSCodeStep';
@@ -31,6 +32,7 @@ export class InitVSCodeLanguageStep extends AzureWizardPromptStep<IProjectWizard
             { label: ProjectLanguage.CSharpScript, data: { language: ProjectLanguage.CSharpScript } },
             { label: ProjectLanguage.FSharp, data: { language: ProjectLanguage.FSharp } },
             { label: ProjectLanguage.FSharpScript, data: { language: ProjectLanguage.FSharpScript } },
+            { label: ProjectLanguage.Go, data: { language: ProjectLanguage.Go } },
             { label: ProjectLanguage.Java, data: { language: ProjectLanguage.Java } },
             { label: ProjectLanguage.JavaScript, data: { language: ProjectLanguage.JavaScript } },
             { label: ProjectLanguage.PowerShell, data: { language: ProjectLanguage.PowerShell } },
@@ -89,6 +91,9 @@ export async function addInitVSCodeSteps(
             break;
         case ProjectLanguage.Ballerina:
             executeSteps.push(new BallerinaInitVSCodeStep());
+            break;
+        case ProjectLanguage.Go:
+            executeSteps.push(new GoInitVSCodeStep());
             break;
         case ProjectLanguage.SelfHostedMCPServer:
             executeSteps.push(new MCPServerInitVSCodeStep());

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
@@ -5,21 +5,10 @@
 
 import { type DebugConfiguration, type TaskDefinition } from 'vscode';
 import { func, hostStartCommand, hostStartTaskName, type ProjectLanguage } from '../../../constants';
+import { goDebugConfig } from '../../../debug/GoDebugProvider';
 import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
 import { type IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
 import { InitVSCodeStepBase } from './InitVSCodeStepBase';
-
-// Default Delve DAP port used by GoDebugProvider. Inlined here so PR 1 is self-contained;
-// PR 2 will introduce GoDebugProvider and may re-export this config.
-export const goDebugConfig: DebugConfiguration = {
-    name: 'Attach to Go Functions',
-    type: 'go',
-    request: 'attach',
-    mode: 'remote',
-    port: 2345,
-    host: '127.0.0.1',
-    preLaunchTask: hostStartTaskName,
-};
 
 export class GoInitVSCodeStep extends InitVSCodeStepBase {
     stepName: string = 'GoInitVSCodeStep';

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
@@ -3,18 +3,24 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as path from 'path';
 import { type DebugConfiguration, type TaskDefinition } from 'vscode';
-import { func, hostStartCommand, hostStartTaskName, type ProjectLanguage } from '../../../constants';
+import { func, hostStartCommand, hostStartTaskName, packCommand, packTaskName, remoteBuildSetting, type ProjectLanguage } from '../../../constants';
 import { goDebugConfig } from '../../../debug/GoDebugProvider';
 import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
 import { type IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
 import { InitVSCodeStepBase } from './InitVSCodeStepBase';
+import { ensureGitIgnoreContents } from './PythonInitVSCodeStep';
 
 export class GoInitVSCodeStep extends InitVSCodeStepBase {
     stepName: string = 'GoInitVSCodeStep';
+    protected preDeployTask: string = packTaskName;
 
     protected async executeCore(context: IProjectWizardContext): Promise<void> {
-        this.setDeploySubpath(context, '.');
+        const zipFileName: string = path.basename(context.projectPath) + '.zip';
+        this.setDeploySubpath(context, zipFileName);
+        this.settings.push({ key: remoteBuildSetting, value: false });
+        await ensureGitIgnoreContents(context.projectPath, [zipFileName]);
     }
 
     protected getTasks(language: ProjectLanguage): TaskDefinition[] {
@@ -25,6 +31,11 @@ export class GoInitVSCodeStep extends InitVSCodeStepBase {
                 command: hostStartCommand,
                 problemMatcher: getFuncWatchProblemMatcher(language),
                 isBackground: true,
+            },
+            {
+                type: func,
+                label: packTaskName,
+                command: packCommand,
             },
         ];
     }

--- a/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
+++ b/src/commands/initProjectForVSCode/InitVSCodeStep/GoInitVSCodeStep.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { type DebugConfiguration, type TaskDefinition } from 'vscode';
+import { func, hostStartCommand, hostStartTaskName, type ProjectLanguage } from '../../../constants';
+import { getFuncWatchProblemMatcher } from '../../../vsCodeConfig/settings';
+import { type IProjectWizardContext } from '../../createNewProject/IProjectWizardContext';
+import { InitVSCodeStepBase } from './InitVSCodeStepBase';
+
+// Default Delve DAP port used by GoDebugProvider. Inlined here so PR 1 is self-contained;
+// PR 2 will introduce GoDebugProvider and may re-export this config.
+export const goDebugConfig: DebugConfiguration = {
+    name: 'Attach to Go Functions',
+    type: 'go',
+    request: 'attach',
+    mode: 'remote',
+    port: 2345,
+    host: '127.0.0.1',
+    preLaunchTask: hostStartTaskName,
+};
+
+export class GoInitVSCodeStep extends InitVSCodeStepBase {
+    stepName: string = 'GoInitVSCodeStep';
+
+    protected async executeCore(context: IProjectWizardContext): Promise<void> {
+        this.setDeploySubpath(context, '.');
+    }
+
+    protected getTasks(language: ProjectLanguage): TaskDefinition[] {
+        return [
+            {
+                type: func,
+                label: hostStartTaskName,
+                command: hostStartCommand,
+                problemMatcher: getFuncWatchProblemMatcher(language),
+                isBackground: true,
+            },
+        ];
+    }
+
+    protected getDebugConfiguration(): DebugConfiguration {
+        return goDebugConfig;
+    }
+
+    protected getRecommendedExtensions(): string[] {
+        return ['golang.go'];
+    }
+}

--- a/src/commands/initProjectForVSCode/detectProjectLanguage.ts
+++ b/src/commands/initProjectForVSCode/detectProjectLanguage.ts
@@ -5,7 +5,7 @@
 
 import { AzExtFsExtra, type IActionContext } from '@microsoft/vscode-azext-utils';
 import * as path from 'path';
-import { ProjectLanguage, ballerinaTomlFileName, buildGradleFileName, localSettingsFileName, packageJsonFileName, pomXmlFileName, previewPythonModel, pythonFunctionAppFileName, workerRuntimeKey } from '../../constants';
+import { ProjectLanguage, ballerinaTomlFileName, buildGradleFileName, goModFileName, localSettingsFileName, packageJsonFileName, pomXmlFileName, previewPythonModel, pythonFunctionAppFileName, workerRuntimeKey } from '../../constants';
 import { getLocalSettingsJson, type ILocalSettingsJson } from '../../funcConfig/local.settings';
 import { dotnetUtils } from '../../utils/dotnetUtils';
 import { hasNodeJsDependency, tryGetPackageJson } from '../../utils/nodeJsUtils';
@@ -45,6 +45,10 @@ export async function detectProjectLanguage(context: IActionContext, projectPath
 
         if (await isBallerinaProject(projectPath)) {
             detectedLangs.push(ProjectLanguage.Ballerina);
+        }
+
+        if (await isGoProject(projectPath)) {
+            detectedLangs.push(ProjectLanguage.Go);
         }
 
         await detectLanguageFromLocalSettings(context, detectedLangs, projectPath);
@@ -89,6 +93,10 @@ export async function isBallerinaProject(projectPath: string): Promise<boolean> 
     return await AzExtFsExtra.pathExists(path.join(projectPath, ballerinaTomlFileName));
 }
 
+export async function isGoProject(projectPath: string): Promise<boolean> {
+    return await AzExtFsExtra.pathExists(path.join(projectPath, goModFileName));
+}
+
 /**
  * If the user has a "local.settings.json" file, we may be able to infer the langauge from the setting "FUNCTIONS_WORKER_RUNTIME"
  */
@@ -107,6 +115,10 @@ async function detectLanguageFromLocalSettings(context: IActionContext, detected
                 break;
             case 'custom':
                 detectedLangs.push(ProjectLanguage.Custom);
+                break;
+            case 'native':
+                // `native` is currently produced only by Go (see getRootFunctionsWorkerRuntime).
+                detectedLangs.push(ProjectLanguage.Go);
                 break;
             default:
             // setting doesn't exist or it could be multiple different languages (aka "node" could by JavaScript or TypeScript)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,6 +77,7 @@ export enum JavaBuildTool {
 }
 
 export const ballerinaTomlFileName: string = "Ballerina.toml";
+export const goModFileName: string = 'go.mod';
 export enum BallerinaBackend {
     jvm = 'jvm',
     native = 'native'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export enum ProjectLanguage {
     JavaScript = 'JavaScript',
     PowerShell = 'PowerShell',
     Python = 'Python',
+    Go = 'Go',
     TypeScript = 'TypeScript',
     Ballerina = 'Ballerina',
     Custom = 'Custom',

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -63,6 +63,10 @@ export class FuncTaskProvider implements TaskProvider {
                                 commands.push(`${packCommand} ${buildNativeDeps}`);
                             }
 
+                            if (language === ProjectLanguage.Go) {
+                                commands.push(packCommand);
+                            }
+
                             for (const command of commands) {
                                 result.push(await this.createTask(context, command, folder, projectRoot, language));
                             }

--- a/src/debug/GoDebugProvider.ts
+++ b/src/debug/GoDebugProvider.ts
@@ -1,0 +1,386 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, isUserCancelledError, UserCancelledError, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { spawn, type ChildProcess } from 'child_process';
+import { createConnection } from 'net';
+import psTree, { type PS } from 'ps-tree';
+import * as vscode from 'vscode';
+import { type CancellationToken, type DebugConfiguration, type WorkspaceFolder } from 'vscode';
+import { hostStartTaskName, hostStartTaskNameRegExp, localhost } from '../constants';
+import { ext } from '../extensionVariables';
+import { runningFuncTaskMap, type IRunningFuncTask } from '../funcCoreTools/funcHostTask';
+import { localize } from '../localize';
+import { cpUtils } from '../utils/cpUtils';
+import { delay } from '../utils/delay';
+import { getWindowsProcessTree, ProcessDataFlag, type IProcessInfo, type IWindowsProcessTree } from '../utils/windowsProcessTree';
+import { FuncDebugProviderBase } from './FuncDebugProviderBase';
+import { validateDelveInstalled } from './validateDelveInstalled';
+
+export const defaultGoDebugPort: number = 2345;
+
+export const goDebugConfig: DebugConfiguration = {
+    name: localize('attachGo', 'Attach to Go Functions'),
+    type: 'go',
+    request: 'attach',
+    mode: 'remote',
+    port: defaultGoDebugPort,
+    host: localhost,
+    preLaunchTask: hostStartTaskName,
+};
+
+// The Go worker binary is always named `app` (or `app.exe` on Windows) by the
+// Functions core tools. If core tools changes that convention, this needs to
+// change too.
+const goWorkerProcessName: string = 'app';
+
+// How long to wait for the Go worker process to appear after `func host start`
+// kicks off. The build step is part of `func host start`, so this needs to
+// cover compile time as well.
+const workerPollTimeoutMs: number = 120_000;
+const workerPollIntervalMs: number = 1_000;
+// How long to wait for dlv to start listening on the debug port after we spawn it.
+const dlvListenTimeoutMs: number = 10_000;
+const dlvListenRetryIntervalMs: number = 500;
+// Brief pause to let a freed port settle after killing a stale dlv.
+const stalePortFreedDelayMs: number = 1_000;
+
+// Tracks the dlv child process we spawned per workspace folder so we can
+// terminate it proactively when the matching debug session ends. Keyed by
+// `WorkspaceFolder.uri.fsPath`. If a second debug session targets the same
+// folder before the first ends, the previous entry is killed and replaced.
+const activeDlvProcesses = new Map<string, ChildProcess>();
+
+/**
+ * Wires the dlv-cleanup-on-session-end behavior. Call once during extension
+ * activation; the returned disposable should be added to context.subscriptions.
+ */
+export function registerGoDebugSessionCleanup(): vscode.Disposable {
+    return vscode.debug.onDidTerminateDebugSession((session) => {
+        if (session.type !== 'go' || !session.workspaceFolder) {
+            return;
+        }
+        // Only act on Functions debug sessions. A user may have a non-Functions Go debug
+        // session open in the same folder; the `func: host start` preLaunchTask is the same
+        // discriminator we use in resolveDebugConfiguration to decide whether to spawn dlv,
+        // so checking it here keeps the spawn and cleanup gates symmetric.
+        const preLaunchTask = session.configuration.preLaunchTask as string | undefined;
+        if (!preLaunchTask || !hostStartTaskNameRegExp.test(preLaunchTask)) {
+            return;
+        }
+        killTrackedDlv(session.workspaceFolder.uri.fsPath);
+    });
+}
+
+function killTrackedDlv(folderFsPath: string): void {
+    const dlv = activeDlvProcesses.get(folderFsPath);
+    if (!dlv) {
+        return;
+    }
+    activeDlvProcesses.delete(folderFsPath);
+    if (dlv.pid === undefined) {
+        return;
+    }
+    try {
+        if (process.platform === 'win32') {
+            // Windows has no process groups — just terminate dlv directly.
+            dlv.kill();
+        } else {
+            // dlv was spawned with `detached: true`, which makes it the leader of a
+            // new process group. Signal the whole group (negative pid) so any
+            // descendants dlv may have spawned are cleaned up too.
+            process.kill(-dlv.pid, 'SIGTERM');
+        }
+        ext.outputChannel.appendLog(localize('dlvCleanedUp', 'Cleaned up Delve process (PID {0}) for "{1}".', dlv.pid, folderFsPath));
+    } catch {
+        // Process already gone — fine.
+    }
+}
+
+export class GoDebugProvider extends FuncDebugProviderBase {
+    // Delve attaches to the worker process out-of-band. These satisfy the
+    // abstract members on FuncDebugProviderBase but are never read because
+    // FuncTaskProvider has no `case ProjectLanguage.Go` branch.
+    public readonly workerArgKey: string = 'GOLANG_WORKER_DEBUG_FLAGS';
+    protected readonly defaultPortOrPipeName: number = defaultGoDebugPort;
+    protected readonly debugConfig: DebugConfiguration = goDebugConfig;
+
+    public async getWorkerArgValue(_folder: WorkspaceFolder): Promise<string> {
+        return '';
+    }
+
+    // resolveDebugConfiguration is a hook VS Code calls every time a debug session is about to start
+    // GoDebugProvider overrides FuncDebugProviderBase.resolveDebugConfiguration
+    public async resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: DebugConfiguration, token?: CancellationToken): Promise<DebugConfiguration | undefined> {
+        const result = await super.resolveDebugConfiguration(folder, debugConfiguration, token);
+        if (!result || result.mode !== 'remote') {
+            return result;
+        }
+
+        // Mirror the gate in FuncDebugProviderBase: only run our Functions-specific
+        // dlv-attach lifecycle when the debug session is actually for a Functions
+        // project (signalled by the `func: host start` preLaunchTask).
+        if (!hostStartTaskNameRegExp.test(debugConfiguration.preLaunchTask as string)) {
+            return result;
+        }
+
+        const port: number = (typeof result.port === 'number' ? result.port : defaultGoDebugPort);
+
+        const delveAvailable = await callWithTelemetryAndErrorHandling('azureFunctions.go.validateDelveBeforeDebug', async (context: IActionContext) => {
+            context.errorHandling.suppressDisplay = true;
+            const message = localize('installDelve', 'Delve (dlv) is required to debug Go Functions. Install Delve and try again.');
+            return await validateDelveInstalled(context, message, folder?.uri.fsPath);
+        });
+
+        if (!delveAvailable) {
+            return undefined;
+        }
+
+        // Fire-and-forget: the preLaunchTask (`func host start`) builds and
+        // launches the Go worker concurrently with this. The poller watches
+        // for that worker, then spawns `dlv attach` so VS Code's Go extension
+        // can connect to dlv's DAP server on `port`.
+        void pollAndAttachDlv(port, folder, token);
+
+        return result;
+    }
+}
+
+async function pollAndAttachDlv(port: number, folder: WorkspaceFolder | undefined, token: CancellationToken | undefined): Promise<void> {
+    await callWithTelemetryAndErrorHandling('azureFunctions.go.attachDlv', async (context: IActionContext) => {
+        context.errorHandling.suppressDisplay = true;
+        context.telemetry.properties.dlvPort = String(port);
+
+        if (!folder) {
+            // findGoWorkerPid keys off runningFuncTaskMap[folder]; with no folder there is
+            // nothing to look up and the 120s poll would spin without ever finding a worker.
+            context.telemetry.properties.dlvAttachResult = 'noWorkspaceFolder';
+            ext.outputChannel.appendLog(localize('dlvNoFolder', 'No workspace folder for the Go debug session; skipping dlv auto-attach.'));
+            return;
+        }
+
+        try {
+            // 1. Free the port if a prior session's dlv is still listening on it.
+            await killStaleDlv(port);
+            throwIfCancelled(token);
+
+            // 2. Wait for `func host start` to build and launch the Go worker, then capture its PID.
+            const pid = await pollForGoWorkerPid(workerPollTimeoutMs, folder, token);
+            throwIfCancelled(token);
+            if (pid === undefined) {
+                context.telemetry.properties.dlvAttachResult = 'workerNotFound';
+                ext.outputChannel.appendLog(localize('dlvWorkerNotFound', 'Could not find Go worker process "{0}" within {1}s. Skipping dlv auto-attach.', goWorkerProcessName, workerPollTimeoutMs / 1_000));
+                return;
+            }
+            context.telemetry.measurements.dlvWorkerPid = pid;
+
+            // 3. Bail if dlv is already listening on the port. The window between killStaleDlv
+            // (step 1) and our spawn is long, so a parallel poller (rapid restart, second window)
+            // may have already attached. Let VS Code connect to whatever's there rather than
+            // spawning a duplicate that would fail with EADDRINUSE.
+            if (await isPortInUse(port)) {
+                context.telemetry.properties.dlvAttachResult = 'portTaken';
+                ext.outputChannel.appendLog(localize('dlvPortTaken', 'Port {0} is already in use; assuming dlv is already attached.', port));
+                return;
+            }
+
+            // 4. Spawn dlv, attaching to the worker PID. Detached so it outlives this poller.
+            const dlvProcess = spawn('dlv', [
+                'attach', String(pid),
+                '--headless',
+                // --continue is required: without it, dlv pauses the worker and the
+                // Functions host kills the worker for being unresponsive.
+                '--continue',
+                `--listen=:${port}`,
+                '--api-version=2',
+                '--accept-multiclient',
+            ], {
+                detached: true,
+                // Pipe stdio so we can surface dlv errors. Without this the spawn
+                // is a black box on failure.
+                stdio: ['ignore', 'pipe', 'pipe'],
+            });
+
+            // 5. Surface spawn errors and dlv's own output to the Azure Functions output channel.
+            dlvProcess.on('error', (err) => {
+                ext.outputChannel.appendLog(localize('dlvSpawnFailed', 'Failed to spawn Delve: {0}', err.message));
+            });
+            dlvProcess.on('exit', () => {
+                // remove dead entries from the tracking map so killTrackedDlv
+                // doesn't log spurious "Cleaned up" lines later.
+                activeDlvProcesses.delete(folder.uri.fsPath);
+            });
+            dlvProcess.stdout?.on('data', (chunk: Buffer) => {
+                ext.outputChannel.append(`[dlv] ${chunk.toString()}`);
+            });
+            dlvProcess.stderr?.on('data', (chunk: Buffer) => {
+                ext.outputChannel.append(`[dlv] ${chunk.toString()}`);
+            });
+            dlvProcess.unref();
+
+            // 6. Track this dlv for proactive cleanup on session end. If a previous dlv was
+            // tracked for this folder (rapid restart), kill it first so it doesn't become orphaned.
+            killTrackedDlv(folder.uri.fsPath);
+            activeDlvProcesses.set(folder.uri.fsPath, dlvProcess);
+
+            // 7. Block until dlv is actually listening, so VS Code's Go extension has a port to connect to.
+            await waitForPort(port, dlvListenTimeoutMs, token);
+            throwIfCancelled(token);
+            context.telemetry.properties.dlvAttachResult = 'attached';
+            ext.outputChannel.appendLog(localize('dlvAttached', 'Delve attached to Go worker (PID {0}) and listening on port {1}.', pid, port));
+        } catch (err) {
+            // Clean up any dlv we already spawned before failing - killTrackedDlv is idempotent.
+            killTrackedDlv(folder.uri.fsPath);
+
+            if (isUserCancelledError(err)) {
+                // callWithTelemetryAndErrorHandling marks the event as cancelled and stays silent.
+                throw err;
+            }
+            context.telemetry.properties.dlvAttachResult = 'failed';
+            const message = err instanceof Error ? err.message : String(err);
+            ext.outputChannel.appendLog(localize('dlvAttachFailed', 'Failed to auto-attach Delve: {0}', message));
+            throw err;
+        }
+    });
+}
+
+async function killStaleDlv(port: number): Promise<void> {
+    if (!await isPortInUse(port)) {
+        return;
+    }
+
+    if (process.platform === 'win32') {
+        // netstat → find PID listening on port → tasklist → confirm it's dlv.exe → taskkill.
+        const netstat = await cpUtils.tryExecuteCommandLine(undefined, undefined, `netstat -ano | findstr ":${port}" | findstr "LISTENING"`);
+        if (netstat.code !== 0) {
+            return;
+        }
+        const match = netstat.cmdOutput.match(/LISTENING\s+(\d+)/);
+        if (!match) {
+            return;
+        }
+        const pid = match[1];
+        const taskInfo = await cpUtils.tryExecuteCommandLine(undefined, undefined, `tasklist /FI "PID eq ${pid}" /FO CSV /NH`);
+        if (taskInfo.code !== 0 || !taskInfo.cmdOutput.toLowerCase().includes('dlv.exe')) {
+            return;
+        }
+        await cpUtils.tryExecuteCommandLine(undefined, undefined, `taskkill /PID ${pid} /F`);
+    } else {
+        const lsof = await cpUtils.tryExecuteCommandLine(undefined, undefined, `lsof -ti :${port}`);
+        if (lsof.code !== 0) {
+            return;
+        }
+        const pid = lsof.cmdOutput.trim().split('\n')[0];
+        if (!pid) {
+            return;
+        }
+        const psInfo = await cpUtils.tryExecuteCommandLine(undefined, undefined, `ps -p ${pid} -o comm=`);
+        if (psInfo.code !== 0 || psInfo.cmdOutput.trim() !== 'dlv') {
+            return;
+        }
+        await cpUtils.tryExecuteCommandLine(undefined, undefined, `kill -9 ${pid}`);
+    }
+
+    await delay(stalePortFreedDelayMs);
+}
+
+async function pollForGoWorkerPid(timeoutMs: number, folder: WorkspaceFolder | undefined, token: CancellationToken | undefined): Promise<number | undefined> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        throwIfCancelled(token);
+        const pid = await findGoWorkerPid(folder);
+        if (pid !== undefined) {
+            return pid;
+        }
+        await delay(workerPollIntervalMs);
+    }
+    return undefined;
+}
+
+/**
+ * Resolves the PID of *this* debug session's Go worker by walking the children
+ * of the func host process tracked in `runningFuncTaskMap`. Scoping by parent
+ * avoids attaching to an unrelated `app.exe` that happens to be running on the
+ * machine, and naturally distinguishes between concurrent Functions debug
+ * sessions in different VS Code windows (each window has its own func host).
+ */
+async function findGoWorkerPid(folder: WorkspaceFolder | undefined): Promise<number | undefined> {
+    if (!folder) {
+        return undefined;
+    }
+    // Use getAll instead of get(folder) because get() filters by cwd, which we
+    // don't have at debug-resolve time. getAll returns every task tracked for
+    // this folder; for our use case there's at most one func host per folder.
+    const hostTask = runningFuncTaskMap.getAll(folder).find((t): t is IRunningFuncTask => t !== undefined);
+    if (hostTask === undefined) {
+        return undefined;
+    }
+    const children = await listDescendantProcesses(hostTask.processId);
+    const goWorker = children.find(c => isGoWorkerProcess(c.name));
+    return goWorker?.pid;
+}
+
+interface DescendantProcess {
+    pid: number;
+    name: string | undefined;
+}
+
+async function listDescendantProcesses(rootPid: number): Promise<DescendantProcess[]> {
+    if (process.platform === 'win32') {
+        const tree: IWindowsProcessTree = getWindowsProcessTree();
+        const procs: IProcessInfo[] | undefined = await new Promise((resolve) => {
+            tree.getProcessList(rootPid, resolve, ProcessDataFlag.None);
+        });
+        return (procs ?? []).map(p => ({ pid: p.pid, name: p.name }));
+    }
+
+    // ps-tree typings omit COMM but it's the actual field on some platforms.
+    // See pickFuncProcess.ts for the same workaround.
+    type ActualUnixPS = PS & { COMM?: string };
+    const procs: ActualUnixPS[] = await new Promise((resolve, reject) => {
+        psTree(rootPid, (err: Error | null, result: PS[]) => err ? reject(err) : resolve(result as ActualUnixPS[]));
+    });
+    return procs.map(p => ({ pid: parseInt(p.PID, 10), name: p.COMMAND ?? p.COMM }));
+}
+
+function isGoWorkerProcess(name: string | undefined): boolean {
+    if (!name) {
+        return false;
+    }
+    const lower = name.toLowerCase();
+    return lower === goWorkerProcessName || lower === `${goWorkerProcessName}.exe`;
+}
+
+async function isPortInUse(port: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const socket = createConnection({ port, host: localhost });
+        socket.once('connect', () => {
+            socket.destroy();
+            resolve(true);
+        });
+        socket.once('error', () => {
+            socket.destroy();
+            resolve(false);
+        });
+    });
+}
+
+async function waitForPort(port: number, timeoutMs: number, token: CancellationToken | undefined): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        throwIfCancelled(token);
+        if (await isPortInUse(port)) {
+            return;
+        }
+        await delay(dlvListenRetryIntervalMs);
+    }
+    throw new Error(localize('dlvListenTimeout', 'Timed out waiting for Delve to start listening on port {0} within {1}s.', port, timeoutMs / 1_000));
+}
+
+function throwIfCancelled(token: CancellationToken | undefined): void {
+    if (token?.isCancellationRequested) {
+        throw new UserCancelledError('go.dlv.attach');
+    }
+}

--- a/src/debug/validateDelveInstalled.ts
+++ b/src/debug/validateDelveInstalled.ts
@@ -1,0 +1,60 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import { type MessageItem } from 'vscode';
+import { cpUtils } from '../utils/cpUtils';
+import { openUrl } from '../utils/openUrl';
+import { getWorkspaceSetting } from '../vsCodeConfig/settings';
+
+const dlvCommand: string = 'dlv';
+const dlvInstallUrl: string = 'https://github.com/go-delve/delve/tree/master/Documentation/installation';
+
+/**
+ * Verifies that Delve (`dlv`) is available on PATH before starting a Go debug
+ * session. If missing, prompts the user with a "Learn more" button that opens
+ * the Delve install docs.
+ *
+ * Honors the `azureFunctions.validateDelve` workspace setting (default true).
+ *
+ * @returns true if Delve is installed (or validation is disabled), false otherwise.
+ */
+export async function validateDelveInstalled(_context: IActionContext, message: string, workspacePath?: string): Promise<boolean> {
+    let installed: boolean = false;
+
+    await callWithTelemetryAndErrorHandling('azureFunctions.validateDelveInstalled', async (innerContext: IActionContext) => {
+        innerContext.errorHandling.suppressDisplay = true;
+
+        if (getWorkspaceSetting<boolean>('validateDelve', workspacePath) === false) {
+            innerContext.telemetry.properties.validateDelve = 'false';
+            installed = true;
+            return;
+        }
+
+        if (await delveInstalled(workspacePath)) {
+            installed = true;
+            return;
+        }
+
+        const result: MessageItem = await innerContext.ui.showWarningMessage(message, { modal: true, stepName: 'delveNotInstalled' }, DialogResponses.learnMore);
+        innerContext.telemetry.properties.dialogResult = result.title;
+        if (result === DialogResponses.learnMore) {
+            await openUrl(dlvInstallUrl);
+        }
+    });
+
+    return installed;
+}
+
+async function delveInstalled(workspacePath: string | undefined): Promise<boolean> {
+    try {
+        // Delve uses `dlv version` (no leading dashes), unlike most CLIs.
+        const result = await cpUtils.tryExecuteCommand(undefined, workspacePath, dlvCommand, composeArgs(withArg('version'))());
+        return result.code === 0;
+    } catch {
+        return false;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { registerCommands } from './commands/registerCommands';
 import { func } from './constants';
 import { BallerinaDebugProvider } from './debug/BallerinaDebugProvider';
 import { FuncTaskProvider } from './debug/FuncTaskProvider';
+import { GoDebugProvider, registerGoDebugSessionCleanup } from './debug/GoDebugProvider';
 import { JavaDebugProvider } from './debug/JavaDebugProvider';
 import { NodeDebugProvider } from './debug/NodeDebugProvider';
 import { PowerShellDebugProvider } from './debug/PowerShellDebugProvider';
@@ -109,6 +110,7 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         const javaDebugProvider: JavaDebugProvider = new JavaDebugProvider();
         const ballerinaDebugProvider: BallerinaDebugProvider = new BallerinaDebugProvider();
         const powershellDebugProvider: PowerShellDebugProvider = new PowerShellDebugProvider();
+        const goDebugProvider: GoDebugProvider = new GoDebugProvider();
 
         // These don't actually overwrite "node", "python", etc. - they just add to it
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('node', nodeDebugProvider));
@@ -117,6 +119,8 @@ export async function activateInternal(context: vscode.ExtensionContext, perfSta
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('java', javaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('ballerina', ballerinaDebugProvider));
         context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('PowerShell', powershellDebugProvider));
+        context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('go', goDebugProvider));
+        context.subscriptions.push(registerGoDebugSessionCleanup());
         context.subscriptions.push(vscode.workspace.registerTaskProvider(func, new FuncTaskProvider(nodeDebugProvider, pythonDebugProvider, javaDebugProvider, ballerinaDebugProvider, powershellDebugProvider)));
 
         context.subscriptions.push(vscode.window.registerUriHandler({

--- a/src/funcCoreTools/validateGoInstalled.ts
+++ b/src/funcCoreTools/validateGoInstalled.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { callWithTelemetryAndErrorHandling, DialogResponses, type IActionContext } from '@microsoft/vscode-azext-utils';
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
+import { type MessageItem } from 'vscode';
+import { cpUtils } from '../utils/cpUtils';
+import { localize } from '../localize';
+import { openUrl } from '../utils/openUrl';
+import { getWorkspaceSetting } from '../vsCodeConfig/settings';
+
+const goCommand: string = 'go';
+const goInstallUrl: string = 'https://go.dev/dl/';
+
+/**
+ * Verifies that the Go toolchain is available on PATH before packaging a Go
+ * Functions project for deployment. If missing, prompts the user with a
+ * "Learn more" button that opens the Go install docs.
+ *
+ * Honors the `azureFunctions.validateGo` workspace setting (default true).
+ *
+ * @returns true if Go is installed (or validation is disabled), false otherwise.
+ */
+export async function validateGoInstalled(_context: IActionContext, workspacePath?: string): Promise<boolean> {
+    let installed: boolean = false;
+
+    await callWithTelemetryAndErrorHandling('azureFunctions.validateGoInstalled', async (innerContext: IActionContext) => {
+        innerContext.errorHandling.suppressDisplay = true;
+
+        if (getWorkspaceSetting<boolean>('validateGo', workspacePath) === false) {
+            innerContext.telemetry.properties.validateGo = 'false';
+            installed = true;
+            return;
+        }
+
+        if (await goInstalled(workspacePath)) {
+            installed = true;
+            return;
+        }
+
+        const message: string = localize('installGoForDeploy', 'The Go toolchain is required to package Go Functions for deployment. Install Go and try again.');
+        const result: MessageItem = await innerContext.ui.showWarningMessage(message, { modal: true, stepName: 'goNotInstalled' }, DialogResponses.learnMore);
+        innerContext.telemetry.properties.dialogResult = result.title;
+        if (result === DialogResponses.learnMore) {
+            await openUrl(goInstallUrl);
+        }
+    });
+
+    return installed;
+}
+
+async function goInstalled(workspacePath: string | undefined): Promise<boolean> {
+    try {
+        const result = await cpUtils.tryExecuteCommand(undefined, workspacePath, goCommand, composeArgs(withArg('version'))());
+        return result.code === 0;
+    } catch {
+        return false;
+    }
+}

--- a/src/vsCodeConfig/settings.ts
+++ b/src/vsCodeConfig/settings.ts
@@ -89,6 +89,11 @@ export function getRootFunctionsWorkerRuntime(language: string | undefined): str
             return 'python';
         case ProjectLanguage.PowerShell:
             return 'powershell';
+        case ProjectLanguage.Go:
+            // Go compiles to a standalone binary, so the Functions host launches the binary directly.
+            // The host and core tools expect FUNCTIONS_WORKER_RUNTIME to be 'native' for Go apps
+            // (this is the value `func init --worker-runtime go` writes to local.settings.json).
+            return 'native';
         case ProjectLanguage.Custom:
             return 'custom';
         default:
@@ -117,7 +122,8 @@ export async function tryGetFunctionsWorkerRuntimeForProject(context: IActionCon
 }
 
 export function isKnownWorkerRuntime(runtime: string | undefined): boolean {
-    return !!runtime && ['node', 'dotnet', 'dotnet-isolated', 'java', 'python', 'powershell', 'custom'].includes(runtime.toLowerCase());
+    // 'native' is the worker runtime used for Go (see getRootFunctionsWorkerRuntime).
+    return !!runtime && ['node', 'dotnet', 'dotnet-isolated', 'java', 'python', 'powershell', 'native', 'custom'].includes(runtime.toLowerCase());
 }
 
 export function promptToUpdateDotnetRuntime(azureRuntime: string | undefined, localRuntime: string | undefined): boolean {
@@ -126,6 +132,10 @@ export function promptToUpdateDotnetRuntime(azureRuntime: string | undefined, lo
 }
 
 export function getFuncWatchProblemMatcher(language: string | undefined): string {
+    // Go uses the user-friendly "$func-golang-watch" matcher name even though its worker runtime is "native".
+    if (language === ProjectLanguage.Go) {
+        return '$func-golang-watch';
+    }
     const runtime: string | undefined = getRootFunctionsWorkerRuntime(language);
     return runtime && runtime !== 'custom' ? `$func-${runtime}-watch` : '$func-watch';
 }

--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -36,6 +36,7 @@ export type LocalProjectOptions = {
     languageModel?: number;
     preCompiledProjectPath?: string
     isIsolated?: boolean;
+    isNativeWorker?: boolean;
 }
 
 export type WorkspaceProject = { options: LocalProjectOptions };

--- a/src/workspace/listLocalFunctions.ts
+++ b/src/workspace/listLocalFunctions.ts
@@ -38,7 +38,7 @@ export async function listLocalFunctions(project: LocalProjectInternal): Promise
         context.errorHandling.suppressDisplay = true;
         const isFunctionalProgrammingModel = isPythonV2Plus(project.options.language, project.options.languageModel) || isNodeV4Plus(project.options);
 
-        if (project.options.isIsolated || isFunctionalProgrammingModel) {
+        if (project.options.isIsolated || project.options.isNativeWorker || isFunctionalProgrammingModel) {
             return { functions: await getFunctionsForHostedProject(context, project), invalidFunctions: [] };
         } else {
             const result: ListLocalFunctionsResult = {

--- a/src/workspace/listLocalProjects.ts
+++ b/src/workspace/listLocalProjects.ts
@@ -25,6 +25,7 @@ export type LocalProjectOptionsInternal = {
     languageModel?: number;
     preCompiledProjectPath?: string
     isIsolated?: boolean;
+    isNativeWorker?: boolean;
 }
 
 export type LocalProjectInternal = { options: LocalProjectOptionsInternal } & IProjectTreeItem;
@@ -62,6 +63,7 @@ export async function listLocalProjects(): Promise<ListLocalProjectsResult> {
                         } else {
                             effectiveProjectPath = projectPath;
                         }
+                        const isNativeWorker: boolean = language === ProjectLanguage.Go;
                         result.initializedProjects.push(new LocalProject({
                             effectiveProjectPath,
                             folder: workspaceFolder,
@@ -70,6 +72,7 @@ export async function listLocalProjects(): Promise<ListLocalProjectsResult> {
                             version,
                             preCompiledProjectPath,
                             isIsolated,
+                            isNativeWorker,
                         }));
                     }
                 } catch (error: unknown) {

--- a/test/detectGoProject.test.ts
+++ b/test/detectGoProject.test.ts
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AzExtFsExtra, createTestActionContext } from '@microsoft/vscode-azext-utils';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { detectProjectLanguage, isGoProject } from '../src/commands/initProjectForVSCode/detectProjectLanguage';
+import { goModFileName, localSettingsFileName, ProjectLanguage } from '../src/constants';
+
+suite('detectProjectLanguage — Go', () => {
+    let tmpDir: string;
+
+    setup(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vsazfn-go-detect-'));
+    });
+
+    teardown(async () => {
+        await AzExtFsExtra.deleteResource(tmpDir, { recursive: true, useTrash: false });
+    });
+
+    test('goModFileName is "go.mod"', () => {
+        // Pinned because the detect function uses this constant; renaming it silently
+        // would break Go project auto-detection.
+        assert.strictEqual(goModFileName, 'go.mod');
+    });
+
+    test('isGoProject returns true when go.mod is present at the project root', async () => {
+        await AzExtFsExtra.writeFile(path.join(tmpDir, goModFileName), 'module example.com/test\n\ngo 1.22\n');
+        assert.strictEqual(await isGoProject(tmpDir), true);
+    });
+
+    test('isGoProject returns false when go.mod is missing', async () => {
+        assert.strictEqual(await isGoProject(tmpDir), false);
+    });
+
+    test('isGoProject does not walk into subdirectories', async () => {
+        // go.mod must be at the project root — a nested go.mod should not count.
+        const nested = path.join(tmpDir, 'sub');
+        await AzExtFsExtra.ensureDir(nested);
+        await AzExtFsExtra.writeFile(path.join(nested, goModFileName), 'module example.com/nested\n');
+        assert.strictEqual(await isGoProject(tmpDir), false);
+    });
+
+    test('detectProjectLanguage infers Go from FUNCTIONS_WORKER_RUNTIME=native in local.settings.json', async () => {
+        // If a user has a Go local.settings.json but no go.mod yet (stub project / mid-migration),
+        // detectProjectLanguage should still identify the language.
+        await AzExtFsExtra.writeFile(
+            path.join(tmpDir, localSettingsFileName),
+            JSON.stringify({ IsEncrypted: false, Values: { FUNCTIONS_WORKER_RUNTIME: 'native' } }),
+        );
+        const context = await createTestActionContext();
+        assert.strictEqual(await detectProjectLanguage(context, tmpDir), ProjectLanguage.Go);
+    });
+});
+

--- a/test/goDebugProvider.test.ts
+++ b/test/goDebugProvider.test.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { hostStartTaskName, localhost } from '../src/constants';
+import { defaultGoDebugPort, goDebugConfig } from '../src/debug/GoDebugProvider';
+
+suite('debug/GoDebugProvider — config shape', () => {
+    test('goDebugConfig matches what the Go extension expects for an external dlv attach', () => {
+        // These values are the contract between this extension and the golang.go extension.
+        // Changing any of them silently breaks F5 for every Go Functions user, so pin them down.
+        assert.strictEqual(goDebugConfig.type, 'go');
+        assert.strictEqual(goDebugConfig.request, 'attach');
+        // mode 'remote' tells golang.go to connect to an externally-started dlv (the one our poller spawns)
+        // rather than starting dlv itself.
+        assert.strictEqual(goDebugConfig.mode, 'remote');
+        assert.strictEqual(goDebugConfig.port, 2345);
+        assert.strictEqual(goDebugConfig.host, localhost);
+        assert.strictEqual(goDebugConfig.preLaunchTask, hostStartTaskName);
+    });
+
+    test('defaultGoDebugPort matches goDebugConfig.port', () => {
+        // GoDebugProvider falls back to defaultGoDebugPort if the resolved config is missing a port,
+        // so the two must stay aligned.
+        assert.strictEqual(defaultGoDebugPort, goDebugConfig.port);
+    });
+});

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ProjectLanguage } from '../src/constants';
+import { getFuncWatchProblemMatcher, getRootFunctionsWorkerRuntime, isKnownWorkerRuntime } from '../src/vsCodeConfig/settings';
+
+suite('vsCodeConfig/settings — Go support', () => {
+    test('getRootFunctionsWorkerRuntime: Go maps to native (not golang)', () => {
+        assert.strictEqual(getRootFunctionsWorkerRuntime(ProjectLanguage.Go), 'native');
+    });
+
+    test('isKnownWorkerRuntime: accepts native', () => {
+        assert.strictEqual(isKnownWorkerRuntime('native'), true);
+    });
+
+    test('getFuncWatchProblemMatcher: Go uses $func-golang-watch (user-friendly name, despite native worker runtime)', () => {
+        assert.strictEqual(getFuncWatchProblemMatcher(ProjectLanguage.Go), '$func-golang-watch');
+    });
+});


### PR DESCRIPTION
Fix Go functions not shown in workspace Functions node (#5082)

Go projects use a native worker model with no function.json files. The existing function listing logic only queries the running host (/admin/functions) for .NET isolated, Python v2+, and Node v4+ projects — Go projects fell through to the function.json scan path and found nothing.

This adds an isNativeWorker flag to LocalProjectOptions, set to true for Go projects, which routes them through the hosted project path to enumerate functions from the running host.

Changes:

 - listLocalProjects.ts — set isNativeWorker: true when language is Go
 - listLocalFunctions.ts — check isNativeWorker alongside isIsolated and functional programming model checks
 - vscode-azurefunctions.api.d.ts — add isNativeWorker to the public type