### PR TITLE
Fix Template Gallery project creation when no folder is open

### DIFF
--- a/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
+++ b/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
@@ -134,7 +134,24 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
             actionContext.telemetry.properties.templateId = template.id;
             actionContext.telemetry.properties.language = language;
 
-            const projectPath = location;
+            // An empty/non-absolute `location` (no folder open, none picked) would
+            // resolve against the cwd and write to the drive root (EPERM). Prompt instead.
+            let projectPath = location;
+            if (!projectPath || !path.isAbsolute(projectPath)) {
+                actionContext.telemetry.properties.promptedForLocation = 'true';
+                const selectedFolder = await this.browseFolder();
+                if (!selectedFolder) {
+                    // User dismissed the folder picker — return to the gallery
+                    // silently (no error banner) and record the cancellation.
+                    this.postMessageToWebview({ type: 'projectCreationFailed', error: '' });
+                    throw new UserCancelledError('selectProjectFolder');
+                }
+                projectPath = selectedFolder;
+                // Reflect the chosen folder in the webview's location field so the
+                // UI stays in sync with where the project is actually created.
+                this.postMessageToWebview({ type: 'folderSelected', path: projectPath, source: 'template' });
+            }
+
             const branch = template.branch || 'main';
             const specificFolder = template.folderPath && template.folderPath !== '.' ? template.folderPath : undefined;
             const tempDir = path.join(os.tmpdir(), `azfunc-template-${Date.now()}`);


### PR DESCRIPTION
 ## Description:

Fixes:  https://github.com/microsoft/vscode-azurefunctions/issues/5066

  When the "Enable Template Gallery" setting is on and VS Code is opened without a folder, clicking "Use this template" failed with:

   Error: EPERM: operation not permitted, copyfile '...\.funcignore' -> 'C:\.funcignore'

  No destination was ever selected, so location arrived empty. path.join('', '.funcignore') resolved against the process cwd and wrote to the drive root, which is not permitted.

##  Fix

  In FunctionsTemplateGalleryController.createProject, validate location before copying. If it's empty or non-absolute, prompt the user with the shared browseFolder() picker:

   - Folder chosen → use it as the project path and sync the webview's location field (folderSelected).
   - Cancelled → return to the gallery silently and record a UserCancelledError.

  Also synced node_modules with the lockfile (@microsoft/vscode-azext-azureutils 4.0.1 → 4.3.0), which resolves pre-existing requestUtils.ts build errors (redirectOptions / 5-arg sendRequestWithTimeout).

 ## Testing

   - npm run check and npm run build pass clean.
   - Manual: no folder open → use template → folder prompt appears → project created successfully; cancel path returns to gallery without error.