### PR TITLE
Fix skipped build tasks when debugging .NET isolated Functions

### DIFF
--- a/src/commands/pickFuncProcess.ts
+++ b/src/commands/pickFuncProcess.ts
@@ -11,7 +11,7 @@ import { hostStartTaskName, jsonOutputFileFlag } from '../constants';
 import { preDebugValidate, type IPreDebugValidateResult } from '../debug/validatePreDebug';
 import { ext } from '../extensionVariables';
 import { buildPathToWorkspaceFolderMap, getFuncPortFromTaskOrProject, isFuncHostTask, runningFuncTaskMap, stopFuncTaskIfRunning, type IRunningFuncTask } from '../funcCoreTools/funcHostTask';
-import { generateJsonOutputFilePath, getWorkerPidFromJsonOutput, injectJsonOutputFileArgIfNeeded, isDotnetIsolatedDebugTask, shouldInjectJsonOutputFile } from '../funcCoreTools/jsonOutputFile';
+import { deleteWorkerPidFile, generateJsonOutputFilePath, getJsonOutputFilePathFromTask, getWorkerPidFromJsonOutput, isDotnetIsolatedDebugTask, shouldInjectJsonOutputFile } from '../funcCoreTools/jsonOutputFile';
 import { localize } from '../localize';
 import { delay } from '../utils/delay';
 import { requestUtils } from '../utils/requestUtils';
@@ -133,8 +133,15 @@ export async function pickFuncProcess(context: IActionContext, debugConfig: vsco
 
     const buildPath: string = (funcTask.execution as vscode.ShellExecution)?.options?.cwd || result.workspace.uri.fsPath;
     await waitForPrevFuncTaskToStop(result.workspace, buildPath);
-    const taskToExecute = injectJsonOutputFileArgIfNeeded(funcTask);
-    const taskInfo = await startFuncTask(context, result.workspace, buildPath, taskToExecute);
+
+    // Remove a PID file left behind by a previous session so a dead worker's PID can't be picked up.
+    await deleteWorkerPidFile(getJsonOutputFilePathFromTask(funcTask));
+
+    // Execute the task exactly as VS Code resolved it from tasks.json. Rebuilding it here to append
+    // args would silently drop its `dependsOn` chain, because `dependsOn` lives in tasks.json and has
+    // no equivalent on the `vscode.Task` API - that skipped the project's clean/build tasks.
+    // The args func needs are added during resolution instead, in FuncTaskProvider.
+    const taskInfo = await startFuncTask(context, result.workspace, buildPath, funcTask);
     return await pickChildProcess(taskInfo);
 }
 
