### PR TITLE
Set DTS as default backend, remove preview bundles

### DIFF
--- a/src/commands/createFunction/durableSteps/DurableProjectConfigureStep.ts
+++ b/src/commands/createFunction/durableSteps/DurableProjectConfigureStep.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtFsExtra, AzureWizardExecuteStepWithActivityOutput, nonNullValue, parseError, type IParsedError } from '@microsoft/vscode-azext-utils';
-import { composeArgs, withArg, withFlagArg } from '@microsoft/vscode-processutils';
+import { composeArgs, withArg } from '@microsoft/vscode-processutils';
 import * as path from "path";
 import { type Progress } from 'vscode';
 import { ConnectionKey, DurableBackend, hostFileName, ProjectLanguage } from '../../../constants';
@@ -79,15 +79,6 @@ export class DurableProjectConfigureStep<T extends IFunctionWizardContext> exten
                 break;
             case DurableBackend.DTS:
                 hostJson.extensions.durableTask = this.getDefaultDTSTaskConfig();
-                // Non- .NET projects require a special preview extension bundle to work properly
-                // Todo: Remove once this functionality is out of preview
-                if (context.language !== ProjectLanguage.CSharp && context.language !== ProjectLanguage.FSharp) {
-                    hostJson.extensionBundle = {
-                        id: 'Microsoft.Azure.Functions.ExtensionBundle.Preview',
-                        version: '[4.29.0, 5.0.0)',
-                    };
-                    ext.outputChannel.appendLog(localize('extensionBundlePreview', 'Updated "host.json" extension bundle to preview version to enable new DTS features.'));
-                }
                 await setLocalAppSetting(context, context.projectPath, ConnectionKey.DTS, '', MismatchBehavior.Overwrite);
                 await setLocalAppSetting(context, context.projectPath, nonNullValue(tryGetVariableSubstitutedKey(ConnectionKey.DTSHub)), '', MismatchBehavior.Overwrite);
                 break;
@@ -171,7 +162,7 @@ export class DurableProjectConfigureStep<T extends IFunctionWizardContext> exten
     }
 
     private async installDotnetDependencies(context: IFunctionWizardContext): Promise<void> {
-        const packages: { name: string; prerelease?: boolean }[] = [];
+        const packages: { name: string }[] = [];
         const isDotnetIsolated: boolean = /Isolated/i.test(context.functionTemplate?.id ?? '');
 
         switch (context.newDurableStorageType) {
@@ -183,11 +174,10 @@ export class DurableProjectConfigureStep<T extends IFunctionWizardContext> exten
                 }
                 break;
             case DurableBackend.DTS:
-                // Todo: Remove prerelease flag once this functionality is out of preview
                 if (isDotnetIsolated) {
-                    packages.push({ name: durableUtils.dotnetIsolatedDTSPackage, prerelease: true });
+                    packages.push({ name: durableUtils.dotnetIsolatedDTSPackage });
                 } else {
-                    packages.push({ name: durableUtils.dotnetInProcDTSPackage, prerelease: true });
+                    packages.push({ name: durableUtils.dotnetInProcDTSPackage });
                 }
                 break;
             case DurableBackend.SQL:
@@ -214,7 +204,6 @@ export class DurableProjectConfigureStep<T extends IFunctionWizardContext> exten
             try {
                 const args = composeArgs(
                     withArg('add', 'package', p.name),
-                    withFlagArg('--prerelease', p.prerelease),
                 )();
                 await cpUtils.executeCommand(ext.outputChannel, context.projectPath, 'dotnet', args);
             } catch {

--- a/src/commands/createFunction/durableSteps/DurableStorageTypePromptStep.ts
+++ b/src/commands/createFunction/durableSteps/DurableStorageTypePromptStep.ts
@@ -16,8 +16,8 @@ export class DurableStorageTypeListStep<T extends IFunctionWizardContext> extend
 
         const placeHolder: string = localize('chooseDurableStorageType', 'Choose a durable storage type.');
         const picks: IAzureQuickPickItem<DurableBackend | undefined>[] = [
-            { label: 'Azure Storage', description: defaultDescription, data: DurableBackend.Storage },
-            { label: 'Durable Task Scheduler', data: DurableBackend.DTS },
+            { label: 'Durable Task Scheduler', description: defaultDescription, data: DurableBackend.DTS },
+            { label: 'Azure Storage', data: DurableBackend.Storage },
             { label: 'MSSQL', data: DurableBackend.SQL },
             { label: durableStorageInfo, data: undefined }
         ];


### PR DESCRIPTION
Sets the Durable Task Scheduler (DTS) as the default storage backend for durable Azure Functions. 
Also removes the special-casing we had to configure for preview extension bundles, as the DTS extensions have been present in the public extension bundles for a long time. 