### PR TITLE
Add Template Gallery create-project telemetry:  entryPoint  and  temp…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
                 "@microsoft/vscode-azext-azureutils": "^4.3.0",
                 "@microsoft/vscode-azext-utils": "^4.1.1",
-                "@microsoft/vscode-azext-webview": "^1.1.0",
+                "@microsoft/vscode-azext-webview": "^1.2.0",
                 "@microsoft/vscode-azureresources-api": "^2.6.2",
                 "@microsoft/vscode-container-client": "^0.3.0",
                 "@microsoft/vscode-processutils": "^0.2.1",
@@ -3785,9 +3785,9 @@
             }
         },
         "node_modules/@microsoft/vscode-azext-webview": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-webview/-/vscode-azext-webview-1.1.0.tgz",
-            "integrity": "sha512-EYispeNjqx/6Kn5TfhPklDMXRd2t6xKBxaoSXfQNBhvF246ThA8DfZ++xh4PjU2DKPkZpSFdBwADafEnxsm0uQ==",
+            "version": "1.2.0",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/vscode-azext-webview/-/vscode-azext-webview-1.2.0.tgz",
+            "integrity": "sha1-6D4DcHaS8uICi167HnXUZilfIzM=",
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-components": "^9.56.2",

--- a/package.json
+++ b/package.json
@@ -1626,7 +1626,7 @@
         "@microsoft/vscode-azext-azureappsettings": "^1.0.0",
         "@microsoft/vscode-azext-azureutils": "^4.3.0",
         "@microsoft/vscode-azext-utils": "^4.1.1",
-        "@microsoft/vscode-azext-webview": "^1.1.0",
+        "@microsoft/vscode-azext-webview": "^1.2.0",
         "@microsoft/vscode-azureresources-api": "^2.6.2",
         "@microsoft/vscode-container-client": "^0.3.0",
         "@microsoft/vscode-processutils": "^0.2.1",

--- a/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
+++ b/src/commands/createNewProject/FunctionsTemplateGalleryController.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtFsExtra, AzureWizard, UserCancelledError, callWithTelemetryAndErrorHandling, parseError, type IActionContext } from '@microsoft/vscode-azext-utils';
-import { TemplateGalleryController, registerWebviewExtensionVariables, type IProjectTemplate as ISharedProjectTemplate, type TemplateGalleryConfig } from '@microsoft/vscode-azext-webview';
+import { TemplateGalleryController, registerWebviewExtensionVariables, type IProjectTemplate as ISharedProjectTemplate, type ProjectCreationEntryPoint, type TemplateGalleryConfig } from '@microsoft/vscode-azext-webview';
 import extract from 'extract-zip';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -128,11 +128,13 @@ export class FunctionsTemplateGalleryController extends TemplateGalleryControlle
         return markdown ?? '';
     }
 
-    protected async createProject(sharedTemplate: ISharedProjectTemplate, language: string, location: string): Promise<void> {
+    protected async createProject(sharedTemplate: ISharedProjectTemplate, language: string, location: string, entryPoint?: ProjectCreationEntryPoint): Promise<void> {
         const template = sharedTemplate as unknown as IProjectTemplate;
         await callWithTelemetryAndErrorHandling('azureFunctions.templateGallery.createProject', async (actionContext: IActionContext) => {
             actionContext.telemetry.properties.templateId = template.id;
+            actionContext.telemetry.properties.templateName = template.displayName;
             actionContext.telemetry.properties.language = language;
+            actionContext.telemetry.properties.entryPoint = entryPoint ?? 'unknown';
 
             const projectPath = location;
             const branch = template.branch || 'main';


### PR DESCRIPTION
### Description:

We want to understand how users create projects from the Template Gallery, specifically whether they use the "Use Template" quick button on a tile or open the details view first and click "Create Project". Today the  createProject  telemetry event can't distinguish the two paths, and it only records the template  id  (not a friendly name).


### Change: 

Enhances the  azureFunctions.templateGallery.createProject  telemetry event with two properties:

•  entryPoint  —  'card'  (tile "Use Template" button) or  'details'  (details view "Create Project" button). Falls back to  'unknown'  when not supplied (e.g. an older webview bundle), so a non-empty value always indicates a confirmed path.
•  templateName  — the template's  displayName  (friendly name), alongside the existing  templateId , for readable reporting.

 createProject  now receives the  entryPoint  from the shared webview controller and records it.

Resulting event

templateId:     "HttpTrigger-TypeScript"
templateName:   "HTTP Trigger"
language:       "TypeScript"
entryPoint:     "card"        // or "details" / "unknown"
downloadMethod: "git"
result:         "Succeeded"


Requires  @microsoft/vscode-azext-webview  updated to the version that adds  ProjectCreationEntryPoint  and threads  entryPoint  through  createProject https://github.com/microsoft/vscode-azuretools/pull/2355