@@ -190,9 +197,10 @@ async function startFuncTask(context: IActionContext, workspaceFolder: vscode.Wo
             const taskInfo: IRunningFuncTask | undefined = runningFuncTaskMap.get(workspaceFolder, buildPath);
             if (taskInfo) {
                 if (dotnetIsolatedDebugMode) {
-                    // Prefer the file written by func core tools via --json-output-file; if that flag
-                    // isn't present (e.g., the task was already running before we could inject it),
-                    // fall back to the worker PID parsed from the terminal stream by funcHostTask.
+                    // Prefer the file func core tools writes via --json-output-file. If that file never
+                    // appears - e.g. a hand-written task the func task provider never resolved, so the
+                    // flag was never added - fall back to the worker PID funcHostTask parses out of the
+                    // terminal stream.
                     const newPid = await getWorkerPidFromJsonOutput(taskInfo.workerPidFile)
                         ?? taskInfo.workerProcessId;
                     if (newPid) {

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -95,7 +95,7 @@ export class FuncTaskProvider implements TaskProvider {
             context.errorHandling.suppressDisplay = true;
             context.telemetry.suppressIfSuccessful = true;
 
-             
+
             const command: string | undefined = task.definition.command;
             if (command && task.scope !== undefined && task.scope !== TaskScope.Global && task.scope !== TaskScope.Workspace) {
                 const folder: WorkspaceFolder = task.scope;
@@ -121,11 +121,7 @@ export class FuncTaskProvider implements TaskProvider {
             problemMatcher = getFuncWatchProblemMatcher(language);
             options = await this.getHostStartOptions(folder, language);
 
-            // Tell func where to write the .NET isolated worker PID, so the debugger can attach before
-            // the worker runs any user code. Added here, while VS Code is still resolving the task,
-            // rather than onto the resolved task: rebuilding a resolved task drops its `dependsOn`
-            // chain and silently skips the project's clean/build tasks.
-            const workerPidFile: string = getWorkerPidFilePath(`${folder.uri.fsPath}|${command}|${definitionArgs.join(' ')}`);
+            const workerPidFile: string = getWorkerPidFilePath(`${folder.uri.fsPath}|${command}|${JSON.stringify(definitionArgs)}`);
             allArgs.push(...getWorkerPidFileArgs(allArgs, workerPidFile));
         }
 

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -121,7 +121,7 @@ export class FuncTaskProvider implements TaskProvider {
             problemMatcher = getFuncWatchProblemMatcher(language);
             options = await this.getHostStartOptions(folder, language);
 
-            const workerPidFile: string = getWorkerPidFilePath(`${folder.uri.fsPath}|${command}|${JSON.stringify(definitionArgs)}`);
+            const workerPidFile: string = await getWorkerPidFilePath(`${folder.uri.fsPath}|${command}|${JSON.stringify(definitionArgs)}`);
             allArgs.push(...getWorkerPidFileArgs(allArgs, workerPidFile));
         }
 

--- a/src/debug/FuncTaskProvider.ts
+++ b/src/debug/FuncTaskProvider.ts
@@ -10,6 +10,7 @@ import { tryGetFunctionProjectRoot } from '../commands/createNewProject/verifyIs
 import { ConnectionKey, ProjectLanguage, buildNativeDeps, extInstallCommand, func, hostStartCommand, packCommand, projectLanguageSetting } from '../constants';
 import { getLocalSettingsConnectionString } from '../funcConfig/local.settings';
 import { getFuncCliPath } from '../funcCoreTools/getFuncCliPath';
+import { getWorkerPidFileArgs, getWorkerPidFilePath } from '../funcCoreTools/jsonOutputFile';
 import { venvUtils } from '../utils/venvUtils';
 import { getFuncWatchProblemMatcher, getWorkspaceSetting } from '../vsCodeConfig/settings';
 import { getTasks } from '../vsCodeConfig/tasks';
@@ -119,6 +120,13 @@ export class FuncTaskProvider implements TaskProvider {
         if (/^\s*(host )?start/i.test(command)) {
             problemMatcher = getFuncWatchProblemMatcher(language);
             options = await this.getHostStartOptions(folder, language);
+
+            // Tell func where to write the .NET isolated worker PID, so the debugger can attach before
+            // the worker runs any user code. Added here, while VS Code is still resolving the task,
+            // rather than onto the resolved task: rebuilding a resolved task drops its `dependsOn`
+            // chain and silently skips the project's clean/build tasks.
+            const workerPidFile: string = getWorkerPidFilePath(`${folder.uri.fsPath}|${command}|${definitionArgs.join(' ')}`);
+            allArgs.push(...getWorkerPidFileArgs(allArgs, workerPidFile));
         }
 
         options = options || {};
@@ -141,7 +149,7 @@ export class FuncTaskProvider implements TaskProvider {
         if (language === ProjectLanguage.Python) {
             // Python requires chaining venv activation with the func command via shell operators (&&, ;),
             // so we must use the string-based ShellExecution form
-            let commandLine = `${funcCliPath} ${[...commandParts, ...definitionArgs].join(' ')}`;
+            let commandLine = `${funcCliPath} ${allArgs.join(' ')}`;
             commandLine = venvUtils.convertToVenvCommand(commandLine, folder.uri.fsPath);
             execution = new ShellExecution(commandLine, options);
         } else {

--- a/src/funcCoreTools/funcHostTask.ts
+++ b/src/funcCoreTools/funcHostTask.ts
@@ -292,9 +292,10 @@ export function registerFuncHostTaskEvents(): void {
                     task.logs.splice(0, task.logs.length - maxLogEntries);
                 }
 
-                // Fallback for dotnet-isolated debug when no --json-output-file is configured: parse the
-                // worker PID directly from the terminal output so pickFuncProcess can still attach.
-                if (!task.workerPidFile && task.workerProcessId === undefined && chunk.includes(workerStartupName)) {
+                // Fallback for dotnet-isolated debug: parse the worker PID straight out of the terminal
+                // output. Kept armed even when --json-output-file is configured, so a file func never
+                // writes degrades to this instead of hanging until pickProcessTimeout.
+                if (task.workerProcessId === undefined && chunk.includes(workerStartupName)) {
                     let obj: unknown;
                     try { obj = JSON.parse(chunk); } catch { /* not full JSON, try regex below */ }
                     if (

--- a/src/funcCoreTools/jsonOutputFile.ts
+++ b/src/funcCoreTools/jsonOutputFile.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
+import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -94,47 +95,60 @@ export function generateJsonOutputFilePath(): string {
 }
 
 /**
- * If the user's func task is configured for dotnet-isolated debugging with JSON output but does not
- * already specify a `--json-output-file`, returns a wrapper task with that flag injected so func
- * core tools writes the worker PID directly to a file we control.
+ * Deterministic path that func core tools writes the .NET isolated worker PID to.
+ *
+ * Deterministic rather than unique-per-run so that a file left behind by a previous session lands at
+ * the same path we delete before starting, and so temp files don't accumulate. `key` should identify
+ * the func task, i.e. its workspace folder plus its configured command and args.
  */
-export function injectJsonOutputFileArgIfNeeded(funcTask: vscode.Task): vscode.Task {
-    const exec = funcTask.execution;
-    if (!(exec instanceof vscode.ShellExecution)) {
-        return funcTask;
+export function getWorkerPidFilePath(key: string): string {
+    const hash: string = crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
+    return path.join(os.tmpdir(), `azfunc-worker-pid-${hash}.json`);
+}
+
+/**
+ * The extra args that make func core tools write the .NET isolated worker PID to `workerPidFile`.
+ *
+ * Returns an empty array unless the task is a dotnet-isolated debug task that doesn't already name
+ * an output file, so a `--json-output-file` the user configured themselves always wins.
+ *
+ * These get added while the task is still being resolved (see `FuncTaskProvider.createTask`) rather
+ * than rebuilt onto an already-resolved task. Rebuilding drops the task's `dependsOn` chain, because
+ * `dependsOn` only exists in tasks.json and VS Code only honors it for tasks it resolved itself,
+ * which silently skipped the clean/build tasks a .NET project depends on.
+ */
+export function getWorkerPidFileArgs(existingArgs: readonly string[], workerPidFile: string): string[] {
+    if (!existingArgs.includes(dotnetIsolatedDebugFlag)) {
+        return [];
+    }
+    if (existingArgs.some(a => a === jsonOutputFileFlag || a.startsWith(`${jsonOutputFileFlag}=`))) {
+        return [];
     }
 
-    const flatArgs = getFlatShellArgs(exec);
-    const hasDebugFlag = flatArgs.includes(dotnetIsolatedDebugFlag);
-    const hasEnableJsonOutput = flatArgs.includes(enableJsonOutputFlag);
-    const alreadyHasOutputFile = flatArgs.includes(jsonOutputFileFlag) || flatArgs.some(a => a.startsWith(`${jsonOutputFileFlag}=`));
-    if (!hasDebugFlag || !hasEnableJsonOutput || alreadyHasOutputFile) {
-        return funcTask;
+    const args: string[] = [];
+    if (!existingArgs.includes(enableJsonOutputFlag)) {
+        args.push(enableJsonOutputFlag);
+    }
+    args.push(jsonOutputFileFlag, workerPidFile);
+    return args;
+}
+
+/**
+ * Removes a worker PID file left behind by a previous debug session, so a stale PID from that
+ * session can't be mistaken for the worker we're about to start.
+ */
+export async function deleteWorkerPidFile(workerPidFile: string | undefined): Promise<void> {
+    if (!workerPidFile) {
+        return;
     }
 
-    const jsonOutputFile = generateJsonOutputFilePath();
-    let newExec: vscode.ShellExecution;
-    if (exec.commandLine !== undefined) {
-        newExec = new vscode.ShellExecution(`${exec.commandLine} ${jsonOutputFileFlag} "${jsonOutputFile}"`, exec.options);
-    } else {
-        // When constructed with command + args, both are defined; defensively coalesce to satisfy the API types.
-        newExec = new vscode.ShellExecution(exec.command ?? 'func', [...(exec.args ?? []), jsonOutputFileFlag, jsonOutputFile], exec.options);
+    try {
+        if (await AzExtFsExtra.pathExists(workerPidFile)) {
+            await AzExtFsExtra.deleteResource(workerPidFile);
+        }
+    } catch {
+        // Best effort - a file we can't delete just means we wait for func to overwrite it.
     }
-
-    const wrapped = new vscode.Task(
-        funcTask.definition,
-        funcTask.scope ?? vscode.TaskScope.Workspace,
-        funcTask.name,
-        funcTask.source,
-        newExec,
-        funcTask.problemMatchers,
-    );
-    wrapped.isBackground = funcTask.isBackground;
-    wrapped.presentationOptions = funcTask.presentationOptions;
-    wrapped.group = funcTask.group;
-    wrapped.runOptions = funcTask.runOptions;
-    wrapped.detail = funcTask.detail;
-    return wrapped;
 }
 
 function parseJsonOutputFileFromString(commandLine: string): string | undefined {

--- a/src/funcCoreTools/jsonOutputFile.ts
+++ b/src/funcCoreTools/jsonOutputFile.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AzExtFsExtra } from '@microsoft/vscode-azext-utils';
-import * as crypto from 'crypto';
+import { AzExtFsExtra, randomUtils } from '@microsoft/vscode-azext-utils';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -101,16 +100,19 @@ export function generateJsonOutputFilePath(): string {
  * the same path we delete before starting, and so temp files don't accumulate. `key` should identify
  * the func task, i.e. its workspace folder plus its configured command and args.
  */
-export function getWorkerPidFilePath(key: string): string {
-    const hash: string = crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
+export async function getWorkerPidFilePath(key: string): Promise<string> {
+    const hash: string = (await randomUtils.getPseudononymousStringHash(key)).slice(0, 16);
     return path.join(os.tmpdir(), `azfunc-worker-pid-${hash}.json`);
 }
 
 /**
  * The extra args that make func core tools write the .NET isolated worker PID to `workerPidFile`.
  *
- * Returns an empty array unless the task is a dotnet-isolated debug task that doesn't already name
- * an output file, so a `--json-output-file` the user configured themselves always wins.
+ * Only applies to a dotnet-isolated debug task that already opted into JSON output and doesn't
+ * already name an output file. `--enable-json-output` changes what func prints to the terminal, so
+ * a task that leaves it off is treated as a deliberate choice and is left alone - the picker falls
+ * back to the host status endpoint for those, exactly as it did before. A `--json-output-file` the
+ * user configured themselves always wins.
  *
  * These get added while the task is still being resolved (see `FuncTaskProvider.createTask`) rather
  * than rebuilt onto an already-resolved task. Rebuilding drops the task's `dependsOn` chain, because
@@ -118,19 +120,14 @@ export function getWorkerPidFilePath(key: string): string {
  * which silently skipped the clean/build tasks a .NET project depends on.
  */
 export function getWorkerPidFileArgs(existingArgs: readonly string[], workerPidFile: string): string[] {
-    if (!existingArgs.includes(dotnetIsolatedDebugFlag)) {
+    if (!existingArgs.includes(dotnetIsolatedDebugFlag) || !existingArgs.includes(enableJsonOutputFlag)) {
         return [];
     }
     if (existingArgs.some(a => a === jsonOutputFileFlag || a.startsWith(`${jsonOutputFileFlag}=`))) {
         return [];
     }
 
-    const args: string[] = [];
-    if (!existingArgs.includes(enableJsonOutputFlag)) {
-        args.push(enableJsonOutputFlag);
-    }
-    args.push(jsonOutputFileFlag, workerPidFile);
-    return args;
+    return [jsonOutputFileFlag, workerPidFile];
 }
 
 /**

--- a/src/funcCoreTools/jsonOutputFile.ts
+++ b/src/funcCoreTools/jsonOutputFile.ts
@@ -143,11 +143,19 @@ export async function deleteWorkerPidFile(workerPidFile: string | undefined): Pr
     }
 
     try {
-        if (await AzExtFsExtra.pathExists(workerPidFile)) {
-            await AzExtFsExtra.deleteResource(workerPidFile);
+        if (!await AzExtFsExtra.pathExists(workerPidFile)) {
+            return;
         }
+        await AzExtFsExtra.deleteResource(workerPidFile);
+        return;
     } catch {
-        // Best effort - a file we can't delete just means we wait for func to overwrite it.
+        // fall through and try to blank the file instead
+    }
+
+    try {
+        await AzExtFsExtra.writeFile(workerPidFile, '{}');
+    } catch {
+        // Best effort - func core tools overwrites the file once the worker starts.
     }
 }
 

--- a/test/jsonOutputFile.test.ts
+++ b/test/jsonOutputFile.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { dotnetIsolatedDebugFlag, enableJsonOutputFlag, jsonOutputFileFlag } from '../src/constants';
+import { getJsonOutputFilePathFromTask, getWorkerPidFileArgs, getWorkerPidFilePath } from '../src/funcCoreTools/jsonOutputFile';
+import { delay } from '../src/utils/delay';
+
+const pidFile: string = '/tmp/azfunc-worker-pid-abc123.json';
+
+suite('funcCoreTools/jsonOutputFile — getWorkerPidFileArgs', () => {
+    test('points a dotnet-isolated debug task at a worker PID file', () => {
+        const args: string[] = getWorkerPidFileArgs(['host', 'start', dotnetIsolatedDebugFlag], pidFile);
+        assert.deepStrictEqual(args, [enableJsonOutputFlag, jsonOutputFileFlag, pidFile]);
+    });
+
+    test('does not repeat --enable-json-output when the task already declares it', () => {
+        const args: string[] = getWorkerPidFileArgs(['host', 'start', dotnetIsolatedDebugFlag, enableJsonOutputFlag], pidFile);
+        assert.deepStrictEqual(args, [jsonOutputFileFlag, pidFile]);
+    });
+
+    test('leaves a task that is not dotnet-isolated debug untouched', () => {
+        // Every language shares this task provider, so a Node/Python/Java `host start` has to come back
+        // with no extra args at all.
+        assert.deepStrictEqual(getWorkerPidFileArgs(['host', 'start'], pidFile), []);
+        assert.deepStrictEqual(getWorkerPidFileArgs(['host', 'start', enableJsonOutputFlag], pidFile), []);
+    });
+
+    test('yields to an output file the user configured themselves', () => {
+        const separateForm: string[] = [dotnetIsolatedDebugFlag, enableJsonOutputFlag, jsonOutputFileFlag, '/my/own.json'];
+        assert.deepStrictEqual(getWorkerPidFileArgs(separateForm, pidFile), []);
+
+        const combinedForm: string[] = [dotnetIsolatedDebugFlag, enableJsonOutputFlag, `${jsonOutputFileFlag}=/my/own.json`];
+        assert.deepStrictEqual(getWorkerPidFileArgs(combinedForm, pidFile), []);
+    });
+});
+
+suite('funcCoreTools/jsonOutputFile — getWorkerPidFilePath', () => {
+    test('is stable across repeated resolutions of the same task', async () => {
+        // VS Code can resolve the same task more than once. If the path moved between resolutions we
+        // would delete one file and then poll a different one. The delay is what makes this catch a
+        // path seeded with the clock, which is how the previous temp-file approach built its name.
+        const key: string = '/repo|host start|--dotnet-isolated-debug';
+        const first: string = getWorkerPidFilePath(key);
+        await delay(10);
+
+        assert.strictEqual(getWorkerPidFilePath(key), first);
+    });
+
+    test('differs per task so two projects debugging at once cannot collide', () => {
+        assert.notStrictEqual(
+            getWorkerPidFilePath('/repo/projectA|host start|'),
+            getWorkerPidFilePath('/repo/projectB|host start|'));
+    });
+});
+
+suite('funcCoreTools/jsonOutputFile — producer/consumer contract', () => {
+    test('the picker reads back the exact path the task provider injected', () => {
+        // getWorkerPidFileArgs writes the flag (from FuncTaskProvider) and getJsonOutputFilePathFromTask
+        // reads it back (from pickFuncProcess). They are two halves of one contract: if either side
+        // changes the flag's shape, debugging silently degrades to scraping the terminal.
+        const configuredArgs: string[] = ['host', 'start', dotnetIsolatedDebugFlag];
+        const allArgs: string[] = [...configuredArgs, ...getWorkerPidFileArgs(configuredArgs, pidFile)];
+        const task = new vscode.Task(
+            { type: 'func', command: 'host start' },
+            vscode.TaskScope.Workspace,
+            'host start',
+            'func',
+            new vscode.ShellExecution('func', allArgs));
+
+        assert.strictEqual(getJsonOutputFilePathFromTask(task), pidFile);
+    });
+});

--- a/test/jsonOutputFile.test.ts
+++ b/test/jsonOutputFile.test.ts
@@ -13,13 +13,15 @@ const pidFile: string = '/tmp/azfunc-worker-pid-abc123.json';
 
 suite('funcCoreTools/jsonOutputFile — getWorkerPidFileArgs', () => {
     test('points a dotnet-isolated debug task at a worker PID file', () => {
-        const args: string[] = getWorkerPidFileArgs(['host', 'start', dotnetIsolatedDebugFlag], pidFile);
-        assert.deepStrictEqual(args, [enableJsonOutputFlag, jsonOutputFileFlag, pidFile]);
-    });
-
-    test('does not repeat --enable-json-output when the task already declares it', () => {
         const args: string[] = getWorkerPidFileArgs(['host', 'start', dotnetIsolatedDebugFlag, enableJsonOutputFlag], pidFile);
         assert.deepStrictEqual(args, [jsonOutputFileFlag, pidFile]);
+    });
+
+    test('leaves a task that opted out of --enable-json-output alone', () => {
+        // The flag changes what func prints to the terminal, so a task that leaves it off is treated
+        // as a deliberate choice rather than something to switch on for the user. Those tasks fall
+        // back to the host status endpoint, which is what shipped before this change.
+        assert.deepStrictEqual(getWorkerPidFileArgs(['host', 'start', dotnetIsolatedDebugFlag], pidFile), []);
     });
 
     test('leaves a task that is not dotnet-isolated debug untouched', () => {
@@ -44,16 +46,16 @@ suite('funcCoreTools/jsonOutputFile — getWorkerPidFilePath', () => {
         // would delete one file and then poll a different one. The delay is what makes this catch a
         // path seeded with the clock, which is how the previous temp-file approach built its name.
         const key: string = '/repo|host start|--dotnet-isolated-debug';
-        const first: string = getWorkerPidFilePath(key);
+        const first: string = await getWorkerPidFilePath(key);
         await delay(10);
 
-        assert.strictEqual(getWorkerPidFilePath(key), first);
+        assert.strictEqual(await getWorkerPidFilePath(key), first);
     });
 
-    test('differs per task so two projects debugging at once cannot collide', () => {
+    test('differs per task so two projects debugging at once cannot collide', async () => {
         assert.notStrictEqual(
-            getWorkerPidFilePath('/repo/projectA|host start|'),
-            getWorkerPidFilePath('/repo/projectB|host start|'));
+            await getWorkerPidFilePath('/repo/projectA|host start|'),
+            await getWorkerPidFilePath('/repo/projectB|host start|'));
     });
 });
 
@@ -62,7 +64,7 @@ suite('funcCoreTools/jsonOutputFile — producer/consumer contract', () => {
         // getWorkerPidFileArgs writes the flag (from FuncTaskProvider) and getJsonOutputFilePathFromTask
         // reads it back (from pickFuncProcess). They are two halves of one contract: if either side
         // changes the flag's shape, debugging silently degrades to scraping the terminal.
-        const configuredArgs: string[] = ['host', 'start', dotnetIsolatedDebugFlag];
+        const configuredArgs: string[] = ['host', 'start', dotnetIsolatedDebugFlag, enableJsonOutputFlag];
         const allArgs: string[] = [...configuredArgs, ...getWorkerPidFileArgs(configuredArgs, pidFile)];
         const task = new vscode.Task(
             { type: 'func', command: 'host start' },


### PR DESCRIPTION
Debugging a .NET isolated project ran `func host start` without first running its `clean` and `build` dependencies, so F5 attached to stale binaries.

To attach the debugger we have to tell func where to write the isolated worker PID, via `--json-output-file`. That flag was added by cloning the task after VS Code had already resolved it. `dependsOn` only exists in tasks.json and VS Code only honors it for tasks it resolved itself, so executing the clone silently dropped the build chain.

Add the flag while the task is still being resolved, in FuncTaskProvider.createTask, so VS Code builds the task with the flag already on it and there is nothing to clone. pickFuncProcess now executes the task it fetched.

This needs no change to tasks.json, so projects scaffolded before the fix behave the same as new ones. The injection is gated on `--dotnet-isolated-debug`, leaving every other language's host start task untouched. The terminal-stream PID fallback is left armed so a task the func task provider never resolves, or a file func never writes, degrades to scraping stdout instead of hanging until pickProcessTimeout.