### PR TITLE
Resolve Core Tools version the way npm does to stop the un-clearable update notification

### DIFF
--- a/src/funcCoreTools/getNpmDistTag.ts
+++ b/src/funcCoreTools/getNpmDistTag.ts
@@ -11,10 +11,38 @@ import { requestUtils } from '../utils/requestUtils';
 
 const npmRegistryUri: string = 'https://aka.ms/AA2qmnu';
 
-export interface INpmDistTag { tag: string; value: string; }
+export interface INpmDistTag {
+    /**
+     * Misnomer: this is the semver range we install with (i.e. the major version, such as "4"),
+     * not an npm dist-tag. It's passed to `npm install -g azure-functions-core-tools@<tag>`.
+     */
+    tag: string;
+    value: string;
+}
 
-interface IPackageMetadata {
+export interface IPackageMetadata {
     versions: { [version: string]: {} };
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- matches the npm packument's actual key
+    'dist-tags': { [tag: string]: string };
+}
+
+/**
+ * Mirrors the precedence npm's `pick-manifest` uses when resolving a _range_ spec like `@4`:
+ * the `latest` dist-tag wins if it satisfies the range, otherwise the max satisfying version is used.
+ * Any other dist-tag (`core`, `v3`, etc.) is ignored for range specs.
+ *
+ * Resolving any other way lets the extension advertise a version that `npm install <pkg>@<major>`
+ * will never actually install, producing a permanent un-clearable "update available" notification
+ * (e.g. the registry publishes 4.13.2 but `dist-tags.latest` is 4.13.0, so `@4` installs 4.13.0).
+ */
+export function resolveNewestVersion(packageMetadata: IPackageMetadata, majorVersion: string): string | undefined {
+    const latest: string | undefined = packageMetadata['dist-tags']?.latest;
+    if (latest && semver.valid(latest) && semver.satisfies(latest, majorVersion)) {
+        return latest;
+    }
+
+    const validVersions: string[] = Object.keys(packageMetadata.versions ?? {}).filter((v: string) => !!semver.valid(v));
+    return semver.maxSatisfying(validVersions, majorVersion) ?? undefined;
 }
 
 export async function getNpmDistTag(context: IActionContext, version: FuncVersion): Promise<INpmDistTag> {
@@ -22,8 +50,7 @@ export async function getNpmDistTag(context: IActionContext, version: FuncVersio
     const packageMetadata: IPackageMetadata = <IPackageMetadata>response.parsedBody;
     const majorVersion: string = getMajorVersion(version);
 
-    const validVersions: string[] = Object.keys(packageMetadata.versions).filter((v: string) => !!semver.valid(v));
-    const maxVersion: string | null = semver.maxSatisfying(validVersions, majorVersion);
+    const maxVersion: string | undefined = resolveNewestVersion(packageMetadata, majorVersion);
     if (!maxVersion) {
         throw new Error(localize('noDistTag', 'Failed to retrieve NPM tag for version "{0}".', version));
     }

--- a/test/resolveNewestVersion.test.ts
+++ b/test/resolveNewestVersion.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { resolveNewestVersion, type IPackageMetadata } from '../src/funcCoreTools/getNpmDistTag';
+
+// Verify the newest core tools version we advertise matches what `npm install <pkg>@<major>` would
+// actually install: npm prefers the `latest` dist-tag when it satisfies the range, otherwise the
+// max satisfying version. Other dist-tags are ignored for range specs.
+
+function createMetadata(versions: string[], distTags: { [tag: string]: string }): IPackageMetadata {
+    const versionMap: { [version: string]: {} } = {};
+    for (const version of versions) {
+        versionMap[version] = {};
+    }
+    return { versions: versionMap, 'dist-tags': distTags };
+}
+
+suite('resolveNewestVersion', () => {
+    test('latest wins over a higher published version', () => {
+        // The exact issue #5163 case: 4.13.1 / 4.13.2 are published but `latest` is still 4.13.0
+        const metadata = createMetadata(['4.12.0', '4.13.0', '4.13.1', '4.13.2'], { latest: '4.13.0' });
+        assert.strictEqual(resolveNewestVersion(metadata, '4'), '4.13.0');
+    });
+
+    test('latest is ignored when it does not satisfy the requested major', () => {
+        const metadata = createMetadata(['2.0.3', '2.7.3188', '4.13.0'], { latest: '4.13.0', core: '2.0.3' });
+        assert.strictEqual(resolveNewestVersion(metadata, '2'), '2.7.3188');
+    });
+
+    test('falls back to max satisfying when there is no latest dist-tag', () => {
+        const metadata = createMetadata(['3.0.3477', '3.0.5682', '4.13.0'], {});
+        assert.strictEqual(resolveNewestVersion(metadata, '3'), '3.0.5682');
+    });
+
+    test('returns undefined when no version matches the requested major', () => {
+        const metadata = createMetadata(['4.13.0', '4.13.2'], { latest: '4.13.0' });
+        assert.strictEqual(resolveNewestVersion(metadata, '5'), undefined);
+    });
+
+    test('prerelease versions are not selected over stable ones', () => {
+        const metadata = createMetadata(['4.13.0', '4.14.0-preview.1'], {});
+        assert.strictEqual(resolveNewestVersion(metadata, '4'), '4.13.0');
+    });
+
+    test('invalid version keys and an invalid latest tag are ignored', () => {
+        const metadata = createMetadata(['4.13.0', 'not-a-version'], { latest: 'not-a-version' });
+        assert.strictEqual(resolveNewestVersion(metadata, '4'), '4.13.0');
+    });
+});


### PR DESCRIPTION
Fixes #5163

## Problem

`getNpmDistTag` picked the newest Core Tools version by taking `semver.maxSatisfying` over every published version for the requested major. But the version that actually gets installed comes from `npm install -g azure-functions-core-tools@<major>`, and npm's `pick-manifest` resolves a **range** spec by preferring the `latest` dist-tag whenever it satisfies the range.

The registry currently has `dist-tags.latest = 4.13.0` while 4.13.1 and 4.13.2 are published (deprecated republishes whose postinstall CDN binaries 404). So:

- the extension advertised **4.13.2** in the "Update your Azure Functions Core Tools (X) to the latest (Y)" notification,
- `npm install -g azure-functions-core-tools@4` installed **4.13.0**,
- the notification could never be cleared.

## Fix

Extract a pure, testable `resolveNewestVersion(packageMetadata, majorVersion)` that mirrors npm's precedence: return `dist-tags.latest` when it's valid semver and satisfies the requested major, otherwise fall back to `semver.maxSatisfying`.

Two alternatives were deliberately **not** taken, because both diverge from npm:
- falling back to a major-specific dist-tag (`core`, `v3`, …) — npm ignores non-`latest` tags for range specs, so `@2` would wrongly resolve to `core`'s 2.0.3 instead of 2.7.3188;
- filtering out deprecated versions — deprecation isn't part of npm's resolution algorithm. 4.13.2 is correctly skipped by the latest-preference rule, not by deprecation.

Ground truth, verified with `npm install azure-functions-core-tools@<major> --dry-run`, all matched by the new resolver:

| Spec | npm installs | Why |
|---|---|---|
| `@1` | 1.0.28 | max satisfying |
| `@2` | 2.7.3188 | max satisfying (not the `core` tag, 2.0.3) |
| `@3` | 3.0.5682 | max satisfying |
| `@4` | 4.13.0 | `latest` satisfies the range |

`updateFuncCoreTools.ts` / `installFuncCoreTools.ts` are intentionally left alone — the corrected resolver already makes advertised == installed, and pinning the exact version is a larger behavioral change worth discussing separately. The brew path is unaffected: `getNewestFunctionRuntimeVersion` scrapes the formula's actual `version`.

Also added a doc comment noting `INpmDistTag.tag` is a misnomer — it holds a semver range (`"4"`), not a dist-tag.

## Tests

New `test/resolveNewestVersion.test.ts` following the existing pure-function test convention:

- `latest` wins over a higher published version (the exact #5163 case)
- `latest` is ignored when its major differs from the requested one (v2 → 2.7.3188, not `core`'s 2.0.3)
- fallback to max satisfying when there's no `latest` tag
- a major with no matching versions returns `undefined`
- prereleases aren't selected over stable versions for the same major
- invalid version keys and an invalid `latest` are ignored

## Validation

- `npm run check` (`tsc --noEmit`) — clean
- `npx eslint --max-warnings 0 src/funcCoreTools/getNpmDistTag.ts` — clean
- New tests pass (verified by running mocha against the test file). Note: `npm test` currently can't complete on my machine for reasons unrelated to this change — esbuild fails reading `core-js-pure` internals, and `@vscode/test-electron` spawns `.../MacOS/Electron` while VS Code 1.134 ships `Code`. CI should confirm.