### PR TITLE
Fix Go functions not appearing under Functions node in workspace view

### DIFF
--- a/src/vscode-azurefunctions.api.d.ts
+++ b/src/vscode-azurefunctions.api.d.ts
@@ -36,6 +36,7 @@ export type LocalProjectOptions = {
     languageModel?: number;
     preCompiledProjectPath?: string
     isIsolated?: boolean;
+    isNativeWorker?: boolean;
 }
 
 export type WorkspaceProject = { options: LocalProjectOptions };

--- a/src/workspace/listLocalFunctions.ts
+++ b/src/workspace/listLocalFunctions.ts
@@ -38,7 +38,7 @@ export async function listLocalFunctions(project: LocalProjectInternal): Promise
         context.errorHandling.suppressDisplay = true;
         const isFunctionalProgrammingModel = isPythonV2Plus(project.options.language, project.options.languageModel) || isNodeV4Plus(project.options);
 
-        if (project.options.isIsolated || isFunctionalProgrammingModel) {
+        if (project.options.isIsolated || project.options.isNativeWorker || isFunctionalProgrammingModel) {
             return { functions: await getFunctionsForHostedProject(context, project), invalidFunctions: [] };
         } else {
             const result: ListLocalFunctionsResult = {

--- a/src/workspace/listLocalProjects.ts
+++ b/src/workspace/listLocalProjects.ts
@@ -25,6 +25,7 @@ export type LocalProjectOptionsInternal = {
     languageModel?: number;
     preCompiledProjectPath?: string
     isIsolated?: boolean;
+    isNativeWorker?: boolean;
 }
 
 export type LocalProjectInternal = { options: LocalProjectOptionsInternal } & IProjectTreeItem;
@@ -62,6 +63,7 @@ export async function listLocalProjects(): Promise<ListLocalProjectsResult> {
                         } else {
                             effectiveProjectPath = projectPath;
                         }
+                        const isNativeWorker: boolean = language === ProjectLanguage.Go;
                         result.initializedProjects.push(new LocalProject({
                             effectiveProjectPath,
                             folder: workspaceFolder,
@@ -70,6 +72,7 @@ export async function listLocalProjects(): Promise<ListLocalProjectsResult> {
                             version,
                             preCompiledProjectPath,
                             isIsolated,
+                            isNativeWorker,
                         }));
                     }
                 } catch (error: unknown) {


### PR DESCRIPTION
Fix Go functions not shown in workspace Functions node (#5082)

Go projects use a native worker model with no function.json files. The existing function listing logic only queries the running host (/admin/functions) for .NET isolated, Python v2+, and Node v4+ projects — Go projects fell through to the function.json scan path and found nothing.

This adds an isNativeWorker flag to LocalProjectOptions, set to true for Go projects, which routes them through the hosted project path to enumerate functions from the running host.

Changes:

 - listLocalProjects.ts — set isNativeWorker: true when language is Go
 - listLocalFunctions.ts — check isNativeWorker alongside isIsolated and functional programming model checks
 - vscode-azurefunctions.api.d.ts — add isNativeWorker to the public